### PR TITLE
Docs 1861 deploy tomcat

### DIFF
--- a/modules/ROOT/pages/application-server-based-hot-deployment.adoc
+++ b/modules/ROOT/pages/application-server-based-hot-deployment.adoc
@@ -85,7 +85,7 @@ To enable Mule to find and load your configuration, you must include a `web.xml`
         To use a Mule XML configuration file use this context listener
     -->
     <listener>
-        <listener-class>org.mule.config.builders.DeployableMuleXmlContextListener</listener-class>
+        <listener-class>org.mule.config.builders.MuleXmlBuilderContextListener</listener-class>
     </listener>
 
 </web-app>

--- a/modules/ROOT/pages/deploying-mule-as-a-service-to-tomcat.adoc
+++ b/modules/ROOT/pages/deploying-mule-as-a-service-to-tomcat.adoc
@@ -17,13 +17,6 @@ For more information on hot deploying Mule applications, see xref:application-se
 The following instructions have been verified for use with Mule 3.7.3 and newer:
 
 . http://tomcat.apache.org[Download] and install Apache Tomcat, following Apache's installation instructions.
-. In the Tomcat home directory on your system, add the following line to the `conf/server.xml` file:
-+
-[source,xml]
-----
-<Listener className="org.mule.module.tomcat.MuleTomcatListener" />
-----
-+
 . Create a `mule-libs` subdirectory under the Tomcat home directory.
 . Copy the contents of the Mule `lib` folder with all its subdirectories – *except* `/boot` to the `mule-libs/` subdirectory of your Tomcat home directory. Do not flatten the directory structure.
 . Copy the `mule-module-tomcat-<version>.jar` file to the `mule-libs/mule/` directory in your Tomcat home directory.
@@ -51,9 +44,9 @@ Ensure you have only one listener in your web.xml file:
 [source,xml,linenums]
 ----
 <listener>
-<listener-class>
-org.mule.module.tomcat.MuleTomcatListener
-</listener-class>
+  <listener-class>
+    org.mule.module.tomcat.MuleTomcatListener
+  </listener-class>
 </listener>
 ----
 ====


### PR DESCRIPTION
3.x: Use MuleXmlBuilderContextListener instead of DeployableMuleXmlContextListener for tomcat embedded applications.