### PR TITLE
Fix typo in method documentation for Upper()

### DIFF
--- a/modules/ROOT/pages/dw-core-functions-upper.adoc
+++ b/modules/ROOT/pages/dw-core-functions-upper.adoc
@@ -48,5 +48,5 @@ output application/json
 [[upper2]]
 == upper&#40;Null&#41;: Null
 
-Helper function that allows *trim* to work with null values.
+Helper function that allows *upper* to work with null values.
 


### PR DESCRIPTION
The null helper method documentation description incorrectly says "trim" instead of "upper".