### PR TITLE
Update dataweave-language-guide.adoc

### DIFF
--- a/modules/ROOT/pages/dataweave-language-guide.adoc
+++ b/modules/ROOT/pages/dataweave-language-guide.adoc
@@ -1,18 +1,18 @@
-= DataWeave Language
+= The DataWeave 2.0 Language
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 :keywords: studio, anypoint, transform, transformer, format, aggregate, rename, split, filter convert, xml, json, csv, pojo, java object, metadata, dataweave, data weave, datawave, datamapper, dwl, dfl, dw, output structure, input structure, map, mapping
 
-DataWeave is the MuleSoft expression language for accessing and transforming data received through a Mule app. DataWeave is tightly integrated with Mule runtime, which runs the scripts and expressions in your Mule app.
+DataWeave 2.0 is the MuleSoft expression language for accessing and transforming data received through a Mule 4 application. DataWeave 2.0 is tightly integrated with Mule 4.x runtimes, which run the scripts and expressions in your Mule app.
 
-DataWeave acts on data in the Mule event. Most commonly, you use it to access and transform data in the message payload. For example, after a component in your app retrieves data from one system, you can use DataWeave to modify and output selected fields in that data to a new data format, then use another component in your app to pass on that data to another system.
+DataWeave 2.0 acts on data in the Mule event. Most commonly, you use it to access and transform data in the message payload. For example, after a component in your app retrieves data from one system, you can use DataWeave to modify and output selected fields in that data to a new data format, then use another component in your app to pass on that data to another system.
 
-The simple example below demonstrates a few important features of the DataWeave language:
+The simple example below demonstrates a few important features of the DataWeave 2.0 language:
 
 * Data transformation from one format to another. The example transforms `application/json` input to `application/xml` output.
 * Data selectors that access fields within an input data structure. The script selects keys in a JSON object from the message payload input (for example, with `payload.title`) and then outputs their values.
-* Use of a core DataWeave function on the value of an input field `upper(payload.author)`.
+* Use of a core DataWeave 2.0 function on the value of an input field `upper(payload.author)`.
 
 .Input Payload
 [source,json,linenums]
@@ -54,23 +54,23 @@ output application/xml
 
 Far more complex data manipulation and transformations are possible.
 
-DataWeave supports several file input and output formats in addition to XML and JSON. It provides a number of functions for manipulating data and includes selectors for accessing fields in the data structure. It can handle a number of data types in addition to arrays, key-value pairs, Java objects, strings, and numbers. It also supports type coercion, and the creation and use of your own functions, data types, and variables in your scripts.
+DataWeave 2.0 supports several file input and output formats in addition to XML and JSON. It provides a number of functions for manipulating data and includes selectors for accessing fields in the data structure. It can handle a number of data types in addition to arrays, key-value pairs, Java objects, strings, and numbers. It also supports type coercion, and the creation and use of your own functions, data types, and variables in your scripts.
 
-You write DataWeave expressions and scripts within message processors (components, connectors, or modules) when creating apps in Anypoint Studio or Design Center, or as handwritten XML configuration files.
+You write DataWeave 2.0 expressions and scripts within message processors (components, connectors, or modules) when creating apps in Anypoint Studio or Design Center, or as handwritten XML configuration files.
 
 * The Transformer component is for creating scripts that perform data transformations, whether simple format conversions or complex data extraction and transformation processes.
 +
 See xref:transform-component-about.adoc[Transform Message Component].
 +
-* Many Mule message processors support DataWeave expressions, allowing you to access and use core DataWeave functions on parts of the Mule event that you need.
+* Many Mule message processors support DataWeave 2.0 expressions, allowing you to access and use core DataWeave 2.0 functions on parts of the Mule event that you need.
 +
-See the inline DataWeave script examples for Set Payload in xref:dataweave-language-introduction.adoc[DataWeave Scripts]. For other examples, see the `message` attribute in  xref:logger-component-reference.adoc[Logger Component] examples, Set Payload (`<ee:set-payload>`) and Set Variable components in the xref:for-each-scope-concept.adoc[For Each Scope] examples, and xref:connectors::file/file-write.adoc[<file:content>] in the File Connector documentation.
+See the inline DataWeave 2.0 script examples for Set Payload in xref:dataweave-language-introduction.adoc[DataWeave 2.0 Scripts]. For other examples, see the `message` attribute in  xref:logger-component-reference.adoc[Logger Component] examples, Set Payload (`<ee:set-payload>`) and Set Variable components in the xref:for-each-scope-concept.adoc[For Each Scope] examples, and xref:connectors::file/file-write.adoc[<file:content>] in the File Connector documentation.
 
 == See Also
 
 * xref:about-mule-event.adoc[Mule Events]
-* xref:dataweave-formats.adoc[Formats Supported by DataWeave]
-* xref:dataweave-selectors.adoc[DataWeave Selectors]
-* xref:dataweave-language-introduction.adoc[DataWeave Scripts]
+* xref:dataweave-formats.adoc[Formats Supported by DataWeave 2.0]
+* xref:dataweave-selectors.adoc[DataWeave 2.0 Selectors]
+* xref:dataweave-language-introduction.adoc[DataWeave 2.0 Scripts]
 * xref:about-components.adoc[Core Components]
 * xref:connectors::index.adoc[Connectors and Modules]


### PR DESCRIPTION
DataWeave 2.0 has language changes, not just additions, compared with DataWeave 1.0. Should always say DataWeave 2.0.