### PR TITLE
remove old email link

### DIFF
--- a/modules/ROOT/pages/installing-an-enterprise-license.adoc
+++ b/modules/ROOT/pages/installing-an-enterprise-license.adoc
@@ -6,7 +6,7 @@ endif::[]
 
 MuleSoft makes available trial versions of its Enterprise Edition runtime for the purpose of evaluation. Though perfect for exploring the myriad uses of Mule, Anypoint Studio, the trial license for Enterprise limits usage of the runtime. Complete the following steps to acquire and install an *Enterprise license*, then begin using Mule runtime in a production environment.
 
-. mailto:info@mulesoft.com[Contact MuleSoft] to acquire an *Enterprise license* in the form of a `license.lic` file.
+. Contact your MuleSoft account representative or http://www.mulesoft.com/contact[the MuleSoft sales team] to acquire an *Enterprise license* in the form of a `license.lic` file.
 . Before installing, it's recommended to remove the previous License from your `$MULE_HOME` directory. To do so, navigate to `$MULE_HOME/conf/` and delete the existing `muleLicenseKey.lic` file.
 . If you are installing your license on multiple platforms, back up your new `license.lic` file in another location before proceeding.
 . Make sure that the Mule Server is *stopped (not running)* and then open the terminal or command line on your system.
@@ -24,7 +24,7 @@ On *Windows*, first copy the `license.lic` file into the \bin folder, then execu
 
 == Verify or Remove Enterprise Edition License
 
-Make sure that the Mule Server is *stopped (not running)* and then open the terminal or command line on your system.
+Make sure that the Mule Server is *stopped* and then open the terminal or command line on your system.
 
 To verify that Mule successfully installed your Enterprise license, run the following command:
 
@@ -39,7 +39,7 @@ Sometimes the license installation fails and it might be necessary to manually d
 
 == Download your license key file
 
-* Login to the Support portal https://support.mulesoft.com[here]. If you do not have credentials to login, please contact your Customer Success Manager.
+* Log in to https://support.mulesoft.com[the Support portal]. If you do not have credentials to log in, please contact your Customer Success Manager.
 
 * Click the "Subscriptions" tab located on the top of the Support Portal Home page.
 
@@ -55,14 +55,14 @@ Sometimes the license installation fails and it might be necessary to manually d
 Though not recommended for production environments, you have the option of installing an Enterprise license on the embedded Mule Server that comes bundled with Mule with Studio.
 
 . Download and install Mule Enterprise Edition runtime.
-. mailto:info@mulesoft.com[Contact MuleSoft] to acquire an *Enterprise Edition license* in the form of a `license.lic` file.
+. Contact your account representative or http://www.mulesoft.com/contact[the MuleSoft sales team] to acquire an *Enterprise Edition license* in the form of a `license.lic` file.
 . Complete the steps outlined above to install the new license on your Mule standalone runtime.
 . From the `$MULE_HOME/conf` directory, copy the new license file that Mule stored:   `muleLicenseKey.lic`
 . Paste the `muleLicenseKey.lic` file into the classpath of your embedded application in Mule.
 
 == Install Product Licenses
 
-To use the SAP Connector or other premium connectors, you must first acquire, then install a product license. mailto:info@mulesoft.com[Contact MuleSoft] to acquire a license for one of the above products.
+To use the SAP Connector or other premium connectors, you must first acquire, then install a product license. Contact your account representative or http://www.mulesoft.com/contact[the MuleSoft sales team] to acquire a license for one of the above products.
 
 [TIP]
 The https://repository.mulesoft.org/nexus-ee/content/repositories/releases-ee/[MuleSoft Enterprise Maven customer repository] allows you to access Mule Enterprise modules, connectors, and other components not included in the trial or community versions. See xref:mmp-concept.adoc[About the Mule Maven Plugin] for details.


### PR DESCRIPTION
There are issues with license vs. subscription and Mule Server vs. Mule, and other issues being covered in another JIRA, this is just for minor style issues and removing the old email address.