### PR TITLE
Update runtime-installation-task.adoc

### DIFF
--- a/modules/ROOT/pages/runtime-installation-task.adoc
+++ b/modules/ROOT/pages/runtime-installation-task.adoc
@@ -79,6 +79,15 @@ $ $MULE_HOME\bin\mule.bat start
 +
 * On Linux/Unix environments:
 +
+To run the Mule service, you need to install it first by running:
++
+[source,console]
+----
+$ $MULE_HOME/bin/mule install
+----
++
+Once installed, you can run the service:
++
 [source,console]
 ----
 $ $MULE_HOME/bin/mule start


### PR DESCRIPTION
Instructions on how to run mule as a service in linux was missing a step: install
Added that