### PR TITLE
DOCS-3499 Move CloudHub DR info to CloudHub doc

### DIFF
--- a/modules/ROOT/pages/hadr-guide.adoc
+++ b/modules/ROOT/pages/hadr-guide.adoc
@@ -215,41 +215,7 @@ System backups are a major component of a solid disaster recovery program. There
 |Zero data loss, 15 mins out of date?
 |===
 
-*Topics*
-
-* <<Disaster Recovery with CloudHub>>
-* <<Anypoint CloudHub Default Deployment Model>>
-* <<Anypoint CloudHub Alternative Deployment Model>>
-
-=== Disaster Recovery with CloudHub
-
-Anypoint CloudHub provides disaster recovery for application and hardware failure by re-deploying the application within the region. If the application uses multiple workers, CloudHub deploys them in separate availability zones within the same region, thereby providing HA across availability zones. The distance between the availability zones is variable and in general it cannot be assumed that they are 350 miles or more apart. If an application uses a single worker, when the availability zone comes down, it needs to be brought up manually. Alerting can be setup when any failure occurs.
-
-image::hadr-aws-global-infrastructure.png[]
-
-CloudHub uses Amazon AWS for its cloud infrastructure. hence the CloudHub availability is dependent on Amazon. The availability and deployments in CloudHub are broken into different regions which in turn point to the regions in Amazon. If an Amazon region goes down, the applications within the region are unavailable and not replicated in other regions (automatically).
-
-If the US East region goes down, the CloudHub management UI as well as the various rest services that enable deployments would be down until the region comes back. This is important to know as it could mean that new apps can not be deployed while US East is down.
-
-CloudHub provides an internal messaging mechanism, in the form of persistent queues (leveraging Amazon SQS), that can be used for message reliability. The persistent queues are highly available within a region. However, these would be lost when the region comes down which could result in some data loss (usually a few second or minutes depending on the use case).
-
-Certain CloudHub modules - Object Store V1, application settings, and Insight related information are maintained in the US East for all applications irrespective of the region they are deployed in. xref:object-store::index.adoc[Object Store V2] is maintained in the same region as the deployed CloudHub application. For both Object Store V1 and V2 if a region goes down, the data persists and is available after the region returns to service.
-
-VPC setup is at a region level. So if a region comes down, unless a VPC setup has been previously done for the other region, the VPC is unavailable.
-
-=== Anypoint CloudHub Default Deployment Model
-
-If the application uses multiple workers, CloudHub by default deploys the workers in separate availability zones providing HA across availability zones. The distance between the availability zones is variable and in general does not exceed more than 350 miles apart.
-
-image::hadr-am-web-services.png[]
-
-If an application uses a single worker, when the availability zone goes down, it needs to be brought up manually. Alerting can be set up within `status.mulesoft.com` to receive alerts when a failure occurs in an availability zone or region level.
-
-=== Anypoint CloudHub Alternative Deployment Model
-
-A load balancer (Cloud/On-Premise) can be pointed to apps deployed to different regions to provide a better disaster recovery strategy.
-
-image::hadr-load-balancer.png[]
+For information about disaster recovery with CloudHub, see xref:runtime-manager::cloudhub-hadr.adoc[CloudHub High Availability and Disaster Recovery].
 
 == Keep Integrations Stateless
 


### PR DESCRIPTION
Moved CloudHub Disaster Recovery section to the CloudHub doc here:

http://docs.mulesoft.com/runtime-manager

https://docs.mulesoft.com/runtime-manager/cloudhub-hadr