### PR TITLE
Fixed invalid flow in MULE_REPLYTO_STOP example.

### DIFF
--- a/modules/ROOT/pages/request-reply-scope.adoc
+++ b/modules/ROOT/pages/request-reply-scope.adoc
@@ -61,8 +61,8 @@ You can choose to disable this behavior by setting a MULE_REPLYTO variable:
 </flow>
 
 <flow name="requestFlow">
-  <set-variable variableName="MULE_REPLYTO_STOP" value="true"/> //<1>
   <vm:inbound-endpoint exchange-pattern="one-way" path="request"/>
+  <set-variable variableName="MULE_REPLYTO_STOP" value="true"/> //<1>
   <logger message="#[payload]" level="INFO"/>
 </flow>
 ----


### PR DESCRIPTION
A flow can not start with a set-variable if it contains a inbound-endpoint