### PR TITLE
Update modules/ROOT/pages/dataweave-cookbook-java-methods.adoc

### DIFF
--- a/modules/ROOT/pages/dataweave-cookbook-java-methods.adoc
+++ b/modules/ROOT/pages/dataweave-cookbook-java-methods.adoc
@@ -65,7 +65,7 @@ output application/json
 output application/json
 ---
 {
-	a: #[java!utils::MyUtils::appendRandom(vars.myString)]
+	a: java!utils::MyUtils::appendRandom(vars.myString)
 }
 ----
 


### PR DESCRIPTION
**Wrong expression** in Dataweave 2.0 mapping for calling Java static method.