### PR TITLE
Be consistent naming DataWeave 1.0 vs. 2.0

### DIFF
--- a/modules/ROOT/pages/intro-dataweave2.adoc
+++ b/modules/ROOT/pages/intro-dataweave2.adoc
@@ -3,33 +3,33 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 
-DataWeave 2 is largely unchanged from DataWeave 1. However, MuleSoft made many improvements to make it easier to learn and added new capabilities.
+DataWeave 2.0 is largely unchanged from DataWeave 1.0. However, MuleSoft made many improvements to make it easier to learn and added new capabilities.
 
 == Operators Are Functions
 In DataWeave 2, all operators are now functions. While this can involve more parentheses, it is less ambiguous and more friendly to learn through auto-completion features. The previous syntax continues to work for functions with two parameters, providing a shorter syntax for power users.
 
 [cols=“1,3”]
 |===
-|DataWeave 1|`sizeOf payload filter $.age > 30` |
-|DataWeave 2 - Function Syntax|`sizeOf(filter(payload, (value) -> value.age > 30)))` |
-|DataWeave 2 - Shortcut Syntax|`sizeOf(payload filter $.age > 30)` |
+|DataWeave 1.0|`sizeOf payload filter $.age > 30` |
+|DataWeave 2.0 - Function Syntax|`sizeOf(filter(payload, (value) -> value.age > 30)))` |
+|DataWeave 2.0 - Shortcut Syntax|`sizeOf(payload filter $.age > 30)` |
 |===
 
 == Traits Are Functions
 
 [cols=“1,3”]
 |===
-| DataWeave 1 | `payload is :empty` |
-| DataWeave 2 | `isEmpty(payload)`  |
+| DataWeave 1.0 | `payload is :empty` |
+| DataWeave 2.0 | `isEmpty(payload)`  |
 |===
 
 == Type Names
-DataWeave 2 uses a type name syntax, which removes the `:` from the name.
+DataWeave 2.0 uses a type name syntax, which removes the `:` from the name.
 
 [cols=“1,3”]
 |===
-| DataWeave 1 | `payload.foo as :string` |
-| DataWeave 2 | `payload.foo as String`  |
+| DataWeave 1.0 | `payload.foo as :string` |
+| DataWeave 2.0 | `payload.foo as String`  |
 |===
 
 == XML Format
@@ -72,7 +72,7 @@ There are also many new capabilities, including:
 
 == See Also
 
-xref:migration-dataweave.adoc[Migrating from DataWeave 1.0 to 2.x]
+xref:migration-dataweave.adoc[Migrating from DataWeave 1.0 to 2.0]
 
 // TODO: WAIT UNTIL MEL TOPIC READY
 // xref:migration-mel.adoc[Migrating MEL to DataWeave]


### PR DESCRIPTION
The actual required directive is %dw 1.0 and %dw 2.0. Also DataWeave 2.0 is easier to read than DataWeave 2. We never say DataWeave, only DataWeave 1.0. We are doing this consistently in all our courseware.