### PR TITLE
Ambiguous description caused customer avoid using it

### DIFF
--- a/modules/ROOT/pages/dw-binaries-functions-frombase64.adoc
+++ b/modules/ROOT/pages/dw-binaries-functions-frombase64.adoc
@@ -6,9 +6,9 @@ endif::[]
 
 
 [[frombase641]]
-== fromBase64&#40;String&#41;: Binary
+== fromBase64&#40;String&#41;: DataWeave output type
 
-Transforms a Base64 string to binary.
+Decodes a Base64 Encoded string and transforms it to the dataweave defined output type in DW script header.
 
 
 === Parameters
@@ -21,7 +21,7 @@ Transforms a Base64 string to binary.
 
 === Example
 
-This example takes a Base64 string and transforms it to binary.
+This example takes a Base64 Encoded string and transforms it to application/json.
 
 ==== Source
 


### PR DESCRIPTION
Ambiguous description caused the customer to avoid using it, we need to clarify actually what happens in this scenario a bit further. this transformer actually decodes the encoded input String and later Dataweave parse/transform it into the type defined in output header of script. For example, is DW header is output application/json, then it will transform the decoded string to application/json