### PR TITLE
SE-9571 | SQS connector thread and configuration information missing …

### DIFF
--- a/modules/ROOT/pages/amazon-sqs-connector.adoc
+++ b/modules/ROOT/pages/amazon-sqs-connector.adoc
@@ -345,13 +345,19 @@ image::demo-receivemessages.jpg[demo_receivemessages]
 |*Display Name* |Enter a name for the connector instance.
 |*Connector Configuration* |Select the global configuration you create.
 |*Operation* |Receive Messages
-|*Number of Messages* |1
-|*Visibility Timeout* |30
+|*Number of Messages* |1 (Default)
+|*Visibility Timeout* |30 (Default)
+|*Polling Period* |5000 (Default)
 |===
 +
 [IMPORTANT]
 ====
 The Message processor's Queue URL attribute takes precedence over the Global Element Properties Queue URL. If none of the attributes belonging to Global Element Properties, including Queue Name, Queue URL, and the Message Processor's Queue URL is provided, the connector throws an exception.
+====
++
+[IMPORTANT]
+====
+The polling period is used when the receive process is interrupted, as a retry mechanism. The interruption can be caused by the interaction between the connector and the queue (AWS SQS).
 ====
 +
 . Add a Logger to print the message in the Mule Console:


### PR DESCRIPTION
…in the connector's documentation

SE-9571 | SQS connector thread and configuration information missing in the connector's documentation. Added default values for: Number of Messages, Visibility Timeout and Polling Period. Polling Period include "Important" aclaration (use of the parameter).