### PR TITLE
MMT-299: Connector config not generated for transports with externalized

### DIFF
--- a/modules/ROOT/pages/migration-transports.adoc
+++ b/modules/ROOT/pages/migration-transports.adoc
@@ -9,6 +9,51 @@ replaceable by a connector in Mule 4.
 This page addresses items of migration that are common to all transports. For transport-specific migration
 documentation, refer to xref:migration-connectors.adoc[Migrating Connectors and Modules to Mule 4] and its child pages.
 
+[[address]]
+== Endpoint Addresses
+
+In Mule 3, an endpoint could be configured with the attributes that are specific to the transport (for instance, `host`, `port` and `path` for http) or with the generic `address` attribute.
+
+In the case where the generic `address` attribute was used, it was possible to reference a property, for instance:
+
+[source,xml,linenums]
+----
+<http:inbound-endpoint address="${External.URL}"/>
+----
+
+where the properties configuration is something like:
+
+[source,text,linenums]
+----
+External.URL=http://0.0.0.0:8080/rootPath
+----
+
+In Mule 4, the connectors define the connection attributes separately, so any full address property has to be split into its components.
+
+[source,xml,linenums]
+----
+<http:listener-config name="listenerConfig">
+    <http:listener-connection host="${External.URL.host}" port="${External.URL.port}"/>
+</http:listener-config>
+
+<flow>
+    <http:listener config-ref="listenerConfig" path="${External.URL.path}"/>
+    
+    ...
+</flow>
+----
+
+and the properties configuration becomes:
+
+[source,text,linenums]
+----
+External.URL.host=0.0.0.0
+External.URL.port=8080
+External.URL.path=/rootPath
+----
+
+Check the documentation for a specific connector for details on what properties it requires. 
+
 [[service_overrides]]
 == Service Overrides
 

--- a/modules/ROOT/pages/migration-transports.adoc
+++ b/modules/ROOT/pages/migration-transports.adoc
@@ -12,9 +12,9 @@ documentation, refer to xref:migration-connectors.adoc[Migrating Connectors and 
 [[address]]
 == Endpoint Addresses
 
-In Mule 3, an endpoint could be configured with the attributes that are specific to the transport (for instance, `host`, `port` and `path` for http) or with the generic `address` attribute.
+In Mule 3, an endpoint could be configured with either transport-specific attributes (for example, an HTTP endpoint could use `host`, `port`, and `path`), or with the generic `address` attribute.
 
-In the case where the generic `address` attribute was used, it was possible to reference a property, for instance:
+Whenever the generic `address` attribute was used, it was possible to reference a property. For instance:
 
 [source,xml,linenums]
 ----


### PR DESCRIPTION
addresses