### PR TITLE
removing outdated info on diffs bt Studio and FD components DOCS-3125

### DIFF
--- a/modules/ROOT/pages/about-components.adoc
+++ b/modules/ROOT/pages/about-components.adoc
@@ -3,9 +3,9 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 
-Like the operations in connectors and modules, Core components are important 
-building blocks of flows in a Mule app. Core components provide the logic 
-for processing a Mule event as it travels in a series of linked steps through 
+Like the operations in connectors and modules, Core components are important
+building blocks of flows in a Mule app. Core components provide the logic
+for processing a Mule event as it travels in a series of linked steps through
 the app. Examples include the Scheduler, For Each, and Logger components.
 
 * In Studio, Mule components are accessible by clicking *Core* from the Mule palette.
@@ -39,10 +39,10 @@ See xref:batch-processing-concept.adoc[Batch Processors].
 
 These Core components perform a variety of tasks:
 
-* xref:business-events-custom.adoc[Custom Business Events]: For collecting information 
-about flows and message processors that handle your business transactions. See also, 
+* xref:business-events-custom.adoc[Custom Business Events]: For collecting information
+about flows and message processors that handle your business transactions. See also,
 xref:business-events.adoc[Business Events].
-* xref:dynamic-evaluate-component-reference.adoc[Dynamic Evaluate]: For dynamically 
+* xref:dynamic-evaluate-component-reference.adoc[Dynamic Evaluate]: For dynamically
 selecting a script, instead of hardcoding it through the Transform Message Component.
 * xref:flowref-about.adoc[Flow Reference]: For routing the Mule event to another
 flow or subflow (and back) within a Mule app.
@@ -55,8 +55,8 @@ data to a new output structure or format.
 
 == Endpoints
 
-Endpoints (sometimes called a Sources or Triggers in the UI) include components that 
-initiate (or trigger) processing in a Mule flow. The xref:scheduler-concept.adoc[Scheduler] 
+Endpoints (sometimes called a Sources or Triggers in the UI) include components that
+initiate (or trigger) processing in a Mule flow. The xref:scheduler-concept.adoc[Scheduler]
 is an endpoint. It triggers a flow to start at a configurable interval.
 
 Note that some connectors provide listeners that serve as endpoints. Listeners
@@ -76,7 +76,7 @@ See xref:error-handling.adoc[Error Handlers]
 
 == Flow Control (Routers)
 
-A Flow Control component (or Router) takes the input Mule event and routes it to 
+A Flow Control component (or Router) takes the input Mule event and routes it to
 one or more separate sequences of components. Flow Control components include:
 
 * Choice
@@ -85,7 +85,7 @@ one or more separate sequences of components. Flow Control components include:
 * Scatter-Gather
 
 For example, a xref:choice-router-concept.adoc[Choice router]) applies
-DataWeave logic to pick one of several routes, where each route is a separate 
+DataWeave logic to pick one of several routes, where each route is a separate
 sequence of event processors.
 
 A xref:scatter-gather-concept.adoc[Scatter-Gather router] router sends the
@@ -95,8 +95,8 @@ combined together into one output event.
 
 == Scopes
 
-A Scope is a type of component that groups together a sequence of event processors 
-(including other Core components and operations from modules and connectors) 
+A Scope is a type of component that groups together a sequence of event processors
+(including other Core components and operations from modules and connectors)
 to apply some programming behavior to that isolated sequence of event processors.
 
 Scopes include these components:
@@ -131,31 +131,6 @@ Transformers include:
 * xref:remove-variable.adoc[Remove Variable]
 * xref:set-payload-transformer-reference.adoc[Set Payload]
 * xref:variable-transformer-reference.adoc[Set Variable]
-
-== Core Components Only in Anypoint Studio
-
-Anypoint Studio provides some additional and more complex components than you
-find in Design Center. Studio also provides a way to code more complex behavior
-and logic in a single Mule app.
-
-* Studio projects can have multiple flows and can divide those flows between
-multiple Mule configuration files. To achieve the same goals in Design Center,
-you need to code and deploy separate Mule apps.
-* Studio flows can reference each other, even in other Mule configuration files.
-This avoids the need to connect flows together with a connector such as
-Anypoint MQ, HTTP, FTP, or another connector type.
-* Components such as Parse Template and dedicated components for explicitly
-setting and removing parts of the Mule event, such as Set Variable,
-Remove Variable, and Set Payload are only available in Studio.
-+
-Though you can set and remove variables and set payloads in Design Center, you must
-do so inside other components, rather than in a standalone component.
-+
-* Additional routers include the Scatter-Gather, Round Robin, and First Successful.
-+
-* Additional scopes include the Async, Cache, Flow, Sub Flow, and Until Successful.
-* Anypoint Studio projects can also include custom Java Spring beans or other
-Scripting languages to build customized components.
 
 
 == See Also

--- a/modules/ROOT/pages/about-components.adoc
+++ b/modules/ROOT/pages/about-components.adoc
@@ -40,10 +40,10 @@ See xref:batch-processing-concept.adoc[Batch Processors].
 These Core components perform a variety of tasks:
 
 * xref:business-events-custom.adoc[Custom Business Events]: For collecting information
-about flows and message processors that handle your business transactions. See also,
+about flows and message processors that handle your business transactions. See also
 xref:business-events.adoc[Business Events].
 * xref:dynamic-evaluate-component-reference.adoc[Dynamic Evaluate]: For dynamically
-selecting a script, instead of hardcoding it through the Transform Message Component.
+selecting a script, instead of forcing you to hardcode it through the Transform Message Component.
 * xref:flowref-about.adoc[Flow Reference]: For routing the Mule event to another
 flow or subflow (and back) within a Mule app.
 * xref:logger-component-reference.adoc[Logger]: For logging important information about
@@ -55,9 +55,10 @@ data to a new output structure or format.
 
 == Endpoints
 
-Endpoints (sometimes called a Sources or Triggers in the UI) include components that
-initiate (or trigger) processing in a Mule flow. The xref:scheduler-concept.adoc[Scheduler]
-is an endpoint. It triggers a flow to start at a configurable interval.
+Endpoints (sometimes called Sources in Studio or Triggers in Design Center) include 
+components that initiate (or trigger) processing in a Mule flow. The 
+xref:scheduler-concept.adoc[Scheduler] is an endpoint. It triggers a flow to start 
+at a configurable interval.
 
 Note that some connectors provide listeners that serve as endpoints. Listeners
 can trigger a flow when they receive an external request. For example, an HTTP
@@ -85,7 +86,7 @@ one or more separate sequences of components. Flow Control components include:
 * Scatter-Gather
 
 For example, a xref:choice-router-concept.adoc[Choice router]) applies
-DataWeave logic to pick one of several routes, where each route is a separate
+DataWeave logic to pick one of two or more routes, where each route is a separate
 sequence of event processors.
 
 A xref:scatter-gather-concept.adoc[Scatter-Gather router] router sends the
@@ -96,7 +97,7 @@ combined together into one output event.
 == Scopes
 
 A Scope is a type of component that groups together a sequence of event processors
-(including other Core components and operations from modules and connectors)
+(such as other Core components and operations from both modules and connectors)
 to apply some programming behavior to that isolated sequence of event processors.
 
 Scopes include these components:


### PR DESCRIPTION
@rddheath There was some outdated info on  differences between Core components in Studio and Flow Designer. That info gets outdated too easily. There's already a simple sentence in the doc that suggests differences: "Design Center provides many of the Core components described below." This is much less likely to remain correct than exhaustively listing differences at certain points in time. 