### PR TITLE
Incorrect directory for object store

### DIFF
--- a/modules/ROOT/pages/cache-scope.adoc
+++ b/modules/ROOT/pages/cache-scope.adoc
@@ -287,7 +287,7 @@ Follow the table below for each scenario:
 (non-persistent)
 | The stored data is stored as volatile memory and will not persist in case a mule is restarted.
 | Persistent Object Store.
-| The data is stored in the filesystem in the `/.mule/objectstore` directory.
+| The data is stored in the filesystem in the `MULE_HOME/.mule/objectstore` directory.
 
 .2+.^| Clustered Environment
 | In Memory Object Store. +


### PR DESCRIPTION
Points incorrectly to the file system root instead of under the Mule installation directory.