### PR TITLE
Always say DataWeave 1.0 or 2.0

### DIFF
--- a/modules/ROOT/pages/migration-dataweave.adoc
+++ b/modules/ROOT/pages/migration-dataweave.adoc
@@ -1,4 +1,4 @@
-= Migrating from DataWeave version 1 to 2
+= Migrating from DataWeave version 1.0 to 2.0
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
@@ -31,14 +31,14 @@ Most of the header directives have been changed in DataWeave. The `%dw` directiv
 [[dw_flow_control]]
 == Flow Controls
 
-Flow control changed somewhat in DataWeave 2.
+Flow control changed somewhat in DataWeave 2.0.
 
 [[dw_flow_control_when_otherwise]]
 === When Otherwise
 
 The `when otherwise` statement is replaced by `if else`, for example:
 
-.Mule 3 Example: DataWeave 1
+.Mule 3 Example: DataWeave 1.0As
 [source,dataweave,linenums]
 ----
 {
@@ -46,7 +46,7 @@ The `when otherwise` statement is replaced by `if else`, for example:
 }
 ----
 
-.Mule 4 Example: DataWeave 2
+.Mule 4 Example: DataWeave 2.0
 [source,dataweave,linenums]
 ----
 {
@@ -59,9 +59,9 @@ The `when otherwise` statement is replaced by `if else`, for example:
 [[dw_flow_control_pattern_matcher]]
 === Pattern Matcher
 
-Pattern matching changed in DataWeave 2. It adds the keyword `case` and `else` (instead of `default`). You also no longer separate cases with commas (`,`) since they are now explicitly separated by the `case` keyword.
+Pattern matching changed in DataWeave 2.0. It adds the keyword `case` and `else` (instead of `default`). You also no longer separate cases with commas (`,`) since they are now explicitly separated by the `case` keyword.
 
-.Mule 3 Example: DataWeave 1
+.Mule 3 Example: DataWeave 1.0
 [source,dataweave,linenums]
 ----
 'world' match {
@@ -70,7 +70,7 @@ Pattern matching changed in DataWeave 2. It adds the keyword `case` and `else` (
   }
 ----
 
-.Mule 4 Example: DataWeave 2
+.Mule 4 Example: DataWeave 2.0
 [source,dataweave,linenums]
 ----
 'world' match {
@@ -104,7 +104,7 @@ The DataWeave 1.0 expression above returns `{a:1}`. Because this is a coercion, 
 In DataWeave 2.0, the coercion is removed, and a new selector (`&`) is introduced to select key-value pair parenthesis.
 //TODO: To select a key-value pair from an object or something like that?
 
-.Mule 3 Example: DataWeave 2
+.Mule 3 Example: DataWeave 2.0
 [source,dataweave,linenums]
 ----
 var payload = {a: 1, b:2}
@@ -129,7 +129,7 @@ In DataWeave 1.0, conditional key-value pairs are declared with the `when` keywo
 
 In DataWeave 2.0, you use the `if` keyword.
 
-.Mule 4 Example: DataWeave 2
+.Mule 4 Example: DataWeave 2.0
 [source,dataweave,linenums]
 ----
 {

--- a/modules/ROOT/pages/migration-dataweave.adoc
+++ b/modules/ROOT/pages/migration-dataweave.adoc
@@ -38,7 +38,7 @@ Flow control changed somewhat in DataWeave 2.0.
 
 The `when otherwise` statement is replaced by `if else`, for example:
 
-.Mule 3 Example: DataWeave 1.0As
+.Mule 3 Example: DataWeave 1.0
 [source,dataweave,linenums]
 ----
 {


### PR DESCRIPTION
The actual required directive is %dw 1.0 and %dw 2.0. Also DataWeave 2.0 is easier to read than DataWeave 2. We never say DataWeave, only DataWeave 1.0. We are doing this consistently in all our courseware.