### PR TITLE
YYYY pattern is not a valid format. It should be yyyy

### DIFF
--- a/modules/ROOT/pages/dataweave-types.adoc
+++ b/modules/ROOT/pages/dataweave-types.adoc
@@ -108,7 +108,7 @@ The language has the following native date types:
 [[dw_type_dates_date]]
 === Date
 
-A `Date` represented by `Year`, `Month`, and `Day`, specified as `|YYYY-MM-dd|`. The `Date` type has no time component.
+A `Date` represented by `Year`, `Month`, and `Day`, specified as `|yyyy-MM-dd|`. The `Date` type has no time component.
 
 .Example
 [source,dataweave,linenums]
@@ -261,7 +261,7 @@ You can specify a date to be in any format you prefer through using *as* in the 
 %dw 2.0
 output application/json
 ---
-formattedDate: |2003-10-01T23:57:59| as String {format: "YYYY-MM-dd"}
+formattedDate: |2003-10-01T23:57:59| as String {format: "yyyy-MM-dd"}
 ----
 
 .Output
@@ -279,7 +279,7 @@ If you are doing multiple similar conversions in your transform, you might want 
 ----
 %dw 2.0
 output application/json
-type Mydate = String { format: "YYYY/MM/dd" }
+type Mydate = String { format: "yyyy/MM/dd" }
 ---
 {
   formattedDate1: |2003-10-01T23:57:59| as Mydate,


### PR DESCRIPTION

`YYYY` pattern is not a valid format. It should be `yyyy`

When using `YYYY` format for year in DW, it will throw an error:

```java
Cannot coerce String (2020-10-10) to Date, 
caused by: Text '2020-10-10' could not be parsed: 
Unable to obtain LocalDate from TemporalAccessor: 
{WeekBasedYear[WeekFields[SUNDAY,1]]=2020, DayOfMonth=10, MonthOfYear=10},ISO of type java.time.format.Parsed

6|     "sampleDate": validDate as Date {format: "YYYY-MM-dd"}
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Trace:
```