### PR TITLE
Changed Windows directory paths to use the backslash.

### DIFF
--- a/modules/ROOT/pages/runtime-installation-task.adoc
+++ b/modules/ROOT/pages/runtime-installation-task.adoc
@@ -29,7 +29,7 @@ On Windows:
 +
 [source,powershell]
 ----
-$ env:MULE_HOME=C:\Downloads/mule-enterprise-standalone-4.1.1/
+$ env:MULE_HOME=C:\Downloads\mule-enterprise-standalone-4.1.1\
 ----
 +
 On Linux/Unix environments:
@@ -47,7 +47,7 @@ You can run the Mule runtime standalone by starting the Mule service inside `$MU
 +
 [source,powershell]
 ----
-$ $MULE_HOME/bin/mule.bat start
+$ $MULE_HOME\bin\mule.bat start
 ----
 +
 * On Linux/Unix environments:


### PR DESCRIPTION
Windows natively uses the backslash to access directories and files. In
certain contexts, the slash is interpreted by the OS and changed
automatically in the background but the example should not assume this.