### PR TITLE
Updated as scatter-gather in mule 4 doesn't work like mule 3

### DIFF
--- a/modules/ROOT/pages/dataweave-cookbook-merge-multiple-payloads.adoc
+++ b/modules/ROOT/pages/dataweave-cookbook-merge-multiple-payloads.adoc
@@ -4,7 +4,7 @@ include::_attributes.adoc[]
 endif::[]
 :keywords: studio, anypoint, transform, transformer, format, aggregate, filter, json, metadata, dataweave, data weave, datamapper, dwl, dfl, dw, output structure, input structure, map, mapping, contains, as
 
-This DataWeave example deals with an input that contains a collection of collections. The first payload index `payload[0]` lists price by book, the second `payload[1]` lists authors by book, where each book can be identified by a unique `bookId` key. This transformation merges both payload array elements into one, matching their keys, where one book may have several authors.
+This DataWeave example deals with an input that contains a collection of collections. The first payload index `payload[0]` lists price by book, and the second `payload[1]` lists authors by book, where each book can be identified by a unique `bookId` key. This transformation merges both payload array elements into one, matching their keys, where one book may have several authors.
 
 
 [NOTE]

--- a/modules/ROOT/pages/dataweave-cookbook-merge-multiple-payloads.adoc
+++ b/modules/ROOT/pages/dataweave-cookbook-merge-multiple-payloads.adoc
@@ -4,15 +4,15 @@ include::_attributes.adoc[]
 endif::[]
 :keywords: studio, anypoint, transform, transformer, format, aggregate, filter, json, metadata, dataweave, data weave, datamapper, dwl, dfl, dw, output structure, input structure, map, mapping, contains, as
 
-This DataWeave example deals with an input that contains a collection of payloads. The first payload lists price by book, the second lists authors by book, where each book can be identified by a unique `bookId` key. This transformation merges both payloads into one, matching their keys, where one book may have several authors.
+This DataWeave example deals with an input that contains a collection of collections. The first payload index `payload[0]` lists price by book, the second `payload[1]` lists authors by book, where each book can be identified by a unique `bookId` key. This transformation merges both payload array elements into one, matching their keys, where one book may have several authors.
 
 
 [NOTE]
-Note that this is not the same as having as an input a single payload that consists of an array. Here, there are multiple separate payload elements within one single Mule Event object. This kind of data structure can be produced, for example, by a scatter-gather component.
+Note that this is not the same as having as an input a single payload that consists of an array. Here, payload is an array of arrays.
 
 It uses these functions:
 
-* `map` goes through the elements of the first payload (`payload[0]`). While on each element, a second `map` function goes through the elements of the second payload (`payload[1]`) that match the filter criteria.
+* `map` goes through the elements of the first payload element (`payload[0]`). While on each element, a second `map` function goes through the elements of the second payload (`payload[1]`) that match the filter criteria.
 * `using` defines a shorter alias within the scope of the main `map` function.
 * `filter` limits the scope of the second `map` function to only objects that share the same `bookId` as is currently being processed by the first `map` function. In that way, only relevant authors for each are listed in the output.
 


### PR DESCRIPTION
Scatter gather now returns a map with 0, 1, 2 etc as the keys, and under that is the mule message rather than just the payload. So the example isn't quite as useful for that. Could be done via doing a payload..payload to get the same sort of structure.