### PR TITLE
Scrubbing docs-mule-runtime for Loc

### DIFF
--- a/modules/ROOT/pages/hardware-and-software-requirements.adoc
+++ b/modules/ROOT/pages/hardware-and-software-requirements.adoc
@@ -4,7 +4,7 @@ include::_attributes.adoc[]
 endif::[]
 :keywords: mule, requirements, jdk, installation
 
-If you plan to install Mule and run it on premises, review these minimum hardware and software requirements before you install.
+If you plan to install Mule runtime engine (Mule) and run it on premises, review these minimum hardware and software requirements before you install.
 
 == Minimum Hardware Requirements
 

--- a/modules/ROOT/pages/index-migration.adoc
+++ b/modules/ROOT/pages/index-migration.adoc
@@ -5,7 +5,7 @@ endif::[]
 
 // author: Dan D
 
-Mule 4 improvements make it easier to learn, develop, and manage than Mule 3. For an overview of these capabilities, you should read xref:mule-runtime-updates.adoc[What's New in Mule 4].
+Mule runtime engine (Mule) 4 improvements make it easier to learn, develop, and manage than Mule 3. For an overview of these capabilities, you should read xref:mule-runtime-updates.adoc[What's New in Mule 4].
 
 This documentation describes the differences between Mule 3 and Mule 4, indicates when you should migrate to Mule 4, and shows what it takes to migrate apps manually. It includes information on these topics:
 

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -16,7 +16,7 @@ With Mule you can:
 * Access, query, and transform data through the DataWeave language.
 * Configure high-availability, clustering, and performance management at scale.
 * Deploy an integration worker, ESB or API gateway, on-premises or in the cloud.
-* Automatically manage thread pools with the self-tuning, reactive Mule runtime engine.
+* Automatically manage thread pools with the self-tuning, reactive Mule.
 * Use error constructs and try scopes for rapid debugging.
 * Isolate the classloader to protect Mule apps from changes to the runtime or connectors.
 
@@ -37,29 +37,26 @@ solutions.
 
 * xref:runtime-manager::cloudhub.adoc[CloudHub] is a fully managed, Cloud-based
 integration platform as a service (iPaaS) for Anypoint Platform that enables you
-to run your Mule apps without requiring you to provide Mule runtimes or the infrastructure
+to run your Mule apps without requiring you to provide Mule or the infrastructure
 on which your apps run. You use Runtime Manager to deploy Mule apps to CloudHub,
-select the Mule runtime version, set the number of vCores needed to run the app,
+select the Mule version, set the number of vCores needed to run the app,
 and so on.
 * Hybrid deployment models manage Mule apps and runtimes from the Cloud while
 running them in a datacenter that is managed by your company:
-** For remote Mule runtimes (also called standalone or "naked" Mules), you
-start Mule runtimes from your datacenter, but you can deploy and manage
+** For standalone Mule, you start Mule from your datacenter, but you can deploy and manage
 Mule apps from the Cloud, though Runtime Manager. In this deployment model, you
-provide the infrastructure and Mule runtime (see
+provide the infrastructure and Mule (see
 xref:mule-standalone.adoc[Mule Installation]).
 ** For a hybrid PaaS deployment, you set up and run the PaaS on your company's
 datacenter and use Runtime Manager to manage Mule apps within the PaaS. In this
 case, you provision the infrastructure in which the apps run. To guarantee the
-high availability of Mule apps, you use Runtime Manager to handle Mule runtimes.
+high availability of Mule apps, you use Runtime Manager to handle Mule.
 xref:anypoint-platform-pcf::index.adoc[Anypoint Platform for PCF] is an
 example of a hybrid PaaS solution. MuleSoft also provides the built-in PaaS
-solution, xref:runtime-fabric::index.adoc[Runtime Fabric], which runs Mule
-runtime engines in a "containerized" environment.
+solution, xref:runtime-fabric::index.adoc[Anypoint Runtime Fabric], which runs Mule in a "containerized" environment.
 
 In addition to using Runtime Manager, you can perform deployments and manage
-Mule apps with
-xref:runtime-manager::anypoint-platform-cli-commands.adoc[Anypoint CLI 3.x],
+Mule apps with xref:runtime-manager::anypoint-platform-cli-commands.adoc[Anypoint CLI 3.x],
 which includes commands for deployments and a number of Anypoint Platform use
 cases.
 
@@ -230,11 +227,11 @@ xref:batch-processing-concept.adoc[Batch Processors].
 
 == API Gateway
 
-Mule Runtime includes an embedded API Gateway, which enables you to apply
+Mule includes an embedded API Gateway, which enables you to apply
 security policies to an API, enrich incoming or outgoing messages, and add
 capabilities to an API without having to write any code. See
 xref:api-manager::runtime-agw-landing-page.adoc[API Gateway]
-for information on the Mule runtime engine in the API Manager documentation.
+for information on Mule in the API Manager documentation.
 
 == Non-blocking Execution Engine
 

--- a/modules/ROOT/pages/installing-an-enterprise-license.adoc
+++ b/modules/ROOT/pages/installing-an-enterprise-license.adoc
@@ -4,7 +4,7 @@ include::_attributes.adoc[]
 endif::[]
 :keywords: mule, studio, enterprise, ee, premium features, paid features, purchase, license, licensed
 
-MuleSoft makes available a trial version of the Enterprise Edition of Mule runtime engine (Mule) for the purpose of evaluation. Though perfect for exploring Mule and Anypoint Studio, the trial license for Enterprise limits usage of Mule and is not appropriate for production uses.
+MuleSoft makes available a trial version of the Enterprise Edition of Mule runtime engine (Mule) for the purpose of evaluation. Though perfect for exploring Mule and Anypoint Studio (Studio), the trial license for Enterprise limits usage of Mule and is not appropriate for production uses.
 
 Complete the following steps to acquire and install a non-trial *Enterprise license* before you use Mule runtime in a production environment.
 
@@ -12,20 +12,28 @@ Complete the following steps to acquire and install a non-trial *Enterprise lice
 . Before installing, it's recommended to remove the previous License from your `$MULE_HOME` directory. To do so, navigate to `$MULE_HOME/conf/` and delete the existing `muleLicenseKey.lic` file.
 . If you are installing your license on multiple platforms, back up your new `license.lic` file in another location before proceeding.
 . Make sure that the Mule Server is *stopped (not running)* and then open the terminal or command line on your system.
-. On *Mac/Unix/Linux*, from the `$MULE_HOME/bin` directory, run the following command:
+. Install the license:
 +
-`mule -installLicense ~/license.lic` +
- +
-On *Windows*, first copy the `license.lic` file into the \bin folder, then execute the following in the command line: +
- +
-`mule -installLicense license.lic `
+** On Mac, Unix, or Linux, from `$MULE_HOME/bin`, run the following command:
++
+[source]
+----
+mule -installLicense ~/license.lic
+----
++
+** On Windows, first copy the `license.lic` file into the `\bin` folder, then execute the following in the command line:
++
+[source]
+----
+mule -installLicense license.lic
+----
+
 . In the `$MULE_HOME/conf` directory, Mule saves a new file called `muleLicenseKey.lic`. This shows that the license has been installed.
 . *Start* your Mule Server again, by the usual means.
-+
 
 == Verify or Remove Enterprise Edition License
 
-Make sure that the Mule Server is *stopped* and then open the terminal or command line on your system.
+Make sure that Mule is *stopped* and then open the terminal or command line on your system.
 
 To verify that Mule successfully installed your Enterprise license, run the following command:
 
@@ -35,19 +43,19 @@ To uninstall a previously installed license, run the following command:
 
 `mule -unInstallLicense`
 
-Sometimes the license installation fails and it might be necessary to manually delete `$MULE_HOME/conf/muleLicenseKey.lic`
+Sometimes the license installation fails and it might be necessary to manually delete `$MULE_HOME/conf/muleLicenseKey.lic`.
 
 == Download Your License Key File
 
 * Log in to https://support.mulesoft.com[the Support portal]. If you do not have credentials to log in, please contact your Customer Success Manager.
 
-* Click the "Subscriptions" tab located on the top of the Support Portal Home page.
+* Click the *Subscriptions* tab located on the top of the Support Portal Home page.
 
-* Click on the "Subscription Name" of the Subscription you would like a license key for. Please note that you must click on the "Subscription Name" (second column on the right) or you will not be forwarded to the correct page.
+* Click the *Subscription Name* of the subscription you would like a license key for. You must click on the *Subscription Name* (second column on the right) or you will not be forwarded to the correct page.
 
-* Click on the "License ID" number found on the bottom left of the page.
+* Click the *License ID* number found on the bottom left of the page.
 
-* Click on the "View" button to download your license key.
+* Click the *View* button to download your license key.
 
 == Install Enterprise License on Embedded Mule
 

--- a/modules/ROOT/pages/intro-configuration.adoc
+++ b/modules/ROOT/pages/intro-configuration.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 
-In Mule 3, Spring property placeholders are often used to configure apps dynamically for the environment in which they are deployed. Mule 4 contains a built-in mechanism for this that allows you to set default values and avoid the need to learn Spring.
+In Mule runtime engine (Mule) 3, Spring property placeholders are often used to configure apps dynamically for the environment in which they are deployed. Mule 4 contains a built-in mechanism for this that allows you to set default values and avoid the need to learn Spring.
 
 These properties are stored in a YAML file:
 [source,yaml]

--- a/modules/ROOT/pages/intro-connectors.adoc
+++ b/modules/ROOT/pages/intro-connectors.adoc
@@ -3,9 +3,9 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 
-Mule 3 offered two ways of connecting to systems: transports and connectors. Transports used the concept of inbound and outbound endpoints to send data. Connectors used the concept of operations to invoke systems, for example, `<http:request>` or `<db:select>`.
+Mule runtime engine (Mule) 3 offered two ways of connecting to systems: transports and connectors. Transports used the concept of inbound and outbound endpoints to send data. Connectors used the concept of operations to invoke systems, for example, `<http:request>` or `<db:select>`.
 
-In Mule 3, MuleSoft started to replace some of these transports through the new HTTP and Database connectors. Mule 4 completes this change by completely standardizing the approach so that all connectivity is built as connectors. This change improves the consistency and usability of connectors, and it enables more powerful connectors.
+In Mule 3, MuleSoft replaced some of these transports with new HTTP and Database connectors. Mule runtime engine (Mule) 4 completes this change: all connectivity is built as connectors. This change improves the consistency and usability of connectors, and it enables more powerful connectors.
 
 == Independent Release Cycles for Core Connectors and Modules
 
@@ -13,6 +13,6 @@ Another big difference is how the connectors are shipped and released. In Mule 3
 
 Mule 4 standardizes the latest model. The Mule 4 distribution ships with no connectors or modules. Instead, each application includes the modules it needs. This approach has the following advantages:
 
-* Faster innovation in core modules/connectors because all connectors have their own release cycle. New features and bug fixes can become available without the need to wait for the next Mule Runtime release.
-* Ability for different apps to use different versions of the same module. This allows for easier adoption of new releases without the need to run a full regression on applications that don't require the upgrade.
-* Consistent approach.
+* All connectors have their own release cycle, supporting faster innovation. New features and bug fixes are available without the need to wait for the next Mule release.
+* Different apps use different versions of the same module. This allows for easier adoption of new releases without the need to run a full regression on applications that don't require the upgrade.
+* The consistent approach makes learning new connectors easier.

--- a/modules/ROOT/pages/intro-dataweave2.adoc
+++ b/modules/ROOT/pages/intro-dataweave2.adoc
@@ -35,7 +35,7 @@ DataWeave 2 uses a type name syntax, which removes the `:` from the name.
 == XML Format
 The default for the reader property `nullValueOn` is `empty` for DataWeave 2.0.
 
-For DataWeave 1.0 (which is compatible with Mule 3.x), the value is `none`, for example:
+For DataWeave 1.0 (which is compatible with Mule runtime engine 3.x), the value is `none`, for example:
 
 .DataWeave Script
 [source,dataweave,linenums]

--- a/modules/ROOT/pages/intro-engine.adoc
+++ b/modules/ROOT/pages/intro-engine.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 
-Mule 4 has an improved execution engine that simplifies the development and scaling of Mule apps. The underlying engine is based on a reactive, non-blocking architecture. This task-oriented execution model allows you to take advantage of non-blocking IO calls and avoid performance problems due to incorrect processing strategy configurations.
+Mule runtime engine (Mule) 4 has an improved execution engine that simplifies the development and scaling of Mule apps. The underlying engine is based on a reactive, non-blocking architecture. This task-oriented execution model allows you to take advantage of non-blocking IO calls and avoid performance problems due to incorrect processing strategy configurations.
 
 From a development point of view, there are a few major changes:
 
@@ -29,4 +29,4 @@ Mule 4 decouples thread configuration from concurrency management. To control co
 
 As mentioned above, there is now a single thread pool for all flows in an app. This decouples overall tuning from flow-specific behavior. Mule allocates threads in proportion to how many CPU cores your machine has.
 
-Each Mule event processor can now inform the runtime if it is a CPU-intensive, CPU-light, or IO-intensive operation. This helps the runtime self-tune for different workloads dynamically, removing the need for you to manage thread pools manually. As a result, Mule 4 removes complex tuning requirements to achieve optimum performance.
+Each Mule event processor can now inform Mule if it is a CPU-intensive, CPU-light, or IO-intensive operation. This helps Mule self-tune for different workloads dynamically, removing the need for you to manage thread pools manually. As a result, Mule 4 removes complex tuning requirements to achieve optimum performance.

--- a/modules/ROOT/pages/intro-error-handlers.adoc
+++ b/modules/ROOT/pages/intro-error-handlers.adoc
@@ -3,17 +3,15 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 
-// sme: Ana, author: sduke?
-
-In Mule 4, error handling is no longer limited to a Java exception handling process that requires you to check the source code or force an error in order to understand what happened. Though Java `Throwable` errors and exceptions are still available, Mule 4 introduces a formal Error concept that's easier to use. Now, each component declares the type of errors it can throw, so you can identify potential errors at design time.
+In Mule runtime engine (Mule) 4, error handling is no longer limited to a Java exception handling process that requires you to check the source code or force an error in order to understand what happened. Though Java `Throwable` errors and exceptions are still available, Mule 4 introduces an Error object that's easier to use. Now, each component declares the type of errors it can throw, so you can identify potential errors at design time.
 
 == Mule Errors
 Execution failures are represented with Mule errors that have the following components:
 
-* A description of the problem.
-* A type that is used to characterize the problem.
-* A cause, the underlying Java `Throwable` that resulted in the failure.
-* An optional error message, which is used to include a proper Mule Message regarding the problem.
+* A description of the problem
+* A type that is used to characterize the problem
+* A cause, the underlying Java `Throwable` that resulted in the failure
+* An optional error message, which is used to include a proper Mule Message regarding the problem
 
 For example, when an HTTP request fails with a 401 status code, a Mule error provides the following information:
 
@@ -25,11 +23,11 @@ Error Message:  { "message" : "Could not authorize the user." }
 -----
 
 == Error Types
-In the example above, the error type is HTTP:UNAUTHORIZED, not simply UNAUTHORIZED. Error types consist of both a namespace and an identifier, allowing you to distinguish the types according to their domain (for example, HTTP:NOT_FOUND and FILE:NOT_FOUND). While connectors define their own namespace, core runtime errors have an implicit one: MULE:EXPRESSION and EXPRESSION are interpreted as one.
+In the example above, the error type is HTTP:UNAUTHORIZED, not simply UNAUTHORIZED. Error types consist of both a namespace and an identifier, allowing you to distinguish the types according to their domain (for example, HTTP:NOT_FOUND and FILE:NOT_FOUND). While connectors define their own namespace, core Mule errors have an implicit one: MULE:EXPRESSION and EXPRESSION are interpreted as one.
 
 Another important characteristic of error types is that they might have a parent type. For example, HTTP:UNAUTHORIZED has MULE:CLIENT_SECURITY as the parent, which, in turn, has MULE:SECURITY as the parent. This establishes error types as specifications of more global ones: an HTTP unauthorized error is a kind of client security error, which is a type of a more broad security issue.
 
-These hierarchies mean routing can be more general, since, for example, a handler for MULE:SECURITY will catch HTTP unauthorized errors as well as OAuth errors. Below you can see what the core runtime hierarchy looks like:
+These hierarchies mean routing can be more general, since, for example, a handler for MULE:SECURITY catches HTTP unauthorized errors as well as OAuth errors. Below you can see what the core Mule hierarchy looks like:
 
 image::error-hierarchy.png[Error Hierarchy]
 
@@ -37,30 +35,30 @@ All errors are either general or CRITICAL, the latter being so severe that they 
 
 It’s important to note the UNKNOWN type, which is used when no clear reason for the failure is found. This error can only be handled through the ANY type to allow specifying the unclear errors in the future, without changing the existing app's behavior.
 
-When it comes to connectors, each connector defines its error type hierarchy considering the core runtime one, though CONNECTIVITY and RETRY_EXHAUSTED types are always present because they are common to all connectors.
+Each connector defines its own error type hierarchy, though CONNECTIVITY and RETRY_EXHAUSTED types are always present because they are common to all connectors.
 
 == Error Handlers
 
-Mule 4 has redesigned error handling by introducing the `error-handler` component, which can contain any number of internal handlers and can route an error to the first one matching it. Such handlers are `on-error-continue` and `on-error-propagate`, which both support matching through an error type (or group of error types) or through an expression (for advanced use cases). These are quite similar to the Mule 3 choice (`choice-exception-strategy`), catch (`catch-exception-strategy`), and rollback (`rollback-exception-strategy`) exceptions strategies However, they are much simpler and more consistent.
+Mule 4 has redesigned error handling by introducing the `error-handler` component, which can contain any number of internal handlers and can route an error to the first one matching it. Such handlers are `on-error-continue` and `on-error-propagate`, which both support matching through an error type (or group of error types) or through an expression (for advanced use cases). These are similar to the Mule 3 choice (`choice-exception-strategy`), catch (`catch-exception-strategy`), and rollback (`rollback-exception-strategy`) exceptions strategies However, they are simpler and more consistent.
 
-If an error is raised in Mule 4, an error handler will be executed and the error will be routed to the first matching handler. At this point, the error is available for inspection, so the handlers can execute and act accordingly, relative to the component where they are used (a Flow or Try scope):
+If an error is raised in Mule 4, an error handler is executed and the error is routed to the first matching handler. At this point, the error is available for inspection, so the handlers can execute and act accordingly, relative to the component where they are used (a Flow or Try scope):
 
-* An `on-error-continue` will execute and use the result of the execution, as the result of its owner (as if the owner had actually completed the execution successfully). Any transactions at this point would be committed as well.
-* An `on-error-propagate` will roll back any transactions, execute, and use that result to re-throw the existing error, meaning its owner will be considered as “failing.”
+* An `on-error-continue` executes and uses the result of the execution, as the result of its owner (as if the owner had actually completed the execution successfully). Any transactions at this point would be committed as well.
+* An `on-error-propagate` rolls back any transactions, execute, and use that result to re-throw the existing error, meaning its owner is considered as “failing.”
 
 Consider the following application where an HTTP listener triggers a Flow reference to another flow that performs an HTTP request. If everything goes right when a message is received (1 below), the reference is triggered (2), and the request performed (3), which results in a successful response (4).
 
 image::error-handling-example-1.png[Error Handling Example 1]
 
-If the HTTP request fails with a not found error (see 3 above) because of the error handler setup of `inner-flow`, then the error will be propagated (4), and the flow reference will fail (2). However, because `primary-flow` is handling that with an `on-error-continue`, this will execute (5), and a successful response will be returned (6).
+If the HTTP request fails with a not found error (see 3 above) because of the error handler setup of `inner-flow`, then the error is propagated (4), and the flow reference fails (2). However, because `primary-flow` handles failure with an `on-error-continue`, the request executes (5), and a successful response is returned (6).
 
 image::error-handling-example-2.png[Error Handling Example 1]
 
-If the request fails with an unauthorized error instead (3), then  `inner-flow` will handle it with an `on-error-continue` by retrieving static content from a file (4). Then the Flow reference will be successful as well (2), and a successful response will be returned (5).
+If the request fails with an unauthorized error instead (3), then  `inner-flow` handles it with an `on-error-continue` by retrieving static content from a file (4). Then the Flow reference is successful as well (2), and a successful response is returned (5).
 
 image::error-handling-example-3.png[Error Handling Example 3]
 
-But what if another error occurred in the HTTP request? Although there are only handlers for NOT_FOUND and UNAUTHORIZED errors in the flow, errors are still propagated by default. This means that if no handler matches the error that is raised, then it will be re-thrown. For example, if the request fails with a method not allowed error (3), then it will be propagated, causing the flow reference to fail (2), and that propagation will result in a failure response (4).
+But what if another error occurred in the HTTP request? Although there are only handlers for NOT_FOUND and UNAUTHORIZED errors in the flow, errors are still propagated by default. This means that if no handler matches the error that is raised, then it is re-thrown. For example, if the request fails with a method not allowed error (3), then it is propagated, causing the flow reference to fail (2), and that propagation will result in a failure response (4).
 
 image::error-handling-example-4.png[Error Handling Example 4]
 
@@ -77,10 +75,10 @@ For the most part, Mule 3 only allows error handling at the flow level, forcing 
 
 image::error-handling-try.png[Try Scope]
 
-The error handler behaves as we have explained earlier. In the example above, any database connection errors are propagated, causing the `try` to fail and the flow’s error handler to execute. In this case, any other errors will be handled, and the Try scope will be considered successful which, in turn, means that the next processor in the flow, an HTTP request, will continue executing.
+The error handler behaves as we have explained earlier. In the example above, any database connection errors are propagated, causing the `try` to fail and the flow’s error handler to execute. In this case, any other errors are handled, and the Try scope is considered successful which, in turn, means that the next processor in the flow, an HTTP request, will continue executing.
 
 == Error Mapping
-Mule 4 now also allows for mapping default errors to custom ones. The Try scope is useful, but if you have several equal components and want to distinguish the errors of each one, using a Try on them can clutter your app. Instead, you can add error mappings to each component, meaning that all or certain kind of errors streaming from the component will be mapped to another error of your choosing. If, for example, you are aggregating results from 2 APIs using an HTTP request component for each, you might want to distinguish between the errors of API 1 and API 2, since by default, their errors will be the same.
+Mule 4 now also allows for mapping default errors to custom ones. The Try scope is useful, but if you have several equal components and want to distinguish the errors of each one, using a Try on them can clutter your app. Instead, you can add error mappings to each component, meaning that all or certain kind of errors streaming from the component are mapped to another error of your choosing. If, for example, you are aggregating results from 2 APIs using an HTTP request component for each, you might want to distinguish between the errors of API 1 and API 2, since by default, their errors will be the same.
 
 By mapping errors from the first request to a custom API_1 error and errors in the second request to API_2, you can route those errors to different handlers. The next example maps HTTP:INTERNAL_SERVER_ERROR  so that different handling policies can be applied if the APIs go down (propagating the error in the first API and handling it in the second API).
 

--- a/modules/ROOT/pages/intro-expressions.adoc
+++ b/modules/ROOT/pages/intro-expressions.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 
-In Mule 3, you must learn both the Mule Expression Language (MEL) and DataWeave. MEL forces you to convert your payloads from binary data (such as XML or JSON documents) into Java objects so that you can write expressions that access that data, for example, when routing to a specific location.
+In Mule runtime engine (Mule) 3, you must learn both the Mule Expression Language (MEL) and DataWeave. MEL forces you to convert your payloads from binary data (such as XML or JSON documents) into Java objects so that you can write expressions that access that data, for example, when routing to a specific location.
 
 In Mule 4, DataWeave is the default expression language. Combined with the built-in streaming capabilities, this change simplifies many common tasks:
 
@@ -11,7 +11,7 @@ In Mule 4, DataWeave is the default expression language. Combined with the built
 * Binary data can easily be queried from an expression anywhere in your flow, for example, when logging.
 * Streaming now happens transparently. You no longer need to worry about larger-than-memory data streams or about consuming a stream twice.
 
-DataWeave 2.0 also features many improvements, which are covered in the xref:intro-dataweave2.adoc[DataWeave 2.0] section.
+DataWeave 2.0 also features xref:intro-dataweave2.adoc[many other improvements].
 
 At the core, expressions continue to work as before. You can use them to extract data, log data, or make decisions about where to route data. And like MEL, the syntax to access properties in your data is very simple.
 

--- a/modules/ROOT/pages/intro-java-integration.adoc
+++ b/modules/ROOT/pages/intro-java-integration.adoc
@@ -4,11 +4,11 @@ include::_attributes.adoc[]
 endif::[]
 
 == Expressions versus Code
-Experienced Mule users will notice that Mule 4 takes a more opinionated approach about how to structure apps, which limits what can be done through the expression language. The intention is to provide a clear separation between the flow logic and the business logic that should be extracted through code.
+Experienced Mule runtime engine (Mule) users will notice that Mule 4 takes a more opinionated approach about how to structure apps, which limits what can be done through the expression language. The intention is to provide a clear separation between the flow logic and the business logic that should be extracted through code.
 
 If you want to extract, query, transform, or otherwise work with data in your flows, DataWeave expressions and transforms are the recommended tool. If you want to write custom logic, instantiate Java objects, or call arbitrary methods, MuleSoft recommends that you encapsulate this code into scripts or classes that can be injected and tested easily.
 
-This is why MuleSoft removed the Expression component and Expression transformer in favor of encouraging you to cleanly separate your logic into scripts or Java classes, instead.
+This is why MuleSoft removed the Expression component and Expression transformer in favor of encouraging you to cleanly separate your logic into scripts or Java classes.
 
 == Calling Static Java Methods from DataWeave
 
@@ -22,7 +22,7 @@ public class MyCompanyUtils {
   }
 }
 ----
-You can call it through the following DataWeave code:
+Call Java logic using DataWeave code:
 [source,dataweave,linenums]
 ----
 import java!org::acme::MyCompanyUtils

--- a/modules/ROOT/pages/intro-mule-message.adoc
+++ b/modules/ROOT/pages/intro-mule-message.adoc
@@ -3,16 +3,16 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 
-Mule 4 includes a simplified Mule message model in which each Mule event has a message and variables associated with it. A Mule message is composed of a payload and its attributes (metadata, such as file size). Variables (`vars`) hold arbitrary user information such as operation results, auxiliary values, and so on. This simplified message model makes it easier to work with data in a consistent way across connectors without overwriting information.
+Mule runtime engine (Mule) 4 includes a simplified Mule message model in which each Mule event has a message and variables associated with it. A Mule message is composed of a payload and its attributes (metadata, such as file size). Variables (`vars`) hold arbitrary user information such as operation results, auxiliary values, and so on. This simplified message model makes it easier to work with data in a consistent way across connectors without overwriting information.
 
 == Inbound Properties Are Now Attributes
 
-In Mule 3, inbound properties stored additional information about a payload obtained through a Message Source, such as the query parameters coming through an HTTP listener. *Attributes* in Mule 4 replace inbound properties and have these advantages:
+In Mule 3, inbound properties stored additional information about a payload obtained through a message source, such as the query parameters coming through an HTTP listener. Attributes in Mule 4 replace inbound properties and have these advantages:
 
 * They are strongly typed, so you can easily see what data is available.
-* They can easily be stored in variables that you can access throughout your flow. Here's an HTTP listener example of a typical Mule Message in Mule 4:
+* They can easily be stored in variables that you can access throughout your flow. Here's an HTTP listener example of a typical Mule message in Mule 4:
 
-image::mule-message.png[Mule Message structure in Mule 4]
+image::mule-message.png[Mule message structure in Mule 4]
 
 Attributes can be easily accessed through expressions, just as inbound properties were in Mule 3, for example:
 [source,text,linenums]
@@ -21,9 +21,9 @@ Attributes can be easily accessed through expressions, just as inbound propertie
 #[attributes.queryParams.searchCriteria]
 ----
 
-When any Source or Operation produces a new Message as a result of its execution, *both parts of the Message (the payload and attributes) are replaced with the new values*, and the previous attributes are lost. If you need to preserve any information from the attributes across operation invocations, you can either store the previous attributes in a variable or xref:target-variables.adoc[set the `target` parameter in the invoked operation].
+When any Source or Operation produces a new message as a result of its execution, both parts of the message (the payload and attributes) are replaced with the new values, and the previous attributes are lost. If you need to preserve any information from the attributes across operation invocations, you can either store the previous attributes in a variable or xref:target-variables.adoc[set the `target` parameter in the invoked operation].
 
-Here is an example of how the Message is updated during the execution of a flow:
+Here is an example of how the message is updated during the execution of a flow:
 
 [source,xml,linenums]
 ----
@@ -51,14 +51,14 @@ Here is an example of how the Message is updated during the execution of a flow:
 </flow>
 ----
 
-<1> A request is received, and the `http:listener` produces a Message with the request payload and the HTTP Attributes.
-<2> Because the `logger` is a void operation and does not produce any output, the Message remains the same after its execution.
-<3> The example stores the current HTTP Attributes in a variable to make use of them later in the flow because the next operation will replace the current Message.
-<4> HTTP Attributes are still available to configure the `jms:publish-consume` operation input.
-<5> Once the `jms:publish-consume` is invoked, the output of the operation is a Message with a different payload and the JMS Attributes.
-<6> Since the HTTP Attributes are stored in a variable, it is possible to use both the current JMS Attributes (as `attributes`) and the previously stored HTTP information.
-<7> The `jms:publish` operation is also void. Because no output is produced, the Message remains unmodified.
-<8> At this point, JMS Attributes from the `jms:publish-consume` invocation still exist.
+<1> A request is received, and the `http:listener` produces a message with the request payload and the HTTP attributes.
+<2> Because the `logger` is a void operation and does not produce any output, the message remains the same after its execution.
+<3> The example stores the current HTTP Attributes in a variable to make use of them later in the flow because the next operation will replace the current message.
+<4> HTTP attributes are still available to configure the `jms:publish-consume` operation input.
+<5> Once the `jms:publish-consume` is invoked, the output of the operation is a message with a different payload and the JMS attributes.
+<6> Since the HTTP attributes are stored in a variable, it is possible to use both the current JMS attributes (as `attributes`) and the previously stored HTTP information.
+<7> The `jms:publish` operation is also void. Because no output is produced, the message remains unmodified.
+<8> At this point, JMS attributes from the `jms:publish-consume` invocation still exist.
 
 == Outbound Properties
 
@@ -112,10 +112,10 @@ handle the attachment concept on their own:
 
 == Message Collections
 
-One of the benefits of the new Mule Message structure is when dealing with collections. In Mule 3, components that returned multiple payloads, used a special structure called the `MuleMessageCollection`. In Mule 4, any component
-that needs to deal with multiple messages can simply set the payload of the message to a List of Mule Messages. You can then iterate over these messages using DataWeave, For Each, or other components.
+One of the benefits of the new Mule message structure is when dealing with collections. In Mule 3, components that returned multiple payloads, used a special structure called the `MuleMessageCollection`. In Mule 4, any component
+that needs to deal with multiple messages can simply set the payload of the message to a List of Mule messages. You can then iterate over these messages using DataWeave, For Each, or other components.
 
-For example, the `<file:list>` operation retrieves a List of Messages. Each message has attributes for each file, which makes it easy to make decisions based on file size, whether it's a directory, and so on.
+For example, the `<file:list>` operation retrieves a List of messages. Each message has attributes for each file, which makes it easy to make decisions based on file size, whether it's a directory, and so on.
 
 == See Also
 

--- a/modules/ROOT/pages/intro-overview.adoc
+++ b/modules/ROOT/pages/intro-overview.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 
-Mule 4 simplifies the expression language and reduces management complexity so that you can speed up the on-ramping process and deliver applications faster than in Mule 3.
+Mule runtime engine (Mule) 4 simplifies the expression language and reduces management complexity so that you can speed up the on-ramping process and deliver applications faster than in Mule 3.
 
 Conceptually, you can think of Mule 4 as an evolution of Mule 3. Many of the core concepts are the same: applications, flows, connectors, DataWeave, and so on. However, because it is simpler, there is less to learn and less for you to manage.
 

--- a/modules/ROOT/pages/intro-packaging.adoc
+++ b/modules/ROOT/pages/intro-packaging.adoc
@@ -4,7 +4,7 @@ include::_attributes.adoc[]
 endif::[]
 
 == Application Structure
-There are few important changes to how Mule applications are packaged in Mule 4. Mule applications are
+There are few important changes to how Mule runtime engine (Mule) applications are packaged in Mule 4. Mule applications are
 now packaged as a JAR and have a different structure. You can use the Mule Maven Plugin to easily package your source code into this structure.
 
 [%header,cols="3,2"]
@@ -65,13 +65,13 @@ Mule 4 applications include a `mule-artifact.json` file in `META-INF/mule-artifa
 
 == Application Versioning
 
-Mule Runtime follows https://semver.org/[semantic versioning] in all its artifacts. By following semantic versioning, clients of our APIs can clearly understand what to expect whenever MuleSoft releases a new version of an asset. For instance, consider the case of Mule connectors. You can expect bug fixes (and only bug fixes) when a patch version is updated. You can expect new features in new minor versions. Both of those changes are expected to be backward compatible so that you can upgrade without any problem. But if MuleSoft updates the major version of the connector, it means that it was necessary to break backward compatibility to include new funcionality or provide a much better UX.
+Mule follows https://semver.org/[semantic versioning] in all its artifacts. By following semantic versioning, clients of our APIs can clearly understand what to expect whenever MuleSoft releases a new version of an asset. For instance, consider the case of Mule connectors. You can expect bug fixes (and only bug fixes) when a patch version is updated. You can expect new features in new minor versions. Both of those changes are expected to be backward compatible so that you can upgrade without any problem. But if MuleSoft updates the major version of the connector, it means that it was necessary to break backward compatibility to include new funcionality or provide a much better UX.
 
 It is also expected that Mule artifacts (app, domains, policies) follow semantic versioning, so you might encounter some validations when working with Mule apps. By following semantic versioning, Anypoint Platform can better understand new assets and provide a better experience. For instance, if there's a new major version of a Mule domain, you can expect that there is not going to be, for instance, the same set of global components defined in it as in the previous major version. So mule apps that belong to that domain might required to be updated if the new domain is used.
 
 == Mule Maven Plugin
 
-The Mule Maven Plugin in Mule 4 packages your app into the required format and enables you to deploy it into your target environment. Studio 7 will automatically add the plugin to your `pom.xml`. See the Mule Maven Plugin
+The Mule Maven Plugin in Mule 4 packages your app into the required format and enables you to deploy it into your target environment. Studio 7 automatically adds the plugin to your `pom.xml`. See the Mule Maven Plugin
 documentation for information on how to use it to deploy apps.
 
 IMPORTANT: Domains, policies, Mule artifact plugins (connectors, modules, and so on) all have the same structure as Mule apps. Depending on the type of artifact, there might be more or less properties in the artifact descriptors (`mule-artifact.json`), but they are all similar and all must follow semantic versioning.

--- a/modules/ROOT/pages/intro-programming-model.adoc
+++ b/modules/ROOT/pages/intro-programming-model.adoc
@@ -3,9 +3,9 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 
-Mule 4 changes the programming paradigm used in previous versions. In Mule 3, the main data component of the flow is the message. All transport provided by the runtime is mainly on the content of message payload. For instance, an `http:outbound-endpoint` is only able to send an HTTP body as the message's payload content in Mule 3. This behavior led users to add other components before the endpoint simply to properly configure the payload with the proper content.
+Mule runtime engine (Mule) 4 changes the programming paradigm used in previous versions. In Mule 3, the main data component of the flow is the message. All transport provided by Mule is mainly on the content of message payload. For instance, an `http:outbound-endpoint` is only able to send an HTTP body as the message's payload content in Mule 3. This behavior led users to add other components before the endpoint simply to properly configure the payload with the proper content.
 
-.Mule 3
+.Mule 3 Example
 [source,xml,linenums]
 ----
 <set-payload value="{ 'name' : 'pepe' }"/>
@@ -14,7 +14,7 @@ Mule 4 changes the programming paradigm used in previous versions. In Mule 3, th
 
 Mule 4 simplifies these use cases by allowing for the customization of all input parameters of the operations (`http:request`).
 
-.Mule 4
+.Mule 4 Example
 [source,xml,linenums]
 ----
 <http:request method="GET" url="google.com" doc:name="Request" config-ref="HTTP_Request_configuration">
@@ -28,9 +28,6 @@ Mule 4 simplifies these use cases by allowing for the customization of all input
 ----
 
 As the example above shows, you can now define the body to be sent by the `http:request` operation within the `body` parameter. This not only reduces the number of components that you need to add to your flow, but it also makes it more readable and prevents affecting the data context just for the purpose of the content required by the `http:request` operation.
-
-
-
 
 When creating a flow in a Mule app, you might need to store data in a variable so that any component in the flow can use it. Non-void operations (such as the Read operation to the File connector) can store the message data that they return in a variable. Once defined, variables created with the target parameter are available for use within the flow, and you can access them like you access any other variable.
 
@@ -91,8 +88,8 @@ Assume that you want to log the entire message (payload and attributes) returned
 </db:insert>
 ----
 
-* Target Variable for the Insert operation: `result`
-* Target Value: `message` in Design Center, `#[message]` in Anypoint Studio.
+* Target variable for the insert operation: `result`
+* Target value: `message` in Design Center, `#[message]` in Anypoint Studio
 
 Then you might retrieve the result from the Logger like this:
 
@@ -112,8 +109,8 @@ Assume that you want to log the name of the first entry in a PLANET database. Yo
 </db:select>
 ----
 
-* Target Variable for the Select operation: `customerName`
-* Target Value: `payload[0].name` in Design Center, `#[payload[0].name]` in Anypoint Studio.
+* Target variable for the select operation: `customerName`
+* Target value: `payload[0].name` in Design Center, `#[payload[0].name]` in Anypoint Studio
 
 Then you might retrieve the result from the Logger like this:
 
@@ -138,7 +135,7 @@ Assume that you want to access all planets discovered after a given planet was d
 </db:select>
 ----
 
-* Target Variable for the Retrieve operation: `discoveryDate`
+* Target variable for the Retrieve operation: `discoveryDate`
 
 Then you can use the Input Parameter of another operation in your flow (such as the Select operation to the Database connector) to make the variable available for use in your query, for example:
 
@@ -152,7 +149,7 @@ Then you can use the Input Parameter of another operation in your flow (such as 
 </db:select>
 ----
 
-* Input Parameter definition for the Select operation:
+* Input parameter definition for the select operation:
  ** Key: `discoveryDate`
  ** Value: `vars.discoveryDate` in Design Center, `#[vars.discoveryDate]` in Anypoint Studio.
 
@@ -161,7 +158,7 @@ Then you can use the Input Parameter of another operation in your flow (such as 
 
 Assume that you want to insert a number of records into a database that are located in the messages's payload, then pass those same records on for further processing by the next component in your flow. Though you want to use the Bulk Insert operation to the Database connector to insert the records, the operation returns a success message which would replace the current payload thus making the records inaccessible. So, to pass on the records to the next component instead of replacing the payload with the bulk insert result, you can store the success message in a target variable, for example:
 
-* Target Variable: `bulkInsertResult`
+* Target variable: `bulkInsertResult`
 
 Then the next operation in your flow can process the records located in the payload.
 

--- a/modules/ROOT/pages/intro-studio.adoc
+++ b/modules/ROOT/pages/intro-studio.adoc
@@ -1,9 +1,9 @@
-= Introduction to Mule 4: Studio 7
+= Introduction to Mule 4: Anypoint Studio 7
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 
-Before learning about what's new in Mule 4, you should install and familiarize yourself with Studio 7. It is the development environment for Mule 4 applications. Beyond support for Mule 4, it includes many new productivity improvements. Note that Studio 7 does not support opening Mule 3 applications.
+Before learning about what's new in Mule runtime engine (Mule) 4, install and familiarize yourself with Anypoint Studio (Studio) 7. It is the development environment for Mule 4 applications. Beyond support for Mule 4, it includes many new productivity improvements. Note that Studio 7 does not support opening Mule 3 applications.
 
 == New Mule Palette
 When using the Studio 6 palette, finding the right operation was a multi-step process: you had to find the connector, drag it onto the canvas, then search for an operation. To speed this process, Studio 7 provides a two-level palette that improves access time, discoverability, and categorization. You can search directly for a connector operation and easily add commonly used operations to your Favorites.
@@ -14,9 +14,9 @@ image::studio-palette.png[Studio Palette]
 
 == Managing Dependencies, Automatic Maven Integration
 
-In previous versions of Studio, every Mule module was an Eclipse plugin that required installation through an "update site" mechanism. Now, every module is simply a project dependency, managed by Maven. This means that you no longer have to deal with huge “update sites,” plugin installations, or plugin versions. Studio will automatically add Maven dependencies to the ‘pom.xml’ file and keep track of them for you.
+In previous versions of Studio, every Mule module was an Eclipse plugin that required installation through an update site mechanism. Now, every module is simply a project dependency, managed by Maven. This means that you no longer have to deal with huge “update sites,” plugin installations, or plugin versions. Studio will automatically add Maven dependencies to the ‘pom.xml’ file and keep track of them for you.
 
-If you don't know Maven, don't worry, Studio will manage Maven for you automatically by creating a default `pom.xml` file for every project.
+If you don't know Maven, don't worry, Studio manages Maven for you automatically by creating a default `pom.xml` file for every project.
 
 == Navigating to XML View
 
@@ -28,11 +28,11 @@ You can now navigate quickly to the XML from the visual view:
 
 In every operation related to the Platform, you'll see a quick-change toolbar that allows you to change accounts and if applicable, the business group. You can also add accounts from the toolbar.
 
-For example, when creating a new Mule project (File > New > Mule Project), if you select an API implementation from Design Center, the toolbar displays at the top of the selection dialog:
+For example, when creating a new Mule project (*File* > *New* > *Mule Project*), if you select an API implementation from Design Center, the toolbar displays at the top of the selection dialog:
 
 image::studio-credentials.png[Studio credentials when creating a new Mule Project]
 
-Similarly, if you select Search in Exchange from the Mule Palette, the toolbar displays in a slightly different form:
+Similarly, if you select *Search* in Anypoint Exchange from the Mule Palette, the toolbar displays in a slightly different form:
 
 image::studio-credentials-exchange.png[Studio Credentials in Mule Palette]
 
@@ -42,5 +42,5 @@ Mule 4 applications contain an `application-types.xml` file, which is where meta
 == Other Improvements
 
 * A new set of graphic icons for better usability.
-* A watermark text that will always display the operation name (such as, Select or Delete) when you change the default Display Name of the operation. This change provides you with better visibility.
+* A watermark text that always displays the operation name (such as, select or delete) when you change the default display name of the operation. This change provides you with better visibility.
 * Collapsible flows with interactive preview.

--- a/modules/ROOT/pages/intro-transformations.adoc
+++ b/modules/ROOT/pages/intro-transformations.adoc
@@ -3,19 +3,19 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 
-The way to think about data in Mule 4 is fundamentally different in Mule 3. In Mule 3, you
-often need to know about the underlying Java types, how to manage InputStreams, whether
-a payload is larger-than-memory, and how to convert data into Java objects so they can be accessed by MEL.
+Data is easier to manage in Mule runtime engine (Mule) 4. In Mule 3, you
+often need to know the underlying Java types, how to manage input streams, whether
+a payload is larger than memory, and how to convert data into Java objects so they can be accessed by MEL.
 
-For Mule 4, these best practices are recommended:
+Not so in Mule 4. You can:
 
 * Avoid unnecessary conversions to Java data types, and work with data directly.
-* Let the runtime handle streaming for you.
-* Do not convert binary data types to `String`, `byte[]`, or `InputStream` unless you are performing a direct integration with custom Java code.
+* Let Mule handle streaming for you.
+* Skip converting binary data types to `String`, `byte[]`, or `InputStream` unless you are performing a direct integration with custom Java code.
 
 == Transparent Streaming
 
-xref:intro-expressions.adoc[Introduction to Mule 4: DataWeave Expression Language] showed how to work with data directly using DataWeave. This ability to access different data formats, combined with Mule 4 streaming capabilities, means that you no longer need to convert your data to Java objects first. This improvement greatly simplifies working with data in the runtime because:
+xref:intro-expressions.adoc[Introduction to Mule 4: DataWeave Expression Language] showed how to work with data directly using DataWeave. This ability to access different data formats, combined with Mule 4 streaming capabilities, means that you no longer need to convert your data to Java objects first. This improvement greatly simplifies working with data in Mule because:
 
 * Data can be read multiple times or accessed randomly using the DataWeave expression language, without side effects.
 * Data can be sent to multiple places without the need to cache that data in memory first.
@@ -23,7 +23,7 @@ xref:intro-expressions.adoc[Introduction to Mule 4: DataWeave Expression Languag
 
 For more information on how streaming works in Mule 4, please see  xref:streaming-about.adoc[About Streaming in Mule 4.0].
 
-== Data Types and Object to String/Byte/InputStream Transformers
+== Data Types and Object to String, Byte, and InputStream Transformers
 
 Because Mule now manages the data streams for you, data access becomes simpler. You do not need to be concerned with the underlying Java representation of that type whether it is a `byte[]`, `InputStream`, `String`, or some other format.
 

--- a/modules/ROOT/pages/migration-cheat-sheet.adoc
+++ b/modules/ROOT/pages/migration-cheat-sheet.adoc
@@ -5,30 +5,30 @@ endif::[]
 
 // author: Mariano Gonzalez
 
-To help you move from Mule 3 to Mule 4, we built this index to help you find the Mule 4 equivalent of the most common Mule 3 use cases.
+To help you move from Mule runtime engine (Mule) 3 to Mule 4, use this list to help you find the Mule 4 equivalent of the most common Mule 3 use cases.
 
-*IMPORTANT:* Keep in mind that this index is only intended to act as a quick entry to the most common migration scenarios. It doesn't contain the entire migration guide. For the full set of migration articles, please visit our Mule xref:index-migration.adoc[Mule 4 for Mule 3 Users] page.
+*IMPORTANT:* This list is a quick reference for the most common migration scenarios. It doesn't contain the entire migration guide. For the full set of migration articles, please visit xref:index-migration.adoc[Mule 4 for Mule 3 Users].
 
-* xref:configuring-properties.adoc[Configuration Properties]: There's a new way of handling configuration properties in Mule 4
-* xref:migration-secure-properties-placeholder.adoc[Using Secure Properties]: Secure placeholders are now a Runtime feature and no longer part of the Security Module
+* xref:configuring-properties.adoc[Configuration Properties]: There's a new way of handling configuration properties in Mule 4.
+* xref:migration-secure-properties-placeholder.adoc[Using Secure Properties]: Secure placeholders are now a Runtime feature and no longer part of the Security Module.
 * xref:migration-connectors-http.adoc[Using the HTTP Connector]: The new HTTP connector has some differences with Mule 3, especially when it comes to handling multipart and form requests.
 * xref:migration-mel.adoc[From MEL to DataWeave]: DataWeave 2.0 is now the expression language. Here's how to adapt your MEL expressions to DataWeave.
-* xref:migration-dataweave.adoc[From DataWeave 1.0 to DataWeave 2.0]: A new version of DataWeave is available in Mule 4
-* Where are the explicit transformers?: Transformers like `<object-to-string />` or `<object-to-json>` are no longer necessary. Mule handles this automatically under the covers
-* xref:connectors::object-store/object-store-to-define-a-new-os.adoc[Define a custom Object Store]: Custom Object Stores are now defined through the new connector
-* xref:migration-patterns-watermark.adoc[Use watermarks]: Watermarks have been simplified. You can also do it manually now allowing for more complex use cases.
-* xref:migration-message-properties.adoc[Accessing the Mule Message]: The Mule Message has a new structure and it's accessed differently. Here's a quick overview.
-* Using Java: Interoperability with Java is now done through the xref:connectors::java/java-module.adoc[Java module]. Optionally you can also try the xref:migration-module-scripting.adoc[Scripting module] or the xref:mule-sdk::index.adoc[Mule SDK]
-* xref:migration-module-spring.adoc[Using Spring]: Instead of defining Spring beans directly in your application, you can now use the xref:connectors::spring/spring-module.adoc[Spring Module].
-* xref:migration-patterns-reconnection-strategies.adoc[Using reconnection strategies]: There are some small but important differences around reconnection in Mule 4.
-* xref:migration-munit.adoc[From MUnit 1.0 to Munit 2.0]: This page explains how to adapt your tests for Mule 4.
-* xref:about-classloading-isolation.adoc[Classloading isolation]: Classloading isolation changes the way resources and classes are shared. Read this article to learn more.
-* xref:migration-core.adoc[Core Components Migration]: A comprehensive list of the changes that were made to the core language elements
-* xref:migration-connectors.adoc[Using the new connectors]: A comprehensive list of the changes that were made to the main connectors.
-* xref:migration-aes.adoc[Using the Security Module (AES)]: Anypoint Enterprise Security module was split into different modules explained here.
-* xref:migration-api-gateways.adoc[Migrating Gateways]: This section covers the migration of API Gateway related features.
-* xref:migration-example-complex.adoc[Migrating ApiKit apps]: Covers the necessary steps to successfully migrate APIkit-based applications.
-* Migrating custom components: You can use the xref:mule-sdk::index.adoc[Mule SDK] to create your own reusable components
-* Migrating DevKit based components: There's a xref:mule-sdk::dmt.adoc[DevKit Migration Tool] that helps to migrate DevKit projects for Mule 3 into Mule SDK ones.
-* xref:migration-transports.adoc[Transport service overrides]: Covers how to migrate from generic transports.
+* xref:migration-dataweave.adoc[From DataWeave 1.0 to DataWeave 2.0]: A new version of DataWeave is available in Mule 4.
+* Where are the explicit transformers?: Transformers like `<object-to-string />` or `<object-to-json>` are no longer necessary. Mule handles this automatically under the covers.
+* xref:connectors::object-store/object-store-to-define-a-new-os.adoc[Define a Custom Object Store]: Custom object stores are now defined through the new connector.
+* xref:migration-patterns-watermark.adoc[Use watermarks]: Watermarks have been simplified. You can update them automatically in some cases, or manually to allow for more complex use cases.
+* xref:migration-message-properties.adoc[Accessing the Mule Message]: The Mule message has a new structure and it's accessed differently. Here's a quick overview.
+* Using Java: Interoperability with Java is now done through the xref:connectors::java/java-module.adoc[Java module]. Optionally you can also try the xref:migration-module-scripting.adoc[Scripting module] or the xref:mule-sdk::index.adoc[Mule SDK].
+* xref:migration-module-spring.adoc[Using Spring]: Instead of defining Spring beans directly in your application, use the xref:connectors::spring/spring-module.adoc[Spring Module].
+* xref:migration-patterns-reconnection-strategies.adoc[Using reconnection strategies]: Review the small but important differences related to reconnection in Mule 4.
+* xref:migration-munit.adoc[From MUnit 1.0 to Munit 2.0]: Adapt your tests for Mule 4.
+* xref:about-classloading-isolation.adoc[Classloading isolation]: Classloading isolation changes the way resources and classes are shared.
+* xref:migration-core.adoc[Core Components Migration]: Changes were made to the core language elements.
+* xref:migration-connectors.adoc[Using the new connectors]: Changes that were made to the main connectors.
+* xref:migration-aes.adoc[Using the Security Module (AES)]: The Anypoint Enterprise Security module was split into different modules.
+* xref:migration-api-gateways.adoc[Migrating Gateways]: This section covers the migration of the features related to API gateway.
+* xref:migration-example-complex.adoc[Migrating Apikit Apps]: Migrate APIkit-based applications.
+* Migrating custom components: Use the xref:mule-sdk::index.adoc[Mule SDK] to create your own reusable components.
+* Migrating DevKit-based components: xref:mule-sdk::dmt.adoc[DevKit Migration Tool] helps you migrate DevKit projects for Mule 3 into Mule SDK projects.
+* xref:migration-transports.adoc[Transport service overrides]: Migrate services from generic transports.
 

--- a/modules/ROOT/pages/migration-cheat-sheet.adoc
+++ b/modules/ROOT/pages/migration-cheat-sheet.adoc
@@ -10,7 +10,7 @@ To help you move from Mule runtime engine (Mule) 3 to Mule 4, use this list to h
 *IMPORTANT:* This list is a quick reference for the most common migration scenarios. It doesn't contain the entire migration guide. For the full set of migration articles, please visit xref:index-migration.adoc[Mule 4 for Mule 3 Users].
 
 * xref:configuring-properties.adoc[Configuration Properties]: There's a new way of handling configuration properties in Mule 4.
-* xref:migration-secure-properties-placeholder.adoc[Using Secure Properties]: Secure placeholders are now a Runtime feature and no longer part of the Security Module.
+* xref:migration-secure-properties-placeholder.adoc[Using Secure Properties]: Secure placeholders are now a Mule feature and no longer part of the Security module.
 * xref:migration-connectors-http.adoc[Using the HTTP Connector]: The new HTTP connector has some differences with Mule 3, especially when it comes to handling multipart and form requests.
 * xref:migration-mel.adoc[From MEL to DataWeave]: DataWeave 2.0 is now the expression language. Here's how to adapt your MEL expressions to DataWeave.
 * xref:migration-dataweave.adoc[From DataWeave 1.0 to DataWeave 2.0]: A new version of DataWeave is available in Mule 4.
@@ -31,4 +31,3 @@ To help you move from Mule runtime engine (Mule) 3 to Mule 4, use this list to h
 * Migrating custom components: Use the xref:mule-sdk::index.adoc[Mule SDK] to create your own reusable components.
 * Migrating DevKit-based components: xref:mule-sdk::dmt.adoc[DevKit Migration Tool] helps you migrate DevKit projects for Mule 3 into Mule SDK projects.
 * xref:migration-transports.adoc[Transport service overrides]: Migrate services from generic transports.
-

--- a/modules/ROOT/pages/migration-core-batch.adoc
+++ b/modules/ROOT/pages/migration-core-batch.adoc
@@ -6,7 +6,8 @@ endif::[]
 // sme: MG, author: sduke?
 
 // Explain generally how and why things changed between Mule 3 and Mule 4.
-The Batch module was introduced to handle Extract Transform Load (ETL) functionality.
+
+The Batch module handles Extract Transform Load (ETL) functionality.
 
 What's covered in this section:
 
@@ -18,7 +19,7 @@ What's covered in this section:
 [[batch_scope]]
 == Migrating the Batch Element
 
-In Mule 3, Batch was a top-level element, at the same level as a flow. In Mule 4, the `<batch:job>` element is a scope that lives inside a flow so that it is easier to understand, invoke dynamically, and interact with other Mule components.
+In Mule runtime engine (Mule) 3, Batch was a top-level element, at the same level as a flow. In Mule 4, the `<batch:job>` element is a scope that lives inside a flow so that it is easier to understand, invoke dynamically, and interact with other Mule components.
 
 This also means that there is no `<batch:input>` anymore. The role of the `<batch:input>` is now accomplished by whatever set of processors are in the flow before the `<batch:job>` is triggered.
 
@@ -81,9 +82,8 @@ In Mule 3, you use record-level variables (`recordVars`) to attach variables to 
 
 In Mule 4, variables (`vars`) replace `recordVars`. Variables are part of the Mule event in Mule 4. From within the `<batch:step>`, you can modify a variable that existed before the `<batch:job>` began executing, and you can do it for one particular record, without side effects on the other ones.
 
-The Mule 3 example here uses `recordVars` within an expression in a For Each component:
+This Mule 3 example uses `recordVars` within an expression in a For Each component:
 
-.Mule 3 Example
 [source,xml,linenums]
 ----
 <batch:step name="commitStep">
@@ -98,9 +98,8 @@ The Mule 3 example here uses `recordVars` within an expression in a For Each com
 </batch:step>
 ----
 
-The Mule 4 example here uses `vars` within an expression in a For Each component:
+This Mule 4 example uses `vars` within an expression in a For Each component:
 
-.Mule 4 Example
 [source,xml,linenums]
 ----
 <batch:job jobName="batchJob">
@@ -126,9 +125,8 @@ The Mule 4 example here uses `vars` within an expression in a For Each component
 
 In Mule 3, the batch input phase required a Java structure. So, for input data in formats such as XML or JSON, you first needed to transform to Java, then make DataWeave use streaming in that transformation to avoid running out of memory for large datasets.
 
-For example, suppose you have this source data pushed to your app through an HTTP call:
+For example, suppose you have this source data (JSON input data) pushed to your app through an HTTP call:
 
-.Example: JSON Input Data
 ----
 [
     {
@@ -146,9 +144,8 @@ For example, suppose you have this source data pushed to your app through an HTT
 ]
 ----
 
-In Mule 3, you need to transform that JSON to Java before passing it over, something like this:
+In Mule 3, you need to transform that JSON to Java before passing it over:
 
-.Mule 3 Example
 [source,xml,linenums]
 ----
 <batch:job name="forceJob">
@@ -170,7 +167,6 @@ In Mule 3, you need to transform that JSON to Java before passing it over, somet
 
 In Mule 4, Batch can automatically determine that the payload is a JSON array and perform the splitting on its own, for example:
 
-.Mule 4 Example
 [source,xml,linenums]
 ----
 <flow name="useTheForceBatch">
@@ -188,7 +184,7 @@ You no longer have to set streaming in Mule 4 because of the automatic streaming
 
 * Camel Case attributes: Following the Mule 4 DSL guidelines, and in order to improve consistency, all DSL attributes have been changed to camel case. For example, `max-failed-records` is now `maxFailedRecords`, `accept-policy` is `acceptPolicy`, and so on.
 
-* MuleSoft removed the `filter-expression` parameter from the `<batch:step>`` element. This attribute was deprecated in Mule 3.6 and should be replaced with `accept-expression` parameter.
+* MuleSoft removed the `filter-expression` parameter from the `<batch:step>` element. This attribute was deprecated in Mule 3.6 and should be replaced with `accept-expression` parameter.
 
 * The `<batch:commit>` is now called `<batch:aggregator>`.
 

--- a/modules/ROOT/pages/migration-core-choice.adoc
+++ b/modules/ROOT/pages/migration-core-choice.adoc
@@ -5,14 +5,16 @@ endif::[]
 
 // sme: DF, author: sduke?
 
-Little changed between Choice router for Mule 3 and Mule 4 except for:
+The Choice router didn't change much from Mule runtime engine (Mule) 3 to Mule 4:
 
-* DataWeave is now the expression language so the when statements are actually going to use it instead of MEL
-* The `<otherwise>` block is now optional
+* DataWeave is now the expression language, so `<when>` attributes use it instead of MEL.
+* The `<otherwise>` block is now optional.
 
 == Expression Language for the When Block
 
-The when expressions need to be changed from MEL to DataWeave. This also mean that you can leverage DataWeave's ability to interpret any format to avoid unnecesary convertions. For example, suppose a flow in which a JSON document representing a user is posted through HTTP and you want to check if the person is underage:
+Change `<when>` expressions from MEL to DataWeave. As an added benefit, you can leverage DataWeave's ability to interpret any format to avoid unnecesary convertions.
+
+For example, suppose a flow in which a JSON document representing a user is posted through HTTP and you want to check if the person is underage.
 
 .Mule 3 Example: MEL
 [source,xml,linenums]
@@ -31,7 +33,7 @@ The when expressions need to be changed from MEL to DataWeave. This also mean th
 </flow>
 ----
 
-With Mule 4, you don't need to worry about JSON or Java formats and just do:
+With Mule 4, you don't need to worry about JSON or Java formats.
 
 .Mule 4 Example: DataWeave 2
 [source,xml,linenums]
@@ -51,8 +53,7 @@ With Mule 4, you don't need to worry about JSON or Java formats and just do:
 
 == Optional Otherwise
 
-In Mule 3, the `<otherwise>` block was required. Many times in which fallback logic was not necessary, you ended up with an `<otherwise>` block which just had an unsignificant logger. In Mule 4, the `<otherwise>` block is optional and you don't need to specify it if not necessary.
-
+In Mule 3, the `<otherwise>` block was required. Many times, when fallback logic wasn't necessary, the `<otherwise>` block contained an insignificant logger. In Mule 4, the `<otherwise>` block is optional and you don't need to specify it if it's not necessary.
 
 == See Also
 

--- a/modules/ROOT/pages/migration-core-choice.adoc
+++ b/modules/ROOT/pages/migration-core-choice.adoc
@@ -14,7 +14,7 @@ The Choice router didn't change much from Mule runtime engine (Mule) 3 to Mule 4
 
 Change `<when>` expressions from MEL to DataWeave. As an added benefit, you can leverage DataWeave's ability to interpret any format to avoid unnecesary convertions.
 
-For example, suppose a flow in which a JSON document representing a user is posted through HTTP and you want to check if the person is underage.
+For example, suppose a flow in which a JSON document representing a user is posted through HTTP and you want to check if the person is below a specified age limit (underage).
 
 .Mule 3 Example: MEL
 [source,xml,linenums]

--- a/modules/ROOT/pages/migration-core-enricher.adoc
+++ b/modules/ROOT/pages/migration-core-enricher.adoc
@@ -4,9 +4,9 @@ include::_attributes.adoc[]
 endif::[]
 
 // Explain generally how and why things changed between Mule 3 and Mule 4.
-The Message Enricher and its functionality in Mule 3 is replaced by the `target` parameter in Mule 4. The Enricher provided a way to execute a group of message processors and redirect their output to a variable without side effects to the current message. In Mule 4, all non-void operations (for example, `<flow-ref>`, `<http:request>`, `<ftp:write>`, `<db:select>`, and so on) include `target` and `targetValue` parameters, which allow redirecting each operation's output into a variable (such as `myVar`). Other components in a Mule flow can then access that data through a DataWeave selector (for example, `vars.myVar`).
+The Message Enricher in Mule runtime engine (Mule) 3 is replaced by the `target` parameter in Mule 4. The Enricher provided a way to execute a group of message processors and redirect their output to a variable without side effects to the current message. In Mule 4, all non-void operations such as `<flow-ref>`, `<http:request>`, `<ftp:write>`, and `<db:select>` include `target` and `targetValue` parameters, which allow redirecting each operation's output into a variable (such as `myVar`). Other components in a Mule flow can then access that data through a DataWeave selector (for example, `vars.myVar`).
 
-Consider a message coming from an HTTP request, which we want to redirect to a third system, only that adding a `state` query param which is to be extracted using a secondary flow called `stateLookup`. Because you don't want to lose the original payload or headers, you need to extract this value without affecting the original message. The Enricher calls out to the enrichment resource with the current message (containing the zip code), then enriches the current message with the result.
+Consider a message coming from an HTTP request, which we want to redirect to a third system, adding a `state` query parameter which is to be extracted using a secondary flow called `stateLookup`. Because you don't want to lose the original payload or headers, you need to extract this value without affecting the original message. The Enricher calls out to the enrichment resource with the current message (containing the zip code), then enriches the current message with the result.
 
 .Mule 3 example
 ----

--- a/modules/ROOT/pages/migration-core-exception-strategies.adoc
+++ b/modules/ROOT/pages/migration-core-exception-strategies.adoc
@@ -5,10 +5,10 @@ endif::[]
 
 // sme: afelisatti, author: fer?
 
-The following examples will guide you through the migration of the different exception
-strategies of Mule 3 considering the new error handling components in Mule 4.
+The following examples guide you through the migration of different exception
+strategies from Mule runtime engine (Mule) 3 to the new error handling components in Mule 4.
 
-IMPORTANT: The examples do not cover the migration of expressions used within the `when` attribute.
+IMPORTANT: The examples do not cover the migration of expressions used within the `<when>` attribute.
 See xref:migration-mel.adoc[Migrating MEL to DataWeave] for guidance with migrating expressions,
 and see xref:connectors::java/java-throwable.adoc[Working With Throwables] to use the Java module
 to analyze exceptions.
@@ -17,8 +17,8 @@ to analyze exceptions.
 
 //TODO: CLEAN UP, ELABORATE
 
-A Catch Exception Strategy is equivalent to an Error Handler with a single `on-error-continue`
-component that accepts all errors, which is the default configuration:
+A Mule 3 `<catch-exception-strategy>` is equivalent to a Mule 4 `<error-handler>` with a single `<on-error-continue>`
+attribute that accepts all errors, which is the default configuration:
 
 .Mule 3 Example
 [source,xml,linenums]
@@ -78,7 +78,7 @@ which is the default configuration:
 
 //TODO: CLEAN UP, ELABORATE
 
-* `idempotent-redelivery-policy` gets renamed to `redelivery-policy`
+* `idempotent-redelivery-policy` is renamed to `redelivery-policy`.
 * `org.mule.runtime.core.api.exception.MessageRedeliveredException` has been replaced by the `REDELIVERY_EXHAUSTED` error type.
 * `dead-letter-queue` is removed. Any outbound operation performed to publish to a DLQ must be done as part of the handling of the `REDELIVERY_EXHAUSTED` error, for example:
 +
@@ -112,8 +112,7 @@ which is the default configuration:
 == Choice Exception Strategy
 
 A Choice exception strategy with inner catch/rollback exception strategies is
-equivalent to an error handler with on-error components continue/propagate according
-to the exception strategy kind, as explained above:
+equivalent to an error handler with on-error attributes continue and propagate:
 
 //TODO: CLEAN UP, ELABORATE
 
@@ -147,8 +146,8 @@ to the exception strategy kind, as explained above:
 
 == Reference Exception Strategy
 
-Considering that the referenced exception strategy has already been migrated according
-to the above guidelines, migrating the actual reference is just adding a reference `error-handler`.
+Since the referenced exception strategy has already been migrated according
+to the guidelines already presented, migrating the actual reference merely requires adding a reference `error-handler`.
 
 //TODO: CLEAN UP, ELABORATE
 

--- a/modules/ROOT/pages/migration-core-foreach.adoc
+++ b/modules/ROOT/pages/migration-core-foreach.adoc
@@ -3,9 +3,9 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 
-Little changed between For Each scope for Mule 3 and Mule 4 except for the use of DataWeave 2 as the expression language. This little change however has a huge impact in terms of usability of the component.
+The For Each scope didn't change much from Mule runtime engine (Mule) 3 to Mule 4, except for the use of DataWeave 2 as the expression language. This one change has a large impact in terms of usability of the component.
 
-In Mule 3, foreach required the input collection to be a Java Iterable, Java Iterator or Java array. You were always forced to make sure that the input was in Java format (and therefore, you were forced to know java).
+In Mule 3, `foreach` required the input collection to be a Java iterable, Java iterator or Java array. You were always forced to make sure that the input was in Java format (and therefore, you were forced to know Java).
 
 In Mule 4, we support iterating over any array-like structure, regardless of the format. For example, suppose the following JSON is posted through an HTTP request:
 
@@ -25,7 +25,7 @@ In Mule 4, we support iterating over any array-like structure, regardless of the
 }
 ----
 
-Mule 3 requires the json being transformed to Java first:
+Mule 3 requires JSON be transformed to Java:
 
 .Mule 3 example
 [source,xml,linenums]
@@ -39,7 +39,7 @@ Mule 3 requires the json being transformed to Java first:
 </flow>
 ----
 
-In Mule 4, you can just access the persons array in Json format directly:
+In Mule 4, you can access the persons array in JSON format directly:
 
 .Mule 4 example
 [source,xml,linenums]

--- a/modules/ROOT/pages/migration-core-poll.adoc
+++ b/modules/ROOT/pages/migration-core-poll.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 
-In Mule 3, the `<poll>` element was used to trigger a certain flow at a fixed frequency of time. This element was also a scope which required one (and only one) message processor to live inside of it. The output of that processor would be the message that the flow receives.
+In Mule runtime engine (Mule) 3, the `<poll>` element was used to trigger a certain flow at a fixed frequency of time. This element was also a scope which required one (and only one) message processor to live inside of it. The output of that processor is the message that the flow receives.
 
 .Mule 3 Example: Poll
 [source,xml,linenums]
@@ -19,10 +19,10 @@ In Mule 3, the `<poll>` element was used to trigger a certain flow at a fixed fr
 </flow>
 ----
 
-In Mule 4, the `<poll>` element was replaced with the `<scheduler>` element. Main differences are:
+In Mule 4, the `<poll>` element was replaced with the `<scheduler>` element. The main differences are:
 
-* It just triggers the flow. It's no longer a scope
-* It supports both fixed frequency and cron expressions
+* `<poll>` triggers the flow. It's no longer a scope.
+* `<poll>` supports both fixed frequency and cron expressions.
 
 .Mule 4 Example: Scheduler
 [source,xml,linenums]
@@ -42,17 +42,16 @@ In Mule 4, the `<poll>` element was replaced with the `<scheduler>` element. Mai
 </flow>
 ----
 
-For more information on the `<scheduler>` element, please read the xref:scheduler-concept.adoc[Scheduler documentation].
+For more information about the `<scheduler>` element, see the xref:scheduler-concept.adoc[Scheduler documentation].
 
 == Migrating a Watermark
 
-The `<poll>` element also supported a `<watermark>` element which was used to aid and scheduled synchronizations. That element doesn't exist anymore. Instead, please read
-the xref:migration-patterns-watermark.adoc[Migrating Watermarks] page.
+The `<poll>` element supported a `<watermark>` element which was used to aid and scheduled synchronizations. That element doesn't exist anymore. To migrate, see xref:migration-patterns-watermark.adoc[Migrating Watermarks.
 
 [[qz]]
 == Quartz Transport
 
-In Mule 3, a `quartz` transport existed that was deprecated in favor of the `poll`, so most of its uses may also be replaced by the `scheduler` in Mule 4.
+In Mule 3, a `quartz` transport existed that was deprecated in favor of the `poll`, so most of its uses have been replaced by the `scheduler` in Mule 4.
 
 Some features of the `quartz` transport do not exist in Mule 4, so a different approach is necessary to migrate those use cases.
 
@@ -61,7 +60,7 @@ Some features of the `quartz` transport do not exist in Mule 4, so a different a
 
 `repeatCount` is not supported in Mule 4 by the `scheduler`.
 
-If you really need to fetch it, compare and store a counter in an xref:connectors::object-store/object-store-connector.adoc[Object Store].
+If you need to fetch it, compare and store a counter in an xref:connectors::object-store/object-store-connector.adoc[object store].
 
 [[qz_outbound_endpoint]]
 === quartz:outbound-endpoint

--- a/modules/ROOT/pages/migration-core-scatter-gather.adoc
+++ b/modules/ROOT/pages/migration-core-scatter-gather.adoc
@@ -5,7 +5,7 @@ endif::[]
 
 // sme: PLG, author: rodro
 
-The most important change in Scatter-Gather router between Mule 3 and Mule 4 
+The most important change in the Scatter-Gather router between Mule runtime engine (Mule) 3 and Mule 4 
 is in the `AggregationStrategy` used to consolidate the results of the 
 different routes. Instead of providing a Java class with the aggregation 
 logic, you can perform the aggregation with a DataWeave transformation.

--- a/modules/ROOT/pages/migration-core-splitter-aggregator.adoc
+++ b/modules/ROOT/pages/migration-core-splitter-aggregator.adoc
@@ -5,7 +5,7 @@ endif::[]
 
 // Contacts/SMEs: LRM
 
-Splitters are not longer available in Mule 4. To process a collection of elements sequentially, use the xref:for-each-scope-concept.adoc[For Each component].
+Splitters are not available in Mule runtime engine (Mule) 4. To process a collection of elements sequentially, use the xref:for-each-scope-concept.adoc[For Each component].
 
 xref:connectors::aggregator/aggregators-module.adoc[Aggregators] remain in Mule 4 but as a separate module with very different behavior.
 
@@ -46,7 +46,7 @@ It does not matter if a Mule 3 aggregator is present. To store the results of th
 
 === Simple Migration
 
-The default format of the migration should be:
+The default format of a migration:
 
 .Mule 3 Example
 [source,xml,linenums]
@@ -87,7 +87,7 @@ The default format of the migration should be:
 
 In the example:
 
-* A variable `collection-splitter0-group-size` should be created to store the size of the collection. This is needed because inside the `foreach` scope, the payload will correspond to the element from the collection being processed.
+* A variable `collection-splitter0-group-size` is created to store the size of the collection. This is needed because inside the `foreach` scope, the payload corresponds to the element from the collection being processed.
 * Every component between the `collection-splitter` and `collection-aggregator` is wrapped inside a `foreach` scope.
 * A `group-based-aggregator` is added at the end of the `foreach` scope to store all the results. The size of the aggregation expected will correspond to the value stored in the `collection-splitter0-group-size` variable. `set-variable` is added inside the `aggregation-complete` to store the result of the aggregation once it is complete.
 * Since the payload after the `foreach` element will be the same as the input received, `set-payload` should be used to set it as the stored value in the variable defined insider the `aggregation-complete` route.
@@ -100,7 +100,7 @@ In some cases, the Mule 3 configuration with splitters and aggregators might set
 Mule 3 aggregators allowed for 2 attributes to be configured: `timeout` and `failOnTimeout`. If the `timeout` attribute is present (with a value greater than 0), the migration should be as follows in the examples.
 
 [IMPORTANT]
-Even when there is a way of adding extra logic when there is a timed-out aggregation and `failOnTimeout` is set to `true`, the behavior will not be the same as in Mule 3. Aggregators in Mule 4 do not raise any errors or dispatch any notifications where there is a timed-out aggregation.
+Even when there is a way of adding extra logic when there is a timed-out aggregation and `failOnTimeout` is set to `true`, the behavior is not the same as in Mule 3. Aggregators in Mule 4 do not raise any errors or dispatch any notifications when there is a timed-out aggregation.
 
 
 .Mule 3 Example
@@ -177,9 +177,9 @@ Another flow should be created and an `aggregator:aggregator-listener` should be
 
 All splitters allowed for the configuration of the `enableCorrelation` attribute.
 
-There is no way to migrate an `enableCorrelation="NEVER"` configuration. A correlation ID will always be set to the events processed from the collection by the `foreach` element.
+There is no way to migrate an `enableCorrelation="NEVER"` configuration. A correlation ID is always set to the events processed from the collection by the `foreach` element.
 
-Expression splitters (`<splitter/>`) allowed for the configuration of two attributes: `evaluator` and `custom-evaluator`. Expression evaluators can't be configured anymore; only DataWeave can be used.
+Expression splitters (`<splitter/>`) allowed for the configuration of two attributes: `evaluator` and `custom-evaluator`. Expression evaluators can't be configured in Mule 4; only DataWeave can be used.
 
 === Available Splitters Migration
 
@@ -193,25 +193,25 @@ Mule 3 had the following splitters, some of which require some extra logic to be
 * `map-splitter` : The DataWeave expression `#[dw::core::Objects::entrySet(payload)]` should be used as the `collection` attribute in the `foreach` element.
 ** Mule 3: `<map-splitter/>`
 ** Mule 4: `<foreach collection="#[dw::core::Objects::entrySet(payload)]">`
-* `message-chunk-splitter`: There is no similar behavior in Mule 4. It cannot be migrated.
+* `message-chunk-splitter`: There is no similar behavior in Mule 4, so it can't be migrated.
 
 === Aggregators
 
 Most parameters allowed by Mule 3 aggregators are not allowed in Mule 4:
 
-* `timeout`: Though the timeout parameter can be set in any new aggregator, there are some differences. First, `timeoutUnit` should also be set to specify the unit of time. Also, the behavior of aggregation timeouts is very different in a Mule 4 aggregator. This is explained in xref:connectors::aggregator/aggregators-module-reference.adoc[Aggregators Module Reference].
-* `failOnTimeout`: No longer available. However similar behavior can be achieved, as explained in the <<complex_migration>>.
-* `processed-groups-object-store-ref`: Processed groups are no longer stored in a separate object store. This paremeter is not allowed anymore.
-* `event-groups-object-store-ref`: You can set this object store using the `objectStore` attribute in Mule 4 aggregators.
-* `persistentStores`: Not allowed anymore. If a persistent object store is needed, the `objectStore` attribute should be the name of a persistent object store.
-* `storePrefix`: Not allowed anymore.
+* `timeout` can be set in any new aggregator, however there are some differences. First, `timeoutUnit` should also be set to specify the unit of time. Also, the behavior of aggregation timeouts is very different in a Mule 4 aggregator. This is explained in xref:connectors::aggregator/aggregators-module-reference.adoc[Aggregators Module Reference].
+* `failOnTimeout`: is not available in Mule 4. However, similar behavior can be achieved as explained in <<complex_migration>>.
+* `processed-groups-object-store-ref` isn't stored in a separate object store in Mule 4, so this parameter isn't allowed in Mule 4.
+* `event-groups-object-store-ref`can be set using the `objectStore` attribute in Mule 4 aggregators.
+* `persistentStores` isn't allowed in Mule 4. If a persistent object store is needed, the `objectStore` attribute should be the name of a persistent object store.
+* `storePrefix` isn't allowed in Mule 4.
 
 
 === Available Aggregators Migration
 
-* `collection-aggregator`: Should be migrated as defined in the main example.
-* `custom-aggregator`: Cannot be migrated. There is no way in Mule 4 to add custom implementations for an interface.
-* `message-chunk-aggregator`: There is no similar behavior in Mule 4. It cannot be migrated.
+* `collection-aggregator` should be migrated as defined in the main example.
+* `custom-aggregator` can't be migrated. You can't add custom implementations for an interface in Mule 4.
+* `message-chunk-aggregator` can't be migrated to Mule 4 because there is no similar behavior.
 
 == See Also
 

--- a/modules/ROOT/pages/migration-core-until-successful.adoc
+++ b/modules/ROOT/pages/migration-core-until-successful.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 
-The Until Successful component for Mule 4 handles some processes differently
+The Until Successful component for Mule runtime engine (Mule) 4 handles some processes differently
 than the Mule 3 version. Some elements and attributes associated with these
 changes are no longer present in Mule 4. In Mule 4, you can either achieve the
 same functionality through different attributes or components, or you no longer
@@ -12,14 +12,14 @@ need to configure the functionality in Mule 4.
 A manual migration of the Until Successful component involves these
 modifications:
 
-* Removal of any `<processor-chain/>` elements.
-* Replacement of the `secondsBetweenRetries` attribute with `millisBetweenRetries`.
+* Removal of any `<processor-chain/>` elements
+* Replacement of the `secondsBetweenRetries` attribute with `millisBetweenRetries`
 * Removal of the `failureExpression` and use of a Validation processor for Mule 4,
-instead.
-* Replacement of the `deadLetterQueue-ref` attribute with an Error Handler for Mule 4.
-* Removal of any `<threading-profile/>` elements.
-* Removal of the `ackExpression` attribute and use of a Set Payload component, instead.
-* Removal of any `synchronous` attributes.
+instead
+* Replacement of the `deadLetterQueue-ref` attribute with an Error Handler for Mule 4
+* Removal of any `<threading-profile/>` elements
+* Removal of the `ackExpression` attribute and use of a Set Payload component, instead
+* Removal of any `synchronous` attributes
 
 These changes are detailed in the next sections.
 
@@ -154,7 +154,7 @@ Mule 4:
 </flow>
 ----
 
-== Threading Profile Removed, Not Needed in Mule 4
+== Threading Profile Removed
 
 In Mule 3, you can tune execution threads using the `<threading-profile/>`
 child element. Mule 4 introduces several changes to the execution engine.
@@ -184,7 +184,7 @@ The Mule 4 example removes the `<threading-profile/>` element.
 </flow>
 ----
 
-== ackExpression Attribute Removed, Use Set Payload
+== ackExpression Attribute Removed
 
 The Mule 3 `ackExpression` attribute configures synchronous production of a response payload. This attribute no longer exists in Mule 4. To achieve this behavior in your app, you can configure a Set Payload component after Until Successful.
 

--- a/modules/ROOT/pages/migration-core.adoc
+++ b/modules/ROOT/pages/migration-core.adoc
@@ -6,7 +6,7 @@ endif::[]
 // sme: Dan, writer: Mariano Gonzalez
 :keywords: studio, server, components, connectors, elements, palette, global elements, configuration elements
 
-The table below maps Mule 3.x components to their Mule 4 equivalents.
+The table below maps Mule runtime engine (Mule) 3.x components to their Mule 4 equivalents.
 
 [%header,cols="30,70"]
 |===
@@ -17,13 +17,13 @@ The table below maps Mule 3.x components to their Mule 4 equivalents.
 | bridge | Build an equivalent flow
 | catch-exception-strategy | Use xref:on-error-scope-concept.adoc[error-handler] with an `on-error-continue` strategy.
 | choice-exception-strategy| Use xref:on-error-scope-concept.adoc[error-handler] with different strategies inside using error type selection or when attribute.
-| combine-collections-transformer | No longer needed with the simplified message model. MuleMessageCollections are replaced with arrays of Mule Messages, which can be merged or iterated through using any Mule component, such as DataWeave or foreach.
+| combine-collections-transformer | No longer needed with the simplified message model. MuleMessageCollections are replaced with arrays of Mule messages, which can be merged or iterated through using any Mule component, such as DataWeave or foreach.
 | component | Use the xref:connectors::java/java-module.adoc[Java module].
 | composite-source | Create one flow per each source and invoke a private flow using flow-ref for the common functionality.
 | configuration[‘defaultExceptionStrategy-ref’] | New name is `defaultErrorHandler-ref`
 | configuration[‘flowEndingWithOneWayEndpointReturnsNull’] | No longer needed with new execution engine.
-| configuration[‘useExtendedTransformations’] | Removed.
-| configuration[enricherPropagatesSessionVariableChanges] | Removed.
+| configuration[‘useExtendedTransformations’] |  This component was removed.
+| configuration[enricherPropagatesSessionVariableChanges] |  This component was removed.
 | copy-attachments | Per the new xref:about-mule-message.adoc[Message Structure], attachments will now be part of the message Attributes. You can manipulate them at will using DataWeave
 | copy-properties | Per the new xref:about-mule-message.adoc[Message Structure], properties will now be part of the message Attributes. You can manipulate them at will using DataWeave
 | custom-agent | No longer supported.
@@ -49,22 +49,21 @@ The table below maps Mule 3.x components to their Mule 4 equivalents.
 | exception-strategy | Use xref:on-error-scope-concept.adoc[error-handler].
 | expression-component | Depending on the nature of your expression, you can either use DataWeave (for data access expressions), xref:migration-module-scripting.adoc[Scripting module] or the xref:mule-sdk::index.adoc[Mule SDK] for algorithmic expressions, or the xref:connectors::java/java-module.adoc[Java module] for expressions which simply access Java.
 | file-queue-store | Use the new xref:migration-module-vm.adoc[VM Connector].
-| flow[‘processingStrategy’] | Removed. Non blocking execution engine ensures that users do not need to tune this.
+| flow[‘processingStrategy’] |  This component was removed. Non blocking execution engine ensures that users do not need to tune this.
 | idempotent-message-filter | Replaced by xref:idempotent-message-validator.adoc[idempotent-message-validator].
 | idempotent-redelivery-policy | New name is `redelivery-policy`.
 | idempotent-secure-hash-message-filter | Replaced by xref:idempotent-message-validator.adoc[idempotent-message-validator].
 | in-memory-store | Use xref:migration-connectors-objectstore.adoc[Object Store connector] to create xref:connectors::object-store/object-store-to-define-a-new-os.adoc[custom stores].
 | inbound-endpoint | Use the event sources or triggers defined on each connector or module.
 | include-entry-point | Use the xref:connectors::java/java-module.adoc[Java module].
-| interceptor-stack | Removed. Use custom policies.
-| invoke | Use the xref:connectors::java/java-module.adoc[Java module]
+| interceptor-stack |  This component was removed. Use custom policies.
+| invoke | Use the xref:connectors::java/java-module.adoc[Java module].
 | jndi-transaction-manager | Use the `<bti:transaction-manager/>`.
 | jrun-transaction-manager | Use the `<bti:transaction-manager/>`.
-| legacy-abstract-exception-strategy | Use the new xref:on-error-scope-concept.adoc[error-handler]
+| legacy-abstract-exception-strategy | Use the new xref:on-error-scope-concept.adoc[error-handler].
 | managed-store | Use xref:migration-connectors-objectstore.adoc[Object Store connector] to create xref:connectors::object-store/object-store-to-define-a-new-os.adoc[custom stores].
 | message-properties-transformer | Use Transform component and DataWeave.
-| model | Removed. Use flows instead.
-| mule[‘version’] |
+| model |  This component was removed. Use flows instead.
 | outbound-endpoint | Element moved from the core namespace to the new transports namespace.
 | poll -> watermark | This capability has been built inside event sources from many connectors, like Salesforce, Database, SFTP, File, etc. You can also use the object-store connector to xred:migration-patterns-watermark.adoc[manually set the watermark values].
 | poll | Replaced with xref:migration-core-poll.adoc[scheduler component].
@@ -72,15 +71,15 @@ The table below maps Mule 3.x components to their Mule 4 equivalents.
 | prototype-object | Use Java module or Spring module.
 | queue-profile | Use the xref:migration-module-vm.adoc[VM Connector].
 | queue-store | xref:migration-module-vm.adoc[VM Connector].
-| recipient-list | Removed.
-| reconnect-custom-notifier | Removed.
-| reconnect-custom-strategy | Removed.
-| reconnect-notifier | Removed.
-| remove-attachment | No longer needed per the new xref:about-mule-message.adoc[Message Structure], attachments
-| remove-property | PNo longer needed per the new xref:about-mule-message.adoc[Message Structure], attachments
+| recipient-list |  This component was removed.
+| reconnect-custom-notifier |  This component was removed.
+| reconnect-custom-strategy |  This component was removed.
+| reconnect-notifier |  This component was removed.
+| remove-attachment | No longer needed per the new xref:about-mule-message.adoc[Message Structure] and attachments.
+| remove-property | PNo longer needed per the new xref:about-mule-message.adoc[Message Structure] and attachments.
 | response |No longer needed.
-| request-reply | Mule 4 will not longer support request-reply for all connectors. Connectors that had a “request-reply” behavior will provide a “request-reply” operation built in, such as the JMS `publish-consume` operation.
-| resin-transaction-manager | Removed.
+| request-reply | Mule 4 no longer supports request-reply for all connectors. Connectors that had a “request-reply” behavior will provide a “request-reply” operation built in, such as the JMS `publish-consume` operation.
+| resin-transaction-manager |  This component was removed.
 | rollback-exception-strategy | Use error-handler with an on-error-propagate strategy.
 | scatter-gather[‘threading-profile’] | No longer needed now that Mule 4 is non blocking.
 | seda-model | No more SEDA queues in Mule 4. The execution engine in Mule 4 is non-blocking.
@@ -94,18 +93,18 @@ The table below maps Mule 3.x components to their Mule 4 equivalents.
 | singleton-object | Use Java module or Spring module.
 | spring-object | Use Java module or Spring module.
 | synchronous-processing-strategy | The behavior related to flow components execution is the same as flows in 4.x but it doesn't always execute in the same thread as in 3.x.
-| transactional scope | Replaced with “try” scope.
-| username-password-filter | Removed.
-| validator | Removed.
+| transactional scope | The try scope replaced transactional scope.
+| username-password-filter |  This component was removed.
+| validator |  This component was removed.
 | weblogic-transaction-manager | Use the `<bti:transaction-manager/>`.
 | websphere-transaction-manager | Use the `<bti:transaction-manager/>`.
-| all-strategy | Removed.
+| all-strategy |  This component was removed.
 | entry-point-resolver | Use the xref:connectors::java/java-module.adoc[Java module].
 | filter | Filters are replaced by the xref:migration-filters.adoc[Validation module].
 | interceptor | Interceptors are replaced with custom policies.
-| message-info-mapping | No longer needed
-| point-resolver-set | Use the Use the xref:connectors::java/java-module.adoc[Java module].
-| router | Removed.
-| threading-profile | No longer needed. The Runtime now tunes itself.
-| transformer | Removed. Most explicit transformations are no longer needed. Use DataWeave for the corner cases.
+| message-info-mapping | This component is no longer needed.
+| point-resolver-set | Use the xref:connectors::java/java-module.adoc[Java module].
+| router |  This component was removed.
+| threading-profile | This component is no longer needed. Mule 4 tunes itself.
+| transformer |  This component was removed. Most explicit transformations are no longer needed. Use DataWeave for the corner cases.
 |===

--- a/modules/ROOT/pages/migration-filters.adoc
+++ b/modules/ROOT/pages/migration-filters.adoc
@@ -5,7 +5,7 @@ endif::[]
 
 // Contacts/SMEs: Rodro
 
-Mule 4 does not use `filters` anymore. The functionality provided by filters 
+Mule runtime engine (Mule) 4 does not use filters anymore. The functionality provided by filters 
 in Mule 3 can be achieved by using the xref:connectors::validation/validation-connector.adoc[Validation Module].
 
 == Applying Filters
@@ -59,11 +59,11 @@ send an appropriate response to the client. For instance, the
 </flow>
 ----
 
-In this case, a 400 (Bad Request) code will be returned if the event is filtered.
+In this case, a 400 (Bad Request) code is returned if the event is filtered.
 
-== Migrating Custom or complex Filters
+== Migrating Custom, Complex, or Nested Filters
 
-Most likely, any custom or complex/nested filters you used can be migrated to use the expression language. The DataWeave script can be externalized to a file if the same filter needs to be in several places.
+Most likely, any custom, complex, or nested filters you used can be migrated to use the expression language. The DataWeave script can be externalized to a file if the same filter needs to be in several places.
 
 For cases where you filter data in ways that DataWeave does not support, you should use the Java module or the Scripting module and use custom code to perform the filtering.
 

--- a/modules/ROOT/pages/migration-message-properties.adoc
+++ b/modules/ROOT/pages/migration-message-properties.adoc
@@ -5,13 +5,13 @@ endif::[]
 
 // Contacts/SMEs: Ana Felissati, Pablo La Greca
 
-In Mule 3, there are several property scopes that you can use for different purposes. In Mule 4, most of these scopes have been removed.
+In Mule runtime engine (Mule) 3, there are several property scopes have been removed in Mule 4.
 
 == Invocation Properties
 
 Invocation properties are now called `variables` in Mule 4. Their behavior is exactly the same as in Mule 3.
 
-== Inbound Properties, Outbound Properties, Inbound and Outbound Attachments
+== Inbound Properties, Outbound Properties, and Inbound and Outbound Attachments
 
 These scopes do not exist in Mule 4. See xref:intro-mule-message.adoc[Intro Mule Message] for more information about migration.
 

--- a/modules/ROOT/pages/migration-patterns-reconnection-strategies.adoc
+++ b/modules/ROOT/pages/migration-patterns-reconnection-strategies.adoc
@@ -3,14 +3,14 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 
-From a syntax point of view, reconnection hasn't changed much between Mule 3 and Mule 4. However, there are significant behavior differneces.
+Reconnection syntax hasn't changed much between Mule runtime engine (Mule) 3 and Mule 4. However, there are significant behavior differneces.
 
 In Mule 3, reconnection strategies were specified on each connector's config element. These strategies had two purposes:
 
 * To reconnect when a running application looses connection to an endpoint
-* To validate all connections when the application is being deployed.
+* To validate all connections when the application is being deployed
 
-So, suppose an application which connects to a mysql Database. If that connection cannot be established at deployment time, the deployment will fail. This was to guarantee that all deployed apps are in a functioning state.
+So, suppose an application which connects to a mysql database. If that connection cannot be established at deployment time, the deployment will fail. This was to guarantee that all deployed apps are in a functioning state.
 
 .Mule 3 Examples: Reconnection Settings (for a MySQL database)
 
@@ -38,7 +38,7 @@ To achieve this with Mule 3, you had to use the `blocking="false"` option, so th
 </db:mysql-config>
 ----
 
-In Mule 4 you can simply specify if deployment should fail or not if connectivity testing fails:
+In Mule 4 you can simply specify if deployment should fail or not if connectivity testing fails.
 
 .Mule 4 Examples: Reconnection Settings (for a SQL database)
 [source,xml,linenums]
@@ -58,13 +58,13 @@ In Mule 4 you can simply specify if deployment should fail or not if connectivit
 </db:mssql-connection>
 ----
 
-By default, a failure to establish connection will only generate a warning in the logs.
+By default, a failure to establish connection only generates a warning in the logs.
 
-== Operation level reconnection strategy
+== Operation-Level Reconnection Strategy
 
-In Mule 3, the same reconnection strategy at the config element was used both at deployment time and at runtime. For example, if connectivity to the Database is lost which executing a flow, the same reconnection strategy will be used.
+In Mule 3, the same reconnection strategy at the config element was used both at deployment time and at runtime. For example, if connectivity to the database is lost while executing a flow, the same reconnection strategy is used.
 
-In Mule 4 this behavior is kept by default, but you also get the chance to specify a different strategy at the operation or Message Source level:
+In Mule 4 this behavior is kept by default, but you also get the chance to specify a different strategy at the operation or message source level:
 
 .Mule 4 Examples: Reconnection Settings (for a SQL database)
 [source,xml,linenums]

--- a/modules/ROOT/pages/migration-patterns-watermark.adoc
+++ b/modules/ROOT/pages/migration-patterns-watermark.adoc
@@ -8,10 +8,7 @@ Watermarking is typically used to perform data synchronization, for example, whe
 
 For the Mule 3 approach, see this MuleSoft blog: https://blogs.mulesoft.com/dev/anypoint-platform-dev/data-synchronizing-made-easy-with-mule-watermarks/[Data Synchronizing made easy with Watermarks].
 
-
-Here's the Mule 3 watermark example from that blog:
-
-.Mule 3 Example: Polling Salesforce contacts using watermark
+.Mule 3 Example from Blog: Polling Salesforce contacts using watermark
 [source,xml,linenums]
 ----
 <flow name="syncWithWatermark" processingStrategy="synchronous">
@@ -26,7 +23,6 @@ Here's the Mule 3 watermark example from that blog:
   <flow-ref name="doYourSyncMagic" />
 </flow>
 ----
-
 
 As the Anypoint Platform grew and our use cases became more complicated, limitations started to appear in the Mule 3 approach:
 
@@ -81,7 +77,7 @@ Let’s break the example down step by step:
 
 == Automatic Watermark
 
-The above is great and more powerful than what we had in Mule 3, but we wanted to make it even simpler. That's why some connectors already include message sources capable of doing watermarking automatically, without the need for you to take any of the steps above. At the moment of writing this document, the File, Ftp, Sftp, Database and Salesforce connectors have this capability, but we will continue to add support for this in other connectors.
+Manual watermarking is more powerful in Mule 4 than Mule 3, but MuleSoft made it even simpler. Some connectors already include message sources capable of doing watermarking automatically, without the need for you to take any of the steps above. The File, FTP, SFTP, Database, and Salesforce connectors have this capability now. MuleSoft continues to add support for automatic watermarking in more connectors.
 
 Let's use the file connector to see an example of how this works:
 
@@ -102,10 +98,10 @@ In this example, we get automatic watermarking using the file's creation time as
 
 We only recommend to take "the long way" described in the first example when:
 
-* Your use case is very custom
-* You are using a connector which doesn't support automatic watermarking.
+* Your use case is has custom requirements not met in any other way.
+* You use a connector which doesn't support automatic watermarking.
 
-In any other case, we recommend automatic watermarking as the best way of dealing with these use cases.
+In any other case, we recommend automatic watermarking.
 
 == See Also
 

--- a/modules/ROOT/pages/migration-prep.adoc
+++ b/modules/ROOT/pages/migration-prep.adoc
@@ -5,7 +5,7 @@ endif::[]
 
 // Contacts/SMEs: Esteban Wasinger, Ana Felisatti, Mariano Gonzalez
 
-Mule 4 introduces many changes, so plan accordingly before attempting to migrate from Mule 3.
+Mule runtime engine (Mule) 4 introduces many changes, so plan accordingly before attempting to migrate from Mule 3.
 
 [[when_to_start]]
 == When to Start Using Mule 4
@@ -13,22 +13,22 @@ Mule 4 introduces many changes, so plan accordingly before attempting to migrate
 We recommend that you develop all *new* projects on Mule 4, provided that:
 
 * You and your team have updated your skills for Mule 4 via the documentation or formal training.
-* You have the proper deployment environment (see below).
-* You do not require all applications to be on a single version of Mule (see below).
+* You have prepared your <<prepare_to_deploy,deployment environment>>.
+* You do not require all applications to be on a single version of Mule.
 
 For projects which are already in development or deployed on Mule 3 (whether a prospect or customer), we recommend you wait to migrate these applications until the Mule 3 to Mule 4 migration tool is available. However, you can follow this guide to migrate manually.
 
 Migrate your applications if any one of the following conditions is met:
 
-* The 3.x version you're using reaches end of life
-* You want to make significant updates to the existing applications
-* You want to take advantage of key Mule 4 capabilities
-* You decide to upgrade all their apps to Mule 4 because you require all apps to be on one version (some onprem customers)
+* The 3.x version you're using reaches its end of life.
+* You want to make significant updates to the existing applications.
+* You want to take advantage of key Mule 4 capabilities.
+* You decide to upgrade all apps to Mule 4 because you require all apps to be on one version, which is a requirement for some on-premises customers.
 
 [[prepare_dev_environ]]
 == Setting up Your Local Development Environment
 
-First, you will need to download Studio 7 and install it. If you're deploying locally, you will also need to download the Mule 4 standalone runtime.
+First, download Studio 7 and install it. If you're deploying locally, you will also need to download the Mule 4 standalone runtime.
 // TODO link to pages
 
 [[prepare_to_deploy]]

--- a/modules/ROOT/pages/migration-process.adoc
+++ b/modules/ROOT/pages/migration-process.adoc
@@ -8,22 +8,22 @@ endif::[]
 //TODO: LINK TO MULE 4 SECTIONS FOR ALL THESE STEPS.
 After learning how to prepare for the migration, it is important to understand the high-level migration steps:
 
-. Add all required modules, such as the Database connector, to the Anypoint Studio 7 palette.
+. Add all required modules, such as the Database connector, to the Anypoint Studio (Studio) 7 palette.
 +
 Notes:
 +
 * You can add modules through the Studio 7 palette. Other modules are available in Anypoint Exchange.
 +
-* All Mule projects are Mavenized by default when you add the modules to your project.
+* All Mule projects are mavenized by default when you add the modules to your project.
 +
 . Migrate all the global configurations.
 . Migrate configuration properties.
 +
 // .yaml or .properties. Include link to properties config in Mule 4.
 +
-. Learn how the components work in Mule 4 to see what has changed from Mule 3.
+. Learn how the components work in Mule runtime engine (Mule) 4 to see what has changed from Mule 3.
 . Understand how changes to the Mule message structure (attributes, payload, and variables) affect your configurations. See xref:intro-mule-message.adoc[Introduction to Mule 4: The Mule Message].
-. Update your expressions and scripts to DataWeave version 2:
+. Update your expressions and scripts to DataWeave 2:
 ** Be aware of changes between DataWeave 1 and DataWeave 2, for example, importing specific function modules and understanding syntax changes. See xref:migration-dataweave.adoc[Migrating from DataWeave 1.0 to 2.x].
 +
 // TODO: ASK ABOUT MIGRATION TOOL, TASK TO MIGRATE SCRIPTS FROM 1.0 TO 2.

--- a/modules/ROOT/pages/migration-secure-properties-placeholder.adoc
+++ b/modules/ROOT/pages/migration-secure-properties-placeholder.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 
-In Mule 3, the Secure Properties Placeholder was part of the Security Module. In Mule 4, it is separated in its own Secure Configuration Properties module.
+In Mule runtime engine (Mule) 3, the Secure Properties Placeholder was part of the Security Module. In Mule 4, it is separated in its own Secure Configuration Properties module.
 
 .Example: Complete Secure Properties Placeholder in Mule 3
 [source,xml,linenums]

--- a/modules/ROOT/pages/migration-security-filters.adoc
+++ b/modules/ROOT/pages/migration-security-filters.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 
-In Mule runtime engine (Mule) 3, the Security Filters are part of the Mule Module Security. In Mule 4, security filters are in the xref:connectors::validation/validation-connector.adoc[Mule Validation Module].
+In Mule runtime engine (Mule) 3, the security filters are part of Mule module security. In Mule 4, security filters are in the xref:connectors::validation/validation-connector.adoc[Mule Validation Module].
 
 == IP filters
 
@@ -37,7 +37,7 @@ Where is necessary to set that `ip` variable (or whichever variable suits).
 
 === Filtering by a Range of IPs
 
-In mule 3, we had two ways of defining subnet mask to filter with:
+In Mule 3, we had two ways of defining subnet mask to filter with:
 
 .Example: Filtering by IP range in Mule 3
 [source,xml,linenums]
@@ -66,7 +66,7 @@ Mule 4 also offers whitelist validation, which only allows IPs from an IP filter
 
 == Time Expiration Filters
 
-In Mule 3 you can filter the message if it older than a specifed time from a starting date. For example:
+In Mule 3 you can filter the message if it's older than a specifed time from a starting date. For example:
 
 .Example: Filtering by elapsed time in Mule 3
 [source,xml,linenums]

--- a/modules/ROOT/pages/migration-security-filters.adoc
+++ b/modules/ROOT/pages/migration-security-filters.adoc
@@ -3,16 +3,16 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 
-In Mule 3, the Security Filters where part of the Mule Module Security. In Mule 4, this where migrated to the xref:connectors::validation/validation-connector.adoc[Mule Validation Module].
+In Mule runtime engine (Mule) 3, the Security Filters are part of the Mule Module Security. In Mule 4, security filters are in the xref:connectors::validation/validation-connector.adoc[Mule Validation Module].
 
 == IP filters
 
-In mule 3 we had three different options to filter by IP:
+In Mule 3 you can filter by IP, IP range, or IP range pulus CIDR:
 * `<filters:filter-by-ip>`
 * `<filters:filter-by-ip-range>`
 * `<filters:filter-by-ip-range-cidr>`
 
-=== Filtering By one IP
+=== Filtering By One IP in Mule 3
 
 .Example: Filtering by one IP in Mule 3
 [source,xml,linenums]
@@ -22,7 +22,7 @@ In mule 3 we had three different options to filter by IP:
 
 This will filter those IPs that matches the regex. In mule4:
 
-.Example: Filtering by one IP in Mule 4
+.Example: Filtering by One IP in Mule 4
 [source,xml,linenums]
 ----
 <validation:is-blacklisted-ip blacklist="iplist" ip="#[vars.ip]">
@@ -35,7 +35,7 @@ This will filter those IPs that matches the regex. In mule4:
 
 Where is necessary to set that `ip` variable (or whichever variable suits).
 
-=== Filtering by range of IPs
+=== Filtering by a Range of IPs
 
 In mule 3, we had two ways of defining subnet mask to filter with:
 
@@ -60,14 +60,13 @@ Both are replaced by:
 </validation:ip-filter-list>
 ----
 
-Where is necessary to set that `ip` variable (or whichever variable suits).
+Set the `ip` variable.
 
-[qanda]
-Are there other similar validations added in mule 4? :: Yes, there is also a WhiteList validation, which only allows IPs from a IP Filter List.
+Mule 4 also offers whitelist validation, which only allows IPs from an IP filter list.
 
 == Time Expiration Filters
 
-In mule 3 we could filter the message if it had elapsed some defined time from a starting date. For example:
+In Mule 3 you can filter the message if it older than a specifed time from a starting date. For example:
 
 .Example: Filtering by elapsed time in Mule 3
 [source,xml,linenums]
@@ -83,8 +82,7 @@ In Mule 4, this validation is in the validations module:
 <validation:is-not-elapsed time="1" timeUnit="SECONDS" since="#[vars.startingTime]"/>
 ----
 
-[qanda]
-Are there other similar validations added in mule 4? :: Yes, there is also a Time Elapsed validation, which validates if the time elapsed has exceded a certain amount of time.
+Mule 4 also offers a time-elapsed validation, which validates whether the time elapsed has exceded a specified amount of time.
 
 == See Also
 xref:connectors::validation/validation-documentation.adoc[Validation Connector Technical Reference]

--- a/modules/ROOT/pages/migration-transformers.adoc
+++ b/modules/ROOT/pages/migration-transformers.adoc
@@ -5,7 +5,7 @@ endif::[]
 
 // Contacts/SMEs: Ana Felissati, Pablo La Greca
 
-Mule 4 does not require `transformers` anymore. Now that DataWeave is the default expression language and the repeatable streams feature is supported, most (if not all) scenarios that required a transformer no longer exist.
+Mule runtime engine (Mule) 4 doesn't require `transformers`. DataWeave is the default expression language and the repeatable streams feature is supported, so scenarios that require a transformer no longer exist.
 
 == Migrating Type Transformers
 

--- a/modules/ROOT/pages/migration-transports.adoc
+++ b/modules/ROOT/pages/migration-transports.adoc
@@ -3,14 +3,11 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 
-Mule 3 transports have been replaced by connectors, which follow an
-operation model in Mule 4. Most Mule transports are replaceable by a
-corresponding connector in Mule 4.
+Mule runtime engine (Mule) 3 transports have been replaced by connectors, which follow an
+operation model in Mule 4. Most Mule transports are replaceable by a corresponding connector in Mule 4.
 
-Some migration issues are common to all transports. For transport-specific
-migration documentation, refer to
-xref:migration-connectors.adoc[Migrating Connectors and Modules to Mule 4] and
-its child pages, instead.
+The migration issues explained here are common to all transports. For transport-specific
+migration documentation, see xref:migration-connectors.adoc[Migrating Connectors and Modules to Mule 4].
 
 [[address]]
 == Endpoint Addresses
@@ -63,7 +60,7 @@ provides detail on the exact properties that the connector requires.
 == Service Overrides
 
 In Mule 4, service override customizations through custom Java code are not
-supported in Mule 4.
+supported.
 
 In Mule 3, it is possible to customize the behavior of a transport through a
 connector's `service-overrides` element. This element provides a way to

--- a/modules/ROOT/pages/mule-app-tutorial.adoc
+++ b/modules/ROOT/pages/mule-app-tutorial.adoc
@@ -3,9 +3,9 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 
-Most integrations require a change to the structure of data as it moves from source to destination. Within a Mule app, you can use the drag-n-drop interface of the Transform Message component to map data from one field or format to another, or you can write mappings by hand within DataWeave scripts. You typically build Mule apps in Studio or Design Center, but you can even write Mule app configurations by hand in XML. This tutorial uses Studio.
+Most integrations require a change to the structure of data as it moves from source to destination. Within a Mule runtime engine (Mule) app, you can use the drag-n-drop interface of the Transform Message component to map data from one field or format to another, or you can write mappings by hand within DataWeave scripts. You typically build Mule apps in Anypoint Studio[Studio] or Design Center, but you can even write Mule app configurations by hand in XML. This tutorial uses Studio.
 
-Using a small data set and a training API available on Exchange, you'll create a project and define the transformation mapping from the API into a different structure and protocol. You'll use the drag-n-drop and also see the xref:dataweave.adoc[DataWeave] code that defines the transformation. After completing this tutorial, you'll be ready to create your own data mappings.
+Using a small data set and a training API available on Anypoint Exchange (Exchange), you'll create a project and define the transformation mapping from the API into a different structure and protocol. You'll use the drag-n-drop and also see the xref:dataweave.adoc[DataWeave] code that defines the transformation. After completing this tutorial, you'll be ready to create your own data mappings.
 
 == Prerequisites
 
@@ -17,7 +17,7 @@ image::dw-quickstart-am-json.png[]
 +
 This is the structure we'll transform.
 
-. Download and install xref:7.2@studio::to-download-and-install-studio.adoc[Anypoint Studio].
+. Download and install xref:7.2@studio::to-download-and-install-studio.adoc[Studio].
 . Create https://anypoint.mulesoft.com/login/#/signin?apintent=exchange[an Anypoint Platform trial account] if you don't have one.
 . Choose a REST API client such as Postman or the Advanced REST client. This tutorial uses the Advanced REST client.
 
@@ -25,7 +25,7 @@ This is the structure we'll transform.
 
 Create the project that will contain your Mule app.
 
-. Open Anypoint Studio, and select **File > New > Mule Project**.
+. Open Studio, and select **File > New > Mule Project**.
 . Set the **Project Name** to `dw-tutorial4-flights-ws`.
 . Leave all other defaults, and select **Finish** to create the project.
 

--- a/modules/ROOT/pages/mule-runtime-updates.adoc
+++ b/modules/ROOT/pages/mule-runtime-updates.adoc
@@ -4,9 +4,9 @@ include::_attributes.adoc[]
 endif::[]
 :keywords: news, updates, mule ESB, mule runtime, 4.0, Mule 4.0, Mule 4.0 for mule 3 developers, what's new Mule 4
 
-Mule 4's simplified language and reduced management complexity enables you to speed up the on ramping process and deliver applications faster.
+Mule runtime engine (Mule) 4's simplified language and reduced management complexity enables you to speed up the on ramping process and deliver applications faster.
 
-If you are familiar with the concepts of the previous versions of the runtime, check the sections below to learn what's changing in Mule Runtime v4.0.
+If you are familiar with the concepts of the previous versions of the runtime, check the sections below to learn what's changing in Mule 4.
 
 == Simplified Event and Message Model
 

--- a/modules/ROOT/pages/mule-standalone.adoc
+++ b/modules/ROOT/pages/mule-standalone.adoc
@@ -4,11 +4,11 @@ include::_attributes.adoc[]
 endif::[]
 :keywords: mule, studio, enterprise, ee, premium features, paid features, purchase, license, licensed
 
-You only need to install Mule, a production-strength runtime engine, if you host it in your own environment.
+You only need to install Mule rutnime engine (Mule), a production-strength runtime engine, if you host it in your own environment.
 
 You don't need to worry about installation in the following instances:
 
-* You use Studio for development and testing, because Studio contains Mule.
+* Use Anypoint Studio (Studio) for development and testing, because Studio contains Mule.
 * Mulesoft hosts your instance of Mule.
 
 Skip this section if you don't need to install Mule.

--- a/modules/ROOT/pages/runtime-installation-task.adoc
+++ b/modules/ROOT/pages/runtime-installation-task.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 
-Before downloading and installing Mule runtime, verify that you have Java SE JDK 1.8 installed, for example:
+Before downloading and installing Mule runtime engine (Mule), verify that you have Java SE JDK 1.8 installed, for example:
 
 [source,console,linenums]
 ----
@@ -15,11 +15,11 @@ Java HotSpot(TM) 64-Bit Server VM (build 25.111-b14, mixed mode)
 
 == Download Mule
 
-. Download the Mule 4 binary file from the Download Site and unzip it:
+. Download the Mule 4 binary file from the download site and unzip it:
 +
 https://support.mulesoft.com/s/downloads[https://support.mulesoft.com/s/downloads]
 +
-The Mule 4 binary files are located under *Downloads* > *Mule Runtime* on the Download Site.
+The Mule 4 binary files are located under *Downloads* > *Mule Runtime* on the download site.
 +
 . Set an environment variable called `MULE_HOME` for the `mule` directory inside your extracted folder.
 +
@@ -39,18 +39,18 @@ On Linux/Unix environments:
 $ export MULE_HOME=~/Downloads/mule-enterprise-standalone-4.1.1/
 ----
 
-== Run the Mule Runtime
+== Run Mule
 
-You can test if the Mule Runtime runs in your system without errors by running the following commands:
+You can test that Mule runs in your system without errors by running the following commands:
 
-* On Windows environments:
+* In Windows environments:
 +
 [source,powershell]
 ----
 $ $MULE_HOME\bin\mule.bat
 ----
 +
-* On Linux/Unix environments:
+* In Linux/Unix environments:
 +
 [source,console]
 ----
@@ -59,7 +59,7 @@ $ $MULE_HOME/bin/mule
 
 == Start the Mule Service
 
-You can run the Mule runtime standalone by starting the Mule service inside `$MULE_HOME/bin/` directory:
+You can run the standalone Mule by starting Mule inside `$MULE_HOME/bin/` directory:
 
 * On Windows environments:
 +
@@ -102,7 +102,7 @@ running: PID:87318
 
 == Stop Mule
 
-Use the `stop` command to Mule from running.
+Use the `stop` command to stop Mule.
 
 This example stops Mule from a Unix console:
 


### PR DESCRIPTION
The first occurrence of "Mule" in every file is Mule runtime engine (full name), followed by (Mule), and Mule should be used in the rest of the file. This matches the glossary given translation.

There may be issues in any topic but I'm just getting the terminology consistent, removing "will" where it isn't needed, and getting rid of spurious init caps. 