### PR TITLE
DOCS-3640 fix

### DIFF
--- a/modules/ROOT/pages/http-request-connector.adoc
+++ b/modules/ROOT/pages/http-request-connector.adoc
@@ -3,6 +3,8 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 
+NOTE: The information in this topic refers only to Mule 3 and Studio 6. For information on the Mule 4 and Studio 7 HTTP connector, see xref:connectors::http/http-connector.adoc[Mule 4 HTTP Connector], xref:connectors::http/http-about-http-request.adoc[Receive HTTP Requests], and xref:connectors::http/http-authentication.adoc[Authenticate HTTP Requests].
+
 The HTTP Request Connector provides the most practical way to consume an external HTTP service. When sending HTTP requests, you can choose what method to use (GET, POST, etc) and may include a body, headers, attachments, query parameters, form parameters and URI parameters. The response is then received by the connector and is passed on to the next element in your flow.
 
 This connector can also implement HTTPS protocol and encrypt your communications via xref:tls-configuration.adoc[TLS], it can also implement xref:authentication-in-http-requests.adoc[authentication] via basic authentication, OAuth, NTLM or digest.


### PR DESCRIPTION
https://www.mulesoft.org/jira/browse/DOCS-3640 -- it appears that the user was trying to use the Mule 3.9 HTTP guide with Studio 7. 
Fix: Added note at the top saying that this guide only pertains to Mule 3/Studio 6, and provided links to the Mule 4/Studio 7 HTTP connector docs.
Build tested & Link checked