### PR TITLE
Hide Secure Properties Tool section

### DIFF
--- a/modules/ROOT/pages/secure-configuration-properties.adoc
+++ b/modules/ROOT/pages/secure-configuration-properties.adoc
@@ -242,6 +242,7 @@ You can use this extension by adding it as a dependency in your Mule app.
 
 image::secure-configuration-properties-studio.png[config extension]
 
+////
 == Secure Properties Tool
 
 You can link:{attachmentsdir}/secure-properties-tool.jar[download the JAR file] for this tool so you can encrypt or decrypt single values, and complete files (both, YAML and Properties files). You can run it in the command line like this:
@@ -272,3 +273,4 @@ properties:
     value: "![qCReIPK3jcqD7WR84ISSIQ==]"
   example2: "![En8lII21ZHrdIaINw0+mSA==]"
 ----
+////


### PR DESCRIPTION
Until someone finds storage for doc attachments