### PR TITLE
DOCS-3844 fixed typos in ref'd file

### DIFF
--- a/modules/ROOT/pages/streaming-about.adoc
+++ b/modules/ROOT/pages/streaming-about.adoc
@@ -11,7 +11,7 @@ For example, consider the following flow:
 +
 image::streaming-about-49d23.png[]
 +
-In a Mule 3 app, this flow results in writing the first file correctly, while the second is created with empty content. This happens because each component that consumes a stream expects to receive a new stream. After the stream is consumed by the first Write operation, the second Write operation receives an empty stream, so is has no content to write to a file.
+In a Mule 3 app, this flow results in writing the first file correctly, while the second is created with empty content. This happens because each component that consumes a stream expects to receive a new stream. After the stream is consumed by the first Write operation, the second Write operation receives an empty stream, so it has no content to write to a file.
 +
 Something similar happened when trying to log the payload before and after a DataWeave transformation. Consider this example:
 +
@@ -26,12 +26,14 @@ Consider a Mule 3 app that uses a Scatter-Gather router to split a data stream a
 +
 image::streaming-about-6af9b.png[]
 +
-This app fails because your streamed content cannot be processed by different processor chains simultaneously.
+This app fails because the streamed content cannot be processed by different processor chains simultaneously.
 
 [[repeatable_streams]]
 == Repeatable Streams
 
-Mule 4.0 introduces Repeatable Streams as its default framework for handling streams. Repeatable Streams enable you to:
+Mule 4 provides Repeatable Streams as its default framework for handling streams. 
+
+Repeatable Streams enable you to:
 
 * Read a stream more than once.
 * Have concurrent access to the stream.
@@ -50,14 +52,16 @@ This is the default streaming strategy in Mule Runtime Enterprise Edition.
 
 [NOTE]
 --
-This option is only available on Mule EE
+This option is only available on Mule Enterprise Edition.
 --
 
-It initially uses an in-memory buffer size of 512 KB. If the stream is larger than that, it creates a temporary file on your disk to store the contents without overflowing your memory.
+This strategy initially uses an in-memory buffer size of 512 KB. If the stream is larger than that, it creates a temporary file on your disk to store the contents without overflowing your memory.
 
-When you know you need to deal with large or small files, you can change the buffer size to optimize performance. +
-Configuring a bigger buffer size increases performance by avoiding the number of times the runtime needs to write the buffer to your disk, but it also limits the number of concurrent requests your application can process. +
-The same way, configuring a smaller buffer size saves you memory load. +
+When you know you need to deal with large or small files, you can change the buffer size to optimize performance.
+Configuring a bigger buffer size increases performance by avoiding the number of times the runtime needs to write the buffer to your disk, but it also limits the number of concurrent requests your application can process.
+
+The same way, configuring a smaller buffer size saves you memory load.
+
 You can even set the buffer's unit of measurement, so you don't have to go through unit conversions.
 
 For example, if you know that you are going to read a file that's always around 1 MB size, you can configure a 1 MB buffer:
@@ -82,15 +86,16 @@ Or if you know you are always processing a file no bigger than 10 KB, you can sa
 </file:read>
 ----
 
-Based on performance test, the default 512 KB buffer size configuration of this strategy does not significantly impact performance in most scenarios. +
-You need to run tests and find the proper buffer size configuration that fits your needs.
+Based on performance test, the default 512 KB buffer size configuration of this strategy does not significantly impact performance in most scenarios. You need to run tests and find the proper buffer size configuration that fits your needs.
 
 === In Memory Repeatable Stream
 
-This configuration is the default for Mule Runtime Community Edition. +
+This configuration is the default for Mule Runtime Community Edition.
+
 It uses a default configured buffer size of 512 KB. If the stream is larger than that, the buffer is expanded to a default increment size of 512 KB until it reaches the configured maximum buffer size. If the stream exceeds this limit, the application fails.
 
-You can customize this behavior by setting the initial size of the buffer, the rate at which the buffer increases, the maximum buffer size, and the measurement unit. +
+You can customize this behavior by setting the initial size of the buffer, the rate at which the buffer increases, the maximum buffer size, and the measurement unit.
+
 For example, these settings configure an in-memory repeatable stream with a 512 KB initial size, which grows at a rate of 256 KB and allows up to 2 MB of content in memory:
 
 [source,xml,linenums]
@@ -104,11 +109,11 @@ For example, these settings configure an in-memory repeatable stream with a 512 
 </file:read>
 ----
 
-Based on performance test, the default 512 KB buffer size, and 512 KB increment size configuration of this strategy does not significantly impact performance in most scenarios. +
+Based on performance test, the default 512 KB buffer size, and 512 KB increment size configuration of this strategy does not significantly impact performance in most scenarios.
+
 You need to run tests and find the proper buffer size and size increment configuration that fits your needs.
 
 === Non Repeatable Stream
-
 
 This strategy disables repeatable streams. It allows you to read an input stream only once.
 In case your use case does not really require the extra memory or performance overhead that come with repeatable stream. Since the stream is not being saved to memory, this is the most performant strategy that you can use.
@@ -124,8 +129,8 @@ In case your use case does not really require the extra memory or performance ov
 
 Having this kind of configuration allows your flows to fail promptly if there’s a component in the configuration that is trying to access a big input stream before the actual streaming component is executed.
 
+Every component in Mule 4 that returns an InputStream or a Streamable collection supports repeatable streams.
 
-Every component in Mule 4.0 that returns an InputStream or a Streamable collection supports repeatable streams. +
 Some of these components are:
 
 * File Connector
@@ -137,8 +142,10 @@ Some of these components are:
 
 == Streaming Objects
 
-A similar scenario happens when an Anypoint Connector is configured to use auto-paging. Mule 4.0 automatically handles the paged output of the connector using Repeatable Auto Paging. +
-This framework is similar to repeatable streams, as the connector receives the object, Mule sets a configurable in-memory buffer to save the object. +
+A similar scenario happens when an Anypoint Connector is configured to use auto-paging. Mule 4 automatically handles the paged output of the connector using Repeatable Auto Paging.
+
+This framework is similar to repeatable streams, as the connector receives the object, Mule sets a configurable in-memory buffer to save the object.
+
 However, while repeatable streams measure the buffer size in byte measurements, when handling objects the runtime measures the buffer size using instance counts.
 
 [IMPORTANT]
@@ -150,11 +157,13 @@ As with repeatable streams, you can use different strategies to configure how Mu
 
 === Repeatable File Store Iterable
 
-This configuration is the default for Mule Runtime Enterprise Edition. +
-It uses a default configured in-memory buffer of 500 objects. If your query returns more results than the buffer size, Mule serializes those objects and writes them to your disk. +
-You can configure the number of objects Mule stores in the in-memory buffer. The more objects you save in memory, the better performance you get by avoiding writing to disk,
+This configuration is the default for Mule Runtime Enterprise Edition.
 
-For example, you can set a buffer size of 100 objects in memory for a query from the SalesForce Connector:
+It uses a default configured in-memory buffer of 500 objects. If your query returns more results than the buffer size, Mule serializes those objects and writes them to your disk.
+
+You can configure the number of objects Mule stores in the in-memory buffer. The more objects you save in memory, the better performance you get by avoiding writing to disk.
+
+For example, you can set a buffer size of 100 objects in memory for a query from the Salesforce Connector:
 
 [source,xml,linenums]
 ----
@@ -163,18 +172,21 @@ For example, you can set a buffer size of 100 objects in memory for a query from
 </sfdc:query>
 ----
 
-This interface uses the Kryo framework to serialize objects so it can write them to your disk. +
+This interface uses the Kryo framework to serialize objects so it can write them to your disk.
+
 Plain old Java serialization fails if the object does not implement the Serializable interface. However if serialization contains another object that doesn’t implement the Serializable interface, Kryo is likely (but not guaranteed) to succeed. For example, a POJO containing an `org.apache.xerces.jaxp.datatype.XMLGregorianCalendarImpl`. Although Kryo serializer allows Mule to serialize objects that the JVM cannot serialize by default, some things can’t be serialized. It's recommended to keep your objects simple.
 
 [NOTE]
 --
-This option is only available on Mule EE
+This option is only available on Mule EE.
 --
 
 === Repeatable In-Memory Iterable
 
-This configuration is the default for Mule Runtime Community Edition. +
-It uses a default configured buffer size of 500 Objects. If the query result is larger than that, the buffer is expanded to a default increment size of 100 objects until it reaches the configured maximum buffer size. If the stream exceeds this limit, the application fails. +
+This configuration is the default for Mule Runtime Community Edition.
+
+It uses a default configured buffer size of 500 Objects. If the query result is larger than that, the buffer is expanded to a default increment size of 100 objects until it reaches the configured maximum buffer size. If the stream exceeds this limit, the application fails.
+
 You can customize the initial size of the buffer, the rate at which the buffer increases, and the maximum buffer size.
 
 For example, this configuration would set an in-memory buffer of 100 objects, that increments per 100 objects and allow a maximum size of 500 objects.


### PR DESCRIPTION
https://www.mulesoft.org/jira/browse/DOCS-3844 -- the FTP doc's streaming section referenced this file, but it had a few typos. Fixing these for clarity.