### PR TITLE
Moved link to Monitoring doc inline

### DIFF
--- a/modules/ROOT/pages/runtime-installation-task.adoc
+++ b/modules/ROOT/pages/runtime-installation-task.adoc
@@ -116,10 +116,10 @@ Stopped Mule Enterprise Edition.
 
 == Enable Anypoint Monitoring 
 
-Optionally, you can install Anypoint Monitoring for cloud-managed supported versions of on-premises runtimes so you can monitor applications running on that server.
+Optionally, you can xref:monitoring::am-installing.adoc[install Anypoint Monitoring] for cloud-managed supported versions of on-premises runtimes so you can monitor applications running on that server.
 
 == See Also
 
 * xref:7.1@studio::to-download-and-install-studio.adoc[Install Anypoint Studio 7.0]
 * xref:mule-runtime-updates.adoc[What's New in Mule 4]
-* xref:monitoring::am-installing.adoc[Install Anypoint Monitoring On-Premises]
+


### PR DESCRIPTION
Missed this before. Andrew wanted the link inline instead of a "See Also: