### PR TITLE
Fix broken links to API Manager documentation

### DIFF
--- a/modules/ROOT/pages/migration-api-gateways-policies.adoc
+++ b/modules/ROOT/pages/migration-api-gateways-policies.adoc
@@ -88,12 +88,10 @@ Endpoint and App `pointcut` elements are no longer available, and there is no re
 
 In 3.x, once the policy is defined, the result is an XML file that has to be uploaded to API Manager.
 
-In Mule 4, once the policy behavior is defined, the policy has to be packaged into a policy template JAR and uploaded
-to Exchange in order to make it available in API Manager.
+In Mule 4, once the policy behavior is defined, the policy has to be packaged into a policy template JAR and uploaded to Exchange to make it available in API Manager.
 
-How to create a Maven project to generate the policy template JAR is explained here: https://docs.mulesoft.com/api-manager/develop-custom-policies-reference[Custom Policy Development Reference (Nov 2017)]
-
-How to upload the JAR to Exchange is explained here: https://docs.mulesoft.com/api-manager/upload-policy-exchange-task[To Upload a Policy to Exchange (Nov 2017)]
+. How to create a Maven project to generate the policy template JAR is explained in the xref:api-manager::custom-policy-packaging-policy.adoc[Packaging a Custom Policy] article.
+. How to upload the JAR to Exchange is explained in the  xref:api-manager::custom-policy-uploading-to-exchange.adoc[Uploading a Custom Policy to Exchange] article.
 
 Just like before, once the policy template JAR is in Exchange, it will appear in API Manager for APIs that belong
 to the same organization where the JAR was uploaded.


### PR DESCRIPTION
For our automatic checks to pick up broken internal references before publishing, we should always use the `xref: ` macro when linking between products. 
