### PR TITLE
MULE-15777: Relative log config file path should be resolved consistently regardless of the OS

### DIFF
--- a/modules/ROOT/pages/logging-in-mule.adoc
+++ b/modules/ROOT/pages/logging-in-mule.adoc
@@ -69,7 +69,7 @@ In Anypoint Studio, `log4j2.xml` appears in the `src/main/resources` path.
 
 The default configuration defines the standard loggers exactly as Mule did before the introduction of asynchronous logging. The only difference is that the new configuration defines all loggers (including the root one) as asynchronous.
 
-You can override this configuration at the domain or application level. You can create a custom file at a custom folder location and point to it in the xref:intro-packaging.adoc#app_descriptor[application descriptor]. To do this, open the application's `mule-artifact.json` file in the root of the project and add a `logConfigFile` property with this location specified in it. The path to the file can be either relative to the working directory (the folder where the runtime was started from) or an absolute path.
+You can override this configuration at the domain or application level. You can create a custom file at a custom folder location and point to it in the xref:intro-packaging.adoc#app_descriptor[application descriptor]. To do this, open the application's `mule-artifact.json` file in the root of the project and add a `logConfigFile` property with this location specified in it. The path to the file can be either relative to the Mule home directory or an absolute path.
 
 ----
 "logConfigFile": "myCustomFolder/myCustomlog4j2.xml"


### PR DESCRIPTION
 - Updating documentation to specify the new way how relative file paths
get resolved for the `logConfigFile` property in the app's
`mule-artifact.json` file