### PR TITLE
Remove reference to Mule 2.x

### DIFF
--- a/modules/ROOT/pages/configuring-reconnection-strategies.adoc
+++ b/modules/ROOT/pages/configuring-reconnection-strategies.adoc
@@ -4,13 +4,6 @@ include::_attributes.adoc[]
 endif::[]
 :keywords: anypoint, studio, on premises, on premise, reconnection strategies, retry policies, framework, retry, forever, non-blocking
 
-[NOTE]
-====
-In Mule 2.x, *Reconnection Strategies* were referred to as "Retry Policies," because the underlying classes provided a generic framework for retrying the same operation over and over again. However, this terminology generated significant confusion among users who expected messages to get re-delivered and message exchanges to be re-executed.
-
-To thwart further misunderstanding, we have, as of Mule 3.x and newer, resumed use of the term "Reconnection Strategies."
-====
-
 Reconnection Strategies specify how a connector behaves when its connection fails. You can control how Mule attempts to reconnect by specifying a number of criteria:
 
 * The type of exception


### PR DESCRIPTION
We should remove those from current versions of Mule 3.x (3.7+).