### PR TITLE
batch 2 of Mule scrubbing for translation

### DIFF
--- a/modules/ROOT/pages/migration-cheat-sheet.adoc
+++ b/modules/ROOT/pages/migration-cheat-sheet.adoc
@@ -5,30 +5,30 @@ endif::[]
 
 // author: Mariano Gonzalez
 
-To help you move from Mule 3 to Mule 4, we built this index to help you find the Mule 4 equivalent of the most common Mule 3 use cases.
+To help you move from Mule runtime engine (Mule) 3 to Mule 4, use this list to help you find the Mule 4 equivalent of the most common Mule 3 use cases.
 
-*IMPORTANT:* Keep in mind that this index is only intended to act as a quick entry to the most common migration scenarios. It doesn't contain the entire migration guide. For the full set of migration articles, please visit our Mule xref:index-migration.adoc[Mule 4 for Mule 3 Users] page.
+*IMPORTANT:* This list is a quick reference for the most common migration scenarios. It doesn't contain the entire migration guide. For the full set of migration articles, please visit xref:index-migration.adoc[Mule 4 for Mule 3 Users].
 
-* xref:configuring-properties.adoc[Configuration Properties]: There's a new way of handling configuration properties in Mule 4
-* xref:migration-secure-properties-placeholder.adoc[Using Secure Properties]: Secure placeholders are now a Runtime feature and no longer part of the Security Module
+* xref:configuring-properties.adoc[Configuration Properties]: There's a new way of handling configuration properties in Mule 4.
+* xref:migration-secure-properties-placeholder.adoc[Using Secure Properties]: Secure placeholders are now a Runtime feature and no longer part of the Security Module.
 * xref:migration-connectors-http.adoc[Using the HTTP Connector]: The new HTTP connector has some differences with Mule 3, especially when it comes to handling multipart and form requests.
 * xref:migration-mel.adoc[From MEL to DataWeave]: DataWeave 2.0 is now the expression language. Here's how to adapt your MEL expressions to DataWeave.
-* xref:migration-dataweave.adoc[From DataWeave 1.0 to DataWeave 2.0]: A new version of DataWeave is available in Mule 4
-* Where are the explicit transformers?: Transformers like `<object-to-string />` or `<object-to-json>` are no longer necessary. Mule handles this automatically under the covers
-* xref:connectors::object-store/object-store-to-define-a-new-os.adoc[Define a custom Object Store]: Custom Object Stores are now defined through the new connector
-* xref:migration-patterns-watermark.adoc[Use watermarks]: Watermarks have been simplified. You can also do it manually now allowing for more complex use cases.
-* xref:migration-message-properties.adoc[Accessing the Mule Message]: The Mule Message has a new structure and it's accessed differently. Here's a quick overview.
-* Using Java: Interoperability with Java is now done through the xref:connectors::java/java-module.adoc[Java module]. Optionally you can also try the xref:migration-module-scripting.adoc[Scripting module] or the xref:mule-sdk::index.adoc[Mule SDK]
-* xref:migration-module-spring.adoc[Using Spring]: Instead of defining Spring beans directly in your application, you can now use the xref:connectors::spring/spring-module.adoc[Spring Module].
-* xref:migration-patterns-reconnection-strategies.adoc[Using reconnection strategies]: There are some small but important differences around reconnection in Mule 4.
-* xref:migration-munit.adoc[From MUnit 1.0 to Munit 2.0]: This page explains how to adapt your tests for Mule 4.
-* xref:about-classloading-isolation.adoc[Classloading isolation]: Classloading isolation changes the way resources and classes are shared. Read this article to learn more.
-* xref:migration-core.adoc[Core Components Migration]: A comprehensive list of the changes that were made to the core language elements
-* xref:migration-connectors.adoc[Using the new connectors]: A comprehensive list of the changes that were made to the main connectors.
-* xref:migration-aes.adoc[Using the Security Module (AES)]: Anypoint Enterprise Security module was split into different modules explained here.
-* xref:migration-api-gateways.adoc[Migrating Gateways]: This section covers the migration of API Gateway related features.
-* xref:migration-example-complex.adoc[Migrating ApiKit apps]: Covers the necessary steps to successfully migrate APIkit-based applications.
-* Migrating custom components: You can use the xref:mule-sdk::index.adoc[Mule SDK] to create your own reusable components
-* Migrating DevKit based components: There's a xref:mule-sdk::dmt.adoc[DevKit Migration Tool] that helps to migrate DevKit projects for Mule 3 into Mule SDK ones.
-* xref:migration-transports.adoc[Transport service overrides]: Covers how to migrate from generic transports.
+* xref:migration-dataweave.adoc[From DataWeave 1.0 to DataWeave 2.0]: A new version of DataWeave is available in Mule 4.
+* Where are the explicit transformers?: Transformers like `<object-to-string />` or `<object-to-json>` are no longer necessary. Mule handles this automatically under the covers.
+* xref:connectors::object-store/object-store-to-define-a-new-os.adoc[Define a Custom Object Store]: Custom object stores are now defined through the new connector.
+* xref:migration-patterns-watermark.adoc[Use watermarks]: Watermarks have been simplified. You can update them automatically in some cases, or manually to allow for more complex use cases.
+* xref:migration-message-properties.adoc[Accessing the Mule Message]: The Mule message has a new structure and it's accessed differently. Here's a quick overview.
+* Using Java: Interoperability with Java is now done through the xref:connectors::java/java-module.adoc[Java module]. Optionally you can also try the xref:migration-module-scripting.adoc[Scripting module] or the xref:mule-sdk::index.adoc[Mule SDK].
+* xref:migration-module-spring.adoc[Using Spring]: Instead of defining Spring beans directly in your application, use the xref:connectors::spring/spring-module.adoc[Spring Module].
+* xref:migration-patterns-reconnection-strategies.adoc[Using reconnection strategies]: Review the small but important differences related to reconnection in Mule 4.
+* xref:migration-munit.adoc[From MUnit 1.0 to Munit 2.0]: Adapt your tests for Mule 4.
+* xref:about-classloading-isolation.adoc[Classloading isolation]: Classloading isolation changes the way resources and classes are shared.
+* xref:migration-core.adoc[Core Components Migration]: Changes were made to the core language elements.
+* xref:migration-connectors.adoc[Using the new connectors]: Changes that were made to the main connectors.
+* xref:migration-aes.adoc[Using the Security Module (AES)]: The Anypoint Enterprise Security module was split into different modules.
+* xref:migration-api-gateways.adoc[Migrating Gateways]: This section covers the migration of the features related to API gateway.
+* xref:migration-example-complex.adoc[Migrating Apikit Apps]: Migrate APIkit-based applications.
+* Migrating custom components: Use the xref:mule-sdk::index.adoc[Mule SDK] to create your own reusable components.
+* Migrating DevKit-based components: xref:mule-sdk::dmt.adoc[DevKit Migration Tool] helps you migrate DevKit projects for Mule 3 into Mule SDK projects.
+* xref:migration-transports.adoc[Transport service overrides]: Migrate services from generic transports.
 

--- a/modules/ROOT/pages/migration-cheat-sheet.adoc
+++ b/modules/ROOT/pages/migration-cheat-sheet.adoc
@@ -10,7 +10,7 @@ To help you move from Mule runtime engine (Mule) 3 to Mule 4, use this list to h
 *IMPORTANT:* This list is a quick reference for the most common migration scenarios. It doesn't contain the entire migration guide. For the full set of migration articles, please visit xref:index-migration.adoc[Mule 4 for Mule 3 Users].
 
 * xref:configuring-properties.adoc[Configuration Properties]: There's a new way of handling configuration properties in Mule 4.
-* xref:migration-secure-properties-placeholder.adoc[Using Secure Properties]: Secure placeholders are now a Runtime feature and no longer part of the Security Module.
+* xref:migration-secure-properties-placeholder.adoc[Using Secure Properties]: Secure placeholders are now a Mule feature and no longer part of the Security module.
 * xref:migration-connectors-http.adoc[Using the HTTP Connector]: The new HTTP connector has some differences with Mule 3, especially when it comes to handling multipart and form requests.
 * xref:migration-mel.adoc[From MEL to DataWeave]: DataWeave 2.0 is now the expression language. Here's how to adapt your MEL expressions to DataWeave.
 * xref:migration-dataweave.adoc[From DataWeave 1.0 to DataWeave 2.0]: A new version of DataWeave is available in Mule 4.
@@ -31,4 +31,3 @@ To help you move from Mule runtime engine (Mule) 3 to Mule 4, use this list to h
 * Migrating custom components: Use the xref:mule-sdk::index.adoc[Mule SDK] to create your own reusable components.
 * Migrating DevKit-based components: xref:mule-sdk::dmt.adoc[DevKit Migration Tool] helps you migrate DevKit projects for Mule 3 into Mule SDK projects.
 * xref:migration-transports.adoc[Transport service overrides]: Migrate services from generic transports.
-

--- a/modules/ROOT/pages/migration-core-batch.adoc
+++ b/modules/ROOT/pages/migration-core-batch.adoc
@@ -6,7 +6,8 @@ endif::[]
 // sme: MG, author: sduke?
 
 // Explain generally how and why things changed between Mule 3 and Mule 4.
-The Batch module was introduced to handle Extract Transform Load (ETL) functionality.
+
+The Batch module handles Extract Transform Load (ETL) functionality.
 
 What's covered in this section:
 
@@ -18,7 +19,7 @@ What's covered in this section:
 [[batch_scope]]
 == Migrating the Batch Element
 
-In Mule 3, Batch was a top-level element, at the same level as a flow. In Mule 4, the `<batch:job>` element is a scope that lives inside a flow so that it is easier to understand, invoke dynamically, and interact with other Mule components.
+In Mule runtime engine (Mule) 3, Batch was a top-level element, at the same level as a flow. In Mule 4, the `<batch:job>` element is a scope that lives inside a flow so that it is easier to understand, invoke dynamically, and interact with other Mule components.
 
 This also means that there is no `<batch:input>` anymore. The role of the `<batch:input>` is now accomplished by whatever set of processors are in the flow before the `<batch:job>` is triggered.
 
@@ -81,9 +82,8 @@ In Mule 3, you use record-level variables (`recordVars`) to attach variables to 
 
 In Mule 4, variables (`vars`) replace `recordVars`. Variables are part of the Mule event in Mule 4. From within the `<batch:step>`, you can modify a variable that existed before the `<batch:job>` began executing, and you can do it for one particular record, without side effects on the other ones.
 
-The Mule 3 example here uses `recordVars` within an expression in a For Each component:
+This Mule 3 example uses `recordVars` within an expression in a For Each component:
 
-.Mule 3 Example
 [source,xml,linenums]
 ----
 <batch:step name="commitStep">
@@ -98,9 +98,8 @@ The Mule 3 example here uses `recordVars` within an expression in a For Each com
 </batch:step>
 ----
 
-The Mule 4 example here uses `vars` within an expression in a For Each component:
+This Mule 4 example uses `vars` within an expression in a For Each component:
 
-.Mule 4 Example
 [source,xml,linenums]
 ----
 <batch:job jobName="batchJob">
@@ -126,9 +125,8 @@ The Mule 4 example here uses `vars` within an expression in a For Each component
 
 In Mule 3, the batch input phase required a Java structure. So, for input data in formats such as XML or JSON, you first needed to transform to Java, then make DataWeave use streaming in that transformation to avoid running out of memory for large datasets.
 
-For example, suppose you have this source data pushed to your app through an HTTP call:
+For example, suppose you have this source data (JSON input data) pushed to your app through an HTTP call:
 
-.Example: JSON Input Data
 ----
 [
     {
@@ -146,9 +144,8 @@ For example, suppose you have this source data pushed to your app through an HTT
 ]
 ----
 
-In Mule 3, you need to transform that JSON to Java before passing it over, something like this:
+In Mule 3, you need to transform that JSON to Java before passing it over:
 
-.Mule 3 Example
 [source,xml,linenums]
 ----
 <batch:job name="forceJob">
@@ -170,7 +167,6 @@ In Mule 3, you need to transform that JSON to Java before passing it over, somet
 
 In Mule 4, Batch can automatically determine that the payload is a JSON array and perform the splitting on its own, for example:
 
-.Mule 4 Example
 [source,xml,linenums]
 ----
 <flow name="useTheForceBatch">
@@ -188,7 +184,7 @@ You no longer have to set streaming in Mule 4 because of the automatic streaming
 
 * Camel Case attributes: Following the Mule 4 DSL guidelines, and in order to improve consistency, all DSL attributes have been changed to camel case. For example, `max-failed-records` is now `maxFailedRecords`, `accept-policy` is `acceptPolicy`, and so on.
 
-* MuleSoft removed the `filter-expression` parameter from the `<batch:step>`` element. This attribute was deprecated in Mule 3.6 and should be replaced with `accept-expression` parameter.
+* MuleSoft removed the `filter-expression` parameter from the `<batch:step>` element. This attribute was deprecated in Mule 3.6 and should be replaced with `accept-expression` parameter.
 
 * The `<batch:commit>` is now called `<batch:aggregator>`.
 

--- a/modules/ROOT/pages/migration-core-choice.adoc
+++ b/modules/ROOT/pages/migration-core-choice.adoc
@@ -5,14 +5,16 @@ endif::[]
 
 // sme: DF, author: sduke?
 
-Little changed between Choice router for Mule 3 and Mule 4 except for:
+The Choice router didn't change much from Mule runtime engine (Mule) 3 to Mule 4:
 
-* DataWeave is now the expression language so the when statements are actually going to use it instead of MEL
-* The `<otherwise>` block is now optional
+* DataWeave is now the expression language, so `<when>` attributes use it instead of MEL.
+* The `<otherwise>` block is now optional.
 
 == Expression Language for the When Block
 
-The when expressions need to be changed from MEL to DataWeave. This also mean that you can leverage DataWeave's ability to interpret any format to avoid unnecesary convertions. For example, suppose a flow in which a JSON document representing a user is posted through HTTP and you want to check if the person is underage:
+Change `<when>` expressions from MEL to DataWeave. As an added benefit, you can leverage DataWeave's ability to interpret any format to avoid unnecesary convertions.
+
+For example, suppose a flow in which a JSON document representing a user is posted through HTTP and you want to check if the person is underage.
 
 .Mule 3 Example: MEL
 [source,xml,linenums]
@@ -31,7 +33,7 @@ The when expressions need to be changed from MEL to DataWeave. This also mean th
 </flow>
 ----
 
-With Mule 4, you don't need to worry about JSON or Java formats and just do:
+With Mule 4, you don't need to worry about JSON or Java formats.
 
 .Mule 4 Example: DataWeave 2
 [source,xml,linenums]
@@ -51,8 +53,7 @@ With Mule 4, you don't need to worry about JSON or Java formats and just do:
 
 == Optional Otherwise
 
-In Mule 3, the `<otherwise>` block was required. Many times in which fallback logic was not necessary, you ended up with an `<otherwise>` block which just had an unsignificant logger. In Mule 4, the `<otherwise>` block is optional and you don't need to specify it if not necessary.
-
+In Mule 3, the `<otherwise>` block was required. Many times, when fallback logic wasn't necessary, the `<otherwise>` block contained an insignificant logger. In Mule 4, the `<otherwise>` block is optional and you don't need to specify it if it's not necessary.
 
 == See Also
 

--- a/modules/ROOT/pages/migration-core-choice.adoc
+++ b/modules/ROOT/pages/migration-core-choice.adoc
@@ -14,7 +14,7 @@ The Choice router didn't change much from Mule runtime engine (Mule) 3 to Mule 4
 
 Change `<when>` expressions from MEL to DataWeave. As an added benefit, you can leverage DataWeave's ability to interpret any format to avoid unnecesary convertions.
 
-For example, suppose a flow in which a JSON document representing a user is posted through HTTP and you want to check if the person is underage.
+For example, suppose a flow in which a JSON document representing a user is posted through HTTP and you want to check if the person is below a specified age limit (underage).
 
 .Mule 3 Example: MEL
 [source,xml,linenums]

--- a/modules/ROOT/pages/migration-core-enricher.adoc
+++ b/modules/ROOT/pages/migration-core-enricher.adoc
@@ -4,9 +4,9 @@ include::_attributes.adoc[]
 endif::[]
 
 // Explain generally how and why things changed between Mule 3 and Mule 4.
-The Message Enricher and its functionality in Mule 3 is replaced by the `target` parameter in Mule 4. The Enricher provided a way to execute a group of message processors and redirect their output to a variable without side effects to the current message. In Mule 4, all non-void operations (for example, `<flow-ref>`, `<http:request>`, `<ftp:write>`, `<db:select>`, and so on) include `target` and `targetValue` parameters, which allow redirecting each operation's output into a variable (such as `myVar`). Other components in a Mule flow can then access that data through a DataWeave selector (for example, `vars.myVar`).
+The Message Enricher in Mule runtime engine (Mule) 3 is replaced by the `target` parameter in Mule 4. The Enricher provided a way to execute a group of message processors and redirect their output to a variable without side effects to the current message. In Mule 4, all non-void operations such as `<flow-ref>`, `<http:request>`, `<ftp:write>`, and `<db:select>` include `target` and `targetValue` parameters, which allow redirecting each operation's output into a variable (such as `myVar`). Other components in a Mule flow can then access that data through a DataWeave selector (for example, `vars.myVar`).
 
-Consider a message coming from an HTTP request, which we want to redirect to a third system, only that adding a `state` query param which is to be extracted using a secondary flow called `stateLookup`. Because you don't want to lose the original payload or headers, you need to extract this value without affecting the original message. The Enricher calls out to the enrichment resource with the current message (containing the zip code), then enriches the current message with the result.
+Consider a message coming from an HTTP request, which we want to redirect to a third system, adding a `state` query parameter which is to be extracted using a secondary flow called `stateLookup`. Because you don't want to lose the original payload or headers, you need to extract this value without affecting the original message. The Enricher calls out to the enrichment resource with the current message (containing the zip code), then enriches the current message with the result.
 
 .Mule 3 example
 ----

--- a/modules/ROOT/pages/migration-core-exception-strategies.adoc
+++ b/modules/ROOT/pages/migration-core-exception-strategies.adoc
@@ -5,10 +5,10 @@ endif::[]
 
 // sme: afelisatti, author: fer?
 
-The following examples will guide you through the migration of the different exception
-strategies of Mule 3 considering the new error handling components in Mule 4.
+The following examples guide you through the migration of different exception
+strategies from Mule runtime engine (Mule) 3 to the new error handling components in Mule 4.
 
-IMPORTANT: The examples do not cover the migration of expressions used within the `when` attribute.
+IMPORTANT: The examples do not cover the migration of expressions used within the `<when>` attribute.
 See xref:migration-mel.adoc[Migrating MEL to DataWeave] for guidance with migrating expressions,
 and see xref:connectors::java/java-throwable.adoc[Working With Throwables] to use the Java module
 to analyze exceptions.
@@ -17,8 +17,8 @@ to analyze exceptions.
 
 //TODO: CLEAN UP, ELABORATE
 
-A Catch Exception Strategy is equivalent to an Error Handler with a single `on-error-continue`
-component that accepts all errors, which is the default configuration:
+A Mule 3 `<catch-exception-strategy>` is equivalent to a Mule 4 `<error-handler>` with a single `<on-error-continue>`
+attribute that accepts all errors, which is the default configuration:
 
 .Mule 3 Example
 [source,xml,linenums]
@@ -78,7 +78,7 @@ which is the default configuration:
 
 //TODO: CLEAN UP, ELABORATE
 
-* `idempotent-redelivery-policy` gets renamed to `redelivery-policy`
+* `idempotent-redelivery-policy` is renamed to `redelivery-policy`.
 * `org.mule.runtime.core.api.exception.MessageRedeliveredException` has been replaced by the `REDELIVERY_EXHAUSTED` error type.
 * `dead-letter-queue` is removed. Any outbound operation performed to publish to a DLQ must be done as part of the handling of the `REDELIVERY_EXHAUSTED` error, for example:
 +
@@ -112,8 +112,7 @@ which is the default configuration:
 == Choice Exception Strategy
 
 A Choice exception strategy with inner catch/rollback exception strategies is
-equivalent to an error handler with on-error components continue/propagate according
-to the exception strategy kind, as explained above:
+equivalent to an error handler with on-error attributes continue and propagate:
 
 //TODO: CLEAN UP, ELABORATE
 
@@ -147,8 +146,8 @@ to the exception strategy kind, as explained above:
 
 == Reference Exception Strategy
 
-Considering that the referenced exception strategy has already been migrated according
-to the above guidelines, migrating the actual reference is just adding a reference `error-handler`.
+Since the referenced exception strategy has already been migrated according
+to the guidelines already presented, migrating the actual reference merely requires adding a reference `error-handler`.
 
 //TODO: CLEAN UP, ELABORATE
 

--- a/modules/ROOT/pages/migration-core-foreach.adoc
+++ b/modules/ROOT/pages/migration-core-foreach.adoc
@@ -3,9 +3,9 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 
-Little changed between For Each scope for Mule 3 and Mule 4 except for the use of DataWeave 2 as the expression language. This little change however has a huge impact in terms of usability of the component.
+The For Each scope didn't change much from Mule runtime engine (Mule) 3 to Mule 4, except for the use of DataWeave 2 as the expression language. This one change has a large impact in terms of usability of the component.
 
-In Mule 3, foreach required the input collection to be a Java Iterable, Java Iterator or Java array. You were always forced to make sure that the input was in Java format (and therefore, you were forced to know java).
+In Mule 3, `foreach` required the input collection to be a Java iterable, Java iterator or Java array. You were always forced to make sure that the input was in Java format (and therefore, you were forced to know Java).
 
 In Mule 4, we support iterating over any array-like structure, regardless of the format. For example, suppose the following JSON is posted through an HTTP request:
 
@@ -25,7 +25,7 @@ In Mule 4, we support iterating over any array-like structure, regardless of the
 }
 ----
 
-Mule 3 requires the json being transformed to Java first:
+Mule 3 requires JSON be transformed to Java:
 
 .Mule 3 example
 [source,xml,linenums]
@@ -39,7 +39,7 @@ Mule 3 requires the json being transformed to Java first:
 </flow>
 ----
 
-In Mule 4, you can just access the persons array in Json format directly:
+In Mule 4, you can access the persons array in JSON format directly:
 
 .Mule 4 example
 [source,xml,linenums]

--- a/modules/ROOT/pages/migration-core-poll.adoc
+++ b/modules/ROOT/pages/migration-core-poll.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 
-In Mule 3, the `<poll>` element was used to trigger a certain flow at a fixed frequency of time. This element was also a scope which required one (and only one) message processor to live inside of it. The output of that processor would be the message that the flow receives.
+In Mule runtime engine (Mule) 3, the `<poll>` element was used to trigger a certain flow at a fixed frequency of time. This element was also a scope which required one (and only one) message processor to live inside of it. The output of that processor is the message that the flow receives.
 
 .Mule 3 Example: Poll
 [source,xml,linenums]
@@ -19,10 +19,10 @@ In Mule 3, the `<poll>` element was used to trigger a certain flow at a fixed fr
 </flow>
 ----
 
-In Mule 4, the `<poll>` element was replaced with the `<scheduler>` element. Main differences are:
+In Mule 4, the `<poll>` element was replaced with the `<scheduler>` element. The main differences are:
 
-* It just triggers the flow. It's no longer a scope
-* It supports both fixed frequency and cron expressions
+* `<poll>` triggers the flow. It's no longer a scope.
+* `<poll>` supports both fixed frequency and cron expressions.
 
 .Mule 4 Example: Scheduler
 [source,xml,linenums]
@@ -42,17 +42,16 @@ In Mule 4, the `<poll>` element was replaced with the `<scheduler>` element. Mai
 </flow>
 ----
 
-For more information on the `<scheduler>` element, please read the xref:scheduler-concept.adoc[Scheduler documentation].
+For more information about the `<scheduler>` element, see the xref:scheduler-concept.adoc[Scheduler documentation].
 
 == Migrating a Watermark
 
-The `<poll>` element also supported a `<watermark>` element which was used to aid and scheduled synchronizations. That element doesn't exist anymore. Instead, please read
-the xref:migration-patterns-watermark.adoc[Migrating Watermarks] page.
+The `<poll>` element supported a `<watermark>` element which was used to aid and scheduled synchronizations. That element doesn't exist anymore. To migrate, see xref:migration-patterns-watermark.adoc[Migrating Watermarks.
 
 [[qz]]
 == Quartz Transport
 
-In Mule 3, a `quartz` transport existed that was deprecated in favor of the `poll`, so most of its uses may also be replaced by the `scheduler` in Mule 4.
+In Mule 3, a `quartz` transport existed that was deprecated in favor of the `poll`, so most of its uses have been replaced by the `scheduler` in Mule 4.
 
 Some features of the `quartz` transport do not exist in Mule 4, so a different approach is necessary to migrate those use cases.
 
@@ -61,7 +60,7 @@ Some features of the `quartz` transport do not exist in Mule 4, so a different a
 
 `repeatCount` is not supported in Mule 4 by the `scheduler`.
 
-If you really need to fetch it, compare and store a counter in an xref:connectors::object-store/object-store-connector.adoc[Object Store].
+If you need to fetch it, compare and store a counter in an xref:connectors::object-store/object-store-connector.adoc[object store].
 
 [[qz_outbound_endpoint]]
 === quartz:outbound-endpoint

--- a/modules/ROOT/pages/migration-core-scatter-gather.adoc
+++ b/modules/ROOT/pages/migration-core-scatter-gather.adoc
@@ -5,7 +5,7 @@ endif::[]
 
 // sme: PLG, author: rodro
 
-The most important change in Scatter-Gather router between Mule 3 and Mule 4 
+The most important change in the Scatter-Gather router between Mule runtime engine (Mule) 3 and Mule 4 
 is in the `AggregationStrategy` used to consolidate the results of the 
 different routes. Instead of providing a Java class with the aggregation 
 logic, you can perform the aggregation with a DataWeave transformation.

--- a/modules/ROOT/pages/migration-core-splitter-aggregator.adoc
+++ b/modules/ROOT/pages/migration-core-splitter-aggregator.adoc
@@ -5,7 +5,7 @@ endif::[]
 
 // Contacts/SMEs: LRM
 
-Splitters are not longer available in Mule 4. To process a collection of elements sequentially, use the xref:for-each-scope-concept.adoc[For Each component].
+Splitters are not available in Mule runtime engine (Mule) 4. To process a collection of elements sequentially, use the xref:for-each-scope-concept.adoc[For Each component].
 
 xref:connectors::aggregator/aggregators-module.adoc[Aggregators] remain in Mule 4 but as a separate module with very different behavior.
 
@@ -46,7 +46,7 @@ It does not matter if a Mule 3 aggregator is present. To store the results of th
 
 === Simple Migration
 
-The default format of the migration should be:
+The default format of a migration:
 
 .Mule 3 Example
 [source,xml,linenums]
@@ -87,7 +87,7 @@ The default format of the migration should be:
 
 In the example:
 
-* A variable `collection-splitter0-group-size` should be created to store the size of the collection. This is needed because inside the `foreach` scope, the payload will correspond to the element from the collection being processed.
+* A variable `collection-splitter0-group-size` is created to store the size of the collection. This is needed because inside the `foreach` scope, the payload corresponds to the element from the collection being processed.
 * Every component between the `collection-splitter` and `collection-aggregator` is wrapped inside a `foreach` scope.
 * A `group-based-aggregator` is added at the end of the `foreach` scope to store all the results. The size of the aggregation expected will correspond to the value stored in the `collection-splitter0-group-size` variable. `set-variable` is added inside the `aggregation-complete` to store the result of the aggregation once it is complete.
 * Since the payload after the `foreach` element will be the same as the input received, `set-payload` should be used to set it as the stored value in the variable defined insider the `aggregation-complete` route.
@@ -100,7 +100,7 @@ In some cases, the Mule 3 configuration with splitters and aggregators might set
 Mule 3 aggregators allowed for 2 attributes to be configured: `timeout` and `failOnTimeout`. If the `timeout` attribute is present (with a value greater than 0), the migration should be as follows in the examples.
 
 [IMPORTANT]
-Even when there is a way of adding extra logic when there is a timed-out aggregation and `failOnTimeout` is set to `true`, the behavior will not be the same as in Mule 3. Aggregators in Mule 4 do not raise any errors or dispatch any notifications where there is a timed-out aggregation.
+Even when there is a way of adding extra logic when there is a timed-out aggregation and `failOnTimeout` is set to `true`, the behavior is not the same as in Mule 3. Aggregators in Mule 4 do not raise any errors or dispatch any notifications when there is a timed-out aggregation.
 
 
 .Mule 3 Example
@@ -177,9 +177,9 @@ Another flow should be created and an `aggregator:aggregator-listener` should be
 
 All splitters allowed for the configuration of the `enableCorrelation` attribute.
 
-There is no way to migrate an `enableCorrelation="NEVER"` configuration. A correlation ID will always be set to the events processed from the collection by the `foreach` element.
+There is no way to migrate an `enableCorrelation="NEVER"` configuration. A correlation ID is always set to the events processed from the collection by the `foreach` element.
 
-Expression splitters (`<splitter/>`) allowed for the configuration of two attributes: `evaluator` and `custom-evaluator`. Expression evaluators can't be configured anymore; only DataWeave can be used.
+Expression splitters (`<splitter/>`) allowed for the configuration of two attributes: `evaluator` and `custom-evaluator`. Expression evaluators can't be configured in Mule 4; only DataWeave can be used.
 
 === Available Splitters Migration
 
@@ -193,25 +193,25 @@ Mule 3 had the following splitters, some of which require some extra logic to be
 * `map-splitter` : The DataWeave expression `#[dw::core::Objects::entrySet(payload)]` should be used as the `collection` attribute in the `foreach` element.
 ** Mule 3: `<map-splitter/>`
 ** Mule 4: `<foreach collection="#[dw::core::Objects::entrySet(payload)]">`
-* `message-chunk-splitter`: There is no similar behavior in Mule 4. It cannot be migrated.
+* `message-chunk-splitter`: There is no similar behavior in Mule 4, so it can't be migrated.
 
 === Aggregators
 
 Most parameters allowed by Mule 3 aggregators are not allowed in Mule 4:
 
-* `timeout`: Though the timeout parameter can be set in any new aggregator, there are some differences. First, `timeoutUnit` should also be set to specify the unit of time. Also, the behavior of aggregation timeouts is very different in a Mule 4 aggregator. This is explained in xref:connectors::aggregator/aggregators-module-reference.adoc[Aggregators Module Reference].
-* `failOnTimeout`: No longer available. However similar behavior can be achieved, as explained in the <<complex_migration>>.
-* `processed-groups-object-store-ref`: Processed groups are no longer stored in a separate object store. This paremeter is not allowed anymore.
-* `event-groups-object-store-ref`: You can set this object store using the `objectStore` attribute in Mule 4 aggregators.
-* `persistentStores`: Not allowed anymore. If a persistent object store is needed, the `objectStore` attribute should be the name of a persistent object store.
-* `storePrefix`: Not allowed anymore.
+* `timeout` can be set in any new aggregator, however there are some differences. First, `timeoutUnit` should also be set to specify the unit of time. Also, the behavior of aggregation timeouts is very different in a Mule 4 aggregator. This is explained in xref:connectors::aggregator/aggregators-module-reference.adoc[Aggregators Module Reference].
+* `failOnTimeout`: is not available in Mule 4. However, similar behavior can be achieved as explained in <<complex_migration>>.
+* `processed-groups-object-store-ref` isn't stored in a separate object store in Mule 4, so this parameter isn't allowed in Mule 4.
+* `event-groups-object-store-ref`can be set using the `objectStore` attribute in Mule 4 aggregators.
+* `persistentStores` isn't allowed in Mule 4. If a persistent object store is needed, the `objectStore` attribute should be the name of a persistent object store.
+* `storePrefix` isn't allowed in Mule 4.
 
 
 === Available Aggregators Migration
 
-* `collection-aggregator`: Should be migrated as defined in the main example.
-* `custom-aggregator`: Cannot be migrated. There is no way in Mule 4 to add custom implementations for an interface.
-* `message-chunk-aggregator`: There is no similar behavior in Mule 4. It cannot be migrated.
+* `collection-aggregator` should be migrated as defined in the main example.
+* `custom-aggregator` can't be migrated. You can't add custom implementations for an interface in Mule 4.
+* `message-chunk-aggregator` can't be migrated to Mule 4 because there is no similar behavior.
 
 == See Also
 

--- a/modules/ROOT/pages/migration-core-until-successful.adoc
+++ b/modules/ROOT/pages/migration-core-until-successful.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 
-The Until Successful component for Mule 4 handles some processes differently
+The Until Successful component for Mule runtime engine (Mule) 4 handles some processes differently
 than the Mule 3 version. Some elements and attributes associated with these
 changes are no longer present in Mule 4. In Mule 4, you can either achieve the
 same functionality through different attributes or components, or you no longer
@@ -12,14 +12,14 @@ need to configure the functionality in Mule 4.
 A manual migration of the Until Successful component involves these
 modifications:
 
-* Removal of any `<processor-chain/>` elements.
-* Replacement of the `secondsBetweenRetries` attribute with `millisBetweenRetries`.
+* Removal of any `<processor-chain/>` elements
+* Replacement of the `secondsBetweenRetries` attribute with `millisBetweenRetries`
 * Removal of the `failureExpression` and use of a Validation processor for Mule 4,
-instead.
-* Replacement of the `deadLetterQueue-ref` attribute with an Error Handler for Mule 4.
-* Removal of any `<threading-profile/>` elements.
-* Removal of the `ackExpression` attribute and use of a Set Payload component, instead.
-* Removal of any `synchronous` attributes.
+instead
+* Replacement of the `deadLetterQueue-ref` attribute with an Error Handler for Mule 4
+* Removal of any `<threading-profile/>` elements
+* Removal of the `ackExpression` attribute and use of a Set Payload component, instead
+* Removal of any `synchronous` attributes
 
 These changes are detailed in the next sections.
 
@@ -154,7 +154,7 @@ Mule 4:
 </flow>
 ----
 
-== Threading Profile Removed, Not Needed in Mule 4
+== Threading Profile Removed
 
 In Mule 3, you can tune execution threads using the `<threading-profile/>`
 child element. Mule 4 introduces several changes to the execution engine.
@@ -184,7 +184,7 @@ The Mule 4 example removes the `<threading-profile/>` element.
 </flow>
 ----
 
-== ackExpression Attribute Removed, Use Set Payload
+== ackExpression Attribute Removed
 
 The Mule 3 `ackExpression` attribute configures synchronous production of a response payload. This attribute no longer exists in Mule 4. To achieve this behavior in your app, you can configure a Set Payload component after Until Successful.
 

--- a/modules/ROOT/pages/migration-core.adoc
+++ b/modules/ROOT/pages/migration-core.adoc
@@ -6,7 +6,7 @@ endif::[]
 // sme: Dan, writer: Mariano Gonzalez
 :keywords: studio, server, components, connectors, elements, palette, global elements, configuration elements
 
-The table below maps Mule 3.x components to their Mule 4 equivalents.
+The table below maps Mule runtime engine (Mule) 3.x components to their Mule 4 equivalents.
 
 [%header,cols="30,70"]
 |===
@@ -17,13 +17,13 @@ The table below maps Mule 3.x components to their Mule 4 equivalents.
 | bridge | Build an equivalent flow
 | catch-exception-strategy | Use xref:on-error-scope-concept.adoc[error-handler] with an `on-error-continue` strategy.
 | choice-exception-strategy| Use xref:on-error-scope-concept.adoc[error-handler] with different strategies inside using error type selection or when attribute.
-| combine-collections-transformer | No longer needed with the simplified message model. MuleMessageCollections are replaced with arrays of Mule Messages, which can be merged or iterated through using any Mule component, such as DataWeave or foreach.
+| combine-collections-transformer | No longer needed with the simplified message model. MuleMessageCollections are replaced with arrays of Mule messages, which can be merged or iterated through using any Mule component, such as DataWeave or foreach.
 | component | Use the xref:connectors::java/java-module.adoc[Java module].
 | composite-source | Create one flow per each source and invoke a private flow using flow-ref for the common functionality.
 | configuration[‘defaultExceptionStrategy-ref’] | New name is `defaultErrorHandler-ref`
 | configuration[‘flowEndingWithOneWayEndpointReturnsNull’] | No longer needed with new execution engine.
-| configuration[‘useExtendedTransformations’] | Removed.
-| configuration[enricherPropagatesSessionVariableChanges] | Removed.
+| configuration[‘useExtendedTransformations’] |  This component was removed.
+| configuration[enricherPropagatesSessionVariableChanges] |  This component was removed.
 | copy-attachments | Per the new xref:about-mule-message.adoc[Message Structure], attachments will now be part of the message Attributes. You can manipulate them at will using DataWeave
 | copy-properties | Per the new xref:about-mule-message.adoc[Message Structure], properties will now be part of the message Attributes. You can manipulate them at will using DataWeave
 | custom-agent | No longer supported.
@@ -49,22 +49,21 @@ The table below maps Mule 3.x components to their Mule 4 equivalents.
 | exception-strategy | Use xref:on-error-scope-concept.adoc[error-handler].
 | expression-component | Depending on the nature of your expression, you can either use DataWeave (for data access expressions), xref:migration-module-scripting.adoc[Scripting module] or the xref:mule-sdk::index.adoc[Mule SDK] for algorithmic expressions, or the xref:connectors::java/java-module.adoc[Java module] for expressions which simply access Java.
 | file-queue-store | Use the new xref:migration-module-vm.adoc[VM Connector].
-| flow[‘processingStrategy’] | Removed. Non blocking execution engine ensures that users do not need to tune this.
+| flow[‘processingStrategy’] |  This component was removed. Non blocking execution engine ensures that users do not need to tune this.
 | idempotent-message-filter | Replaced by xref:idempotent-message-validator.adoc[idempotent-message-validator].
 | idempotent-redelivery-policy | New name is `redelivery-policy`.
 | idempotent-secure-hash-message-filter | Replaced by xref:idempotent-message-validator.adoc[idempotent-message-validator].
 | in-memory-store | Use xref:migration-connectors-objectstore.adoc[Object Store connector] to create xref:connectors::object-store/object-store-to-define-a-new-os.adoc[custom stores].
 | inbound-endpoint | Use the event sources or triggers defined on each connector or module.
 | include-entry-point | Use the xref:connectors::java/java-module.adoc[Java module].
-| interceptor-stack | Removed. Use custom policies.
-| invoke | Use the xref:connectors::java/java-module.adoc[Java module]
+| interceptor-stack |  This component was removed. Use custom policies.
+| invoke | Use the xref:connectors::java/java-module.adoc[Java module].
 | jndi-transaction-manager | Use the `<bti:transaction-manager/>`.
 | jrun-transaction-manager | Use the `<bti:transaction-manager/>`.
-| legacy-abstract-exception-strategy | Use the new xref:on-error-scope-concept.adoc[error-handler]
+| legacy-abstract-exception-strategy | Use the new xref:on-error-scope-concept.adoc[error-handler].
 | managed-store | Use xref:migration-connectors-objectstore.adoc[Object Store connector] to create xref:connectors::object-store/object-store-to-define-a-new-os.adoc[custom stores].
 | message-properties-transformer | Use Transform component and DataWeave.
-| model | Removed. Use flows instead.
-| mule[‘version’] |
+| model |  This component was removed. Use flows instead.
 | outbound-endpoint | Element moved from the core namespace to the new transports namespace.
 | poll -> watermark | This capability has been built inside event sources from many connectors, like Salesforce, Database, SFTP, File, etc. You can also use the object-store connector to xred:migration-patterns-watermark.adoc[manually set the watermark values].
 | poll | Replaced with xref:migration-core-poll.adoc[scheduler component].
@@ -72,15 +71,15 @@ The table below maps Mule 3.x components to their Mule 4 equivalents.
 | prototype-object | Use Java module or Spring module.
 | queue-profile | Use the xref:migration-module-vm.adoc[VM Connector].
 | queue-store | xref:migration-module-vm.adoc[VM Connector].
-| recipient-list | Removed.
-| reconnect-custom-notifier | Removed.
-| reconnect-custom-strategy | Removed.
-| reconnect-notifier | Removed.
-| remove-attachment | No longer needed per the new xref:about-mule-message.adoc[Message Structure], attachments
-| remove-property | PNo longer needed per the new xref:about-mule-message.adoc[Message Structure], attachments
+| recipient-list |  This component was removed.
+| reconnect-custom-notifier |  This component was removed.
+| reconnect-custom-strategy |  This component was removed.
+| reconnect-notifier |  This component was removed.
+| remove-attachment | No longer needed per the new xref:about-mule-message.adoc[Message Structure] and attachments.
+| remove-property | PNo longer needed per the new xref:about-mule-message.adoc[Message Structure] and attachments.
 | response |No longer needed.
-| request-reply | Mule 4 will not longer support request-reply for all connectors. Connectors that had a “request-reply” behavior will provide a “request-reply” operation built in, such as the JMS `publish-consume` operation.
-| resin-transaction-manager | Removed.
+| request-reply | Mule 4 no longer supports request-reply for all connectors. Connectors that had a “request-reply” behavior will provide a “request-reply” operation built in, such as the JMS `publish-consume` operation.
+| resin-transaction-manager |  This component was removed.
 | rollback-exception-strategy | Use error-handler with an on-error-propagate strategy.
 | scatter-gather[‘threading-profile’] | No longer needed now that Mule 4 is non blocking.
 | seda-model | No more SEDA queues in Mule 4. The execution engine in Mule 4 is non-blocking.
@@ -94,18 +93,18 @@ The table below maps Mule 3.x components to their Mule 4 equivalents.
 | singleton-object | Use Java module or Spring module.
 | spring-object | Use Java module or Spring module.
 | synchronous-processing-strategy | The behavior related to flow components execution is the same as flows in 4.x but it doesn't always execute in the same thread as in 3.x.
-| transactional scope | Replaced with “try” scope.
-| username-password-filter | Removed.
-| validator | Removed.
+| transactional scope | The try scope replaced transactional scope.
+| username-password-filter |  This component was removed.
+| validator |  This component was removed.
 | weblogic-transaction-manager | Use the `<bti:transaction-manager/>`.
 | websphere-transaction-manager | Use the `<bti:transaction-manager/>`.
-| all-strategy | Removed.
+| all-strategy |  This component was removed.
 | entry-point-resolver | Use the xref:connectors::java/java-module.adoc[Java module].
 | filter | Filters are replaced by the xref:migration-filters.adoc[Validation module].
 | interceptor | Interceptors are replaced with custom policies.
-| message-info-mapping | No longer needed
-| point-resolver-set | Use the Use the xref:connectors::java/java-module.adoc[Java module].
-| router | Removed.
-| threading-profile | No longer needed. The Runtime now tunes itself.
-| transformer | Removed. Most explicit transformations are no longer needed. Use DataWeave for the corner cases.
+| message-info-mapping | This component is no longer needed.
+| point-resolver-set | Use the xref:connectors::java/java-module.adoc[Java module].
+| router |  This component was removed.
+| threading-profile | This component is no longer needed. Mule 4 tunes itself.
+| transformer |  This component was removed. Most explicit transformations are no longer needed. Use DataWeave for the corner cases.
 |===

--- a/modules/ROOT/pages/migration-filters.adoc
+++ b/modules/ROOT/pages/migration-filters.adoc
@@ -5,7 +5,7 @@ endif::[]
 
 // Contacts/SMEs: Rodro
 
-Mule 4 does not use `filters` anymore. The functionality provided by filters 
+Mule runtime engine (Mule) 4 does not use filters anymore. The functionality provided by filters 
 in Mule 3 can be achieved by using the xref:connectors::validation/validation-connector.adoc[Validation Module].
 
 == Applying Filters
@@ -59,11 +59,11 @@ send an appropriate response to the client. For instance, the
 </flow>
 ----
 
-In this case, a 400 (Bad Request) code will be returned if the event is filtered.
+In this case, a 400 (Bad Request) code is returned if the event is filtered.
 
-== Migrating Custom or complex Filters
+== Migrating Custom, Complex, or Nested Filters
 
-Most likely, any custom or complex/nested filters you used can be migrated to use the expression language. The DataWeave script can be externalized to a file if the same filter needs to be in several places.
+Most likely, any custom, complex, or nested filters you used can be migrated to use the expression language. The DataWeave script can be externalized to a file if the same filter needs to be in several places.
 
 For cases where you filter data in ways that DataWeave does not support, you should use the Java module or the Scripting module and use custom code to perform the filtering.
 

--- a/modules/ROOT/pages/migration-message-properties.adoc
+++ b/modules/ROOT/pages/migration-message-properties.adoc
@@ -5,13 +5,13 @@ endif::[]
 
 // Contacts/SMEs: Ana Felissati, Pablo La Greca
 
-In Mule 3, there are several property scopes that you can use for different purposes. In Mule 4, most of these scopes have been removed.
+In Mule runtime engine (Mule) 3, there are several property scopes have been removed in Mule 4.
 
 == Invocation Properties
 
 Invocation properties are now called `variables` in Mule 4. Their behavior is exactly the same as in Mule 3.
 
-== Inbound Properties, Outbound Properties, Inbound and Outbound Attachments
+== Inbound Properties, Outbound Properties, and Inbound and Outbound Attachments
 
 These scopes do not exist in Mule 4. See xref:intro-mule-message.adoc[Intro Mule Message] for more information about migration.
 

--- a/modules/ROOT/pages/migration-patterns-reconnection-strategies.adoc
+++ b/modules/ROOT/pages/migration-patterns-reconnection-strategies.adoc
@@ -3,14 +3,14 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 
-From a syntax point of view, reconnection hasn't changed much between Mule 3 and Mule 4. However, there are significant behavior differneces.
+Reconnection syntax hasn't changed much between Mule runtime engine (Mule) 3 and Mule 4. However, there are significant behavior differneces.
 
 In Mule 3, reconnection strategies were specified on each connector's config element. These strategies had two purposes:
 
 * To reconnect when a running application looses connection to an endpoint
-* To validate all connections when the application is being deployed.
+* To validate all connections when the application is being deployed
 
-So, suppose an application which connects to a mysql Database. If that connection cannot be established at deployment time, the deployment will fail. This was to guarantee that all deployed apps are in a functioning state.
+So, suppose an application which connects to a mysql database. If that connection cannot be established at deployment time, the deployment will fail. This was to guarantee that all deployed apps are in a functioning state.
 
 .Mule 3 Examples: Reconnection Settings (for a MySQL database)
 
@@ -38,7 +38,7 @@ To achieve this with Mule 3, you had to use the `blocking="false"` option, so th
 </db:mysql-config>
 ----
 
-In Mule 4 you can simply specify if deployment should fail or not if connectivity testing fails:
+In Mule 4 you can simply specify if deployment should fail or not if connectivity testing fails.
 
 .Mule 4 Examples: Reconnection Settings (for a SQL database)
 [source,xml,linenums]
@@ -58,13 +58,13 @@ In Mule 4 you can simply specify if deployment should fail or not if connectivit
 </db:mssql-connection>
 ----
 
-By default, a failure to establish connection will only generate a warning in the logs.
+By default, a failure to establish connection only generates a warning in the logs.
 
-== Operation level reconnection strategy
+== Operation-Level Reconnection Strategy
 
-In Mule 3, the same reconnection strategy at the config element was used both at deployment time and at runtime. For example, if connectivity to the Database is lost which executing a flow, the same reconnection strategy will be used.
+In Mule 3, the same reconnection strategy at the config element was used both at deployment time and at runtime. For example, if connectivity to the database is lost while executing a flow, the same reconnection strategy is used.
 
-In Mule 4 this behavior is kept by default, but you also get the chance to specify a different strategy at the operation or Message Source level:
+In Mule 4 this behavior is kept by default, but you also get the chance to specify a different strategy at the operation or message source level:
 
 .Mule 4 Examples: Reconnection Settings (for a SQL database)
 [source,xml,linenums]

--- a/modules/ROOT/pages/migration-patterns-watermark.adoc
+++ b/modules/ROOT/pages/migration-patterns-watermark.adoc
@@ -8,10 +8,7 @@ Watermarking is typically used to perform data synchronization, for example, whe
 
 For the Mule 3 approach, see this MuleSoft blog: https://blogs.mulesoft.com/dev/anypoint-platform-dev/data-synchronizing-made-easy-with-mule-watermarks/[Data Synchronizing made easy with Watermarks].
 
-
-Here's the Mule 3 watermark example from that blog:
-
-.Mule 3 Example: Polling Salesforce contacts using watermark
+.Mule 3 Example from Blog: Polling Salesforce contacts using watermark
 [source,xml,linenums]
 ----
 <flow name="syncWithWatermark" processingStrategy="synchronous">
@@ -26,7 +23,6 @@ Here's the Mule 3 watermark example from that blog:
   <flow-ref name="doYourSyncMagic" />
 </flow>
 ----
-
 
 As the Anypoint Platform grew and our use cases became more complicated, limitations started to appear in the Mule 3 approach:
 
@@ -81,7 +77,7 @@ Let’s break the example down step by step:
 
 == Automatic Watermark
 
-The above is great and more powerful than what we had in Mule 3, but we wanted to make it even simpler. That's why some connectors already include message sources capable of doing watermarking automatically, without the need for you to take any of the steps above. At the moment of writing this document, the File, Ftp, Sftp, Database and Salesforce connectors have this capability, but we will continue to add support for this in other connectors.
+Manual watermarking is more powerful in Mule 4 than Mule 3, but MuleSoft made it even simpler. Some connectors already include message sources capable of doing watermarking automatically, without the need for you to take any of the steps above. The File, FTP, SFTP, Database, and Salesforce connectors have this capability now. MuleSoft continues to add support for automatic watermarking in more connectors.
 
 Let's use the file connector to see an example of how this works:
 
@@ -102,10 +98,10 @@ In this example, we get automatic watermarking using the file's creation time as
 
 We only recommend to take "the long way" described in the first example when:
 
-* Your use case is very custom
-* You are using a connector which doesn't support automatic watermarking.
+* Your use case is has custom requirements not met in any other way.
+* You use a connector which doesn't support automatic watermarking.
 
-In any other case, we recommend automatic watermarking as the best way of dealing with these use cases.
+In any other case, we recommend automatic watermarking.
 
 == See Also
 

--- a/modules/ROOT/pages/migration-prep.adoc
+++ b/modules/ROOT/pages/migration-prep.adoc
@@ -5,7 +5,7 @@ endif::[]
 
 // Contacts/SMEs: Esteban Wasinger, Ana Felisatti, Mariano Gonzalez
 
-Mule 4 introduces many changes, so plan accordingly before attempting to migrate from Mule 3.
+Mule runtime engine (Mule) 4 introduces many changes, so plan accordingly before attempting to migrate from Mule 3.
 
 [[when_to_start]]
 == When to Start Using Mule 4
@@ -13,22 +13,22 @@ Mule 4 introduces many changes, so plan accordingly before attempting to migrate
 We recommend that you develop all *new* projects on Mule 4, provided that:
 
 * You and your team have updated your skills for Mule 4 via the documentation or formal training.
-* You have the proper deployment environment (see below).
-* You do not require all applications to be on a single version of Mule (see below).
+* You have prepared your <<prepare_to_deploy,deployment environment>>.
+* You do not require all applications to be on a single version of Mule.
 
 For projects which are already in development or deployed on Mule 3 (whether a prospect or customer), we recommend you wait to migrate these applications until the Mule 3 to Mule 4 migration tool is available. However, you can follow this guide to migrate manually.
 
 Migrate your applications if any one of the following conditions is met:
 
-* The 3.x version you're using reaches end of life
-* You want to make significant updates to the existing applications
-* You want to take advantage of key Mule 4 capabilities
-* You decide to upgrade all their apps to Mule 4 because you require all apps to be on one version (some onprem customers)
+* The 3.x version you're using reaches its end of life.
+* You want to make significant updates to the existing applications.
+* You want to take advantage of key Mule 4 capabilities.
+* You decide to upgrade all apps to Mule 4 because you require all apps to be on one version, which is a requirement for some on-premises customers.
 
 [[prepare_dev_environ]]
 == Setting up Your Local Development Environment
 
-First, you will need to download Studio 7 and install it. If you're deploying locally, you will also need to download the Mule 4 standalone runtime.
+First, download Studio 7 and install it. If you're deploying locally, you will also need to download the Mule 4 standalone runtime.
 // TODO link to pages
 
 [[prepare_to_deploy]]

--- a/modules/ROOT/pages/migration-process.adoc
+++ b/modules/ROOT/pages/migration-process.adoc
@@ -8,22 +8,22 @@ endif::[]
 //TODO: LINK TO MULE 4 SECTIONS FOR ALL THESE STEPS.
 After learning how to prepare for the migration, it is important to understand the high-level migration steps:
 
-. Add all required modules, such as the Database connector, to the Anypoint Studio 7 palette.
+. Add all required modules, such as the Database connector, to the Anypoint Studio (Studio) 7 palette.
 +
 Notes:
 +
 * You can add modules through the Studio 7 palette. Other modules are available in Anypoint Exchange.
 +
-* All Mule projects are Mavenized by default when you add the modules to your project.
+* All Mule projects are mavenized by default when you add the modules to your project.
 +
 . Migrate all the global configurations.
 . Migrate configuration properties.
 +
 // .yaml or .properties. Include link to properties config in Mule 4.
 +
-. Learn how the components work in Mule 4 to see what has changed from Mule 3.
+. Learn how the components work in Mule runtime engine (Mule) 4 to see what has changed from Mule 3.
 . Understand how changes to the Mule message structure (attributes, payload, and variables) affect your configurations. See xref:intro-mule-message.adoc[Introduction to Mule 4: The Mule Message].
-. Update your expressions and scripts to DataWeave version 2:
+. Update your expressions and scripts to DataWeave 2:
 ** Be aware of changes between DataWeave 1 and DataWeave 2, for example, importing specific function modules and understanding syntax changes. See xref:migration-dataweave.adoc[Migrating from DataWeave 1.0 to 2.x].
 +
 // TODO: ASK ABOUT MIGRATION TOOL, TASK TO MIGRATE SCRIPTS FROM 1.0 TO 2.

--- a/modules/ROOT/pages/migration-secure-properties-placeholder.adoc
+++ b/modules/ROOT/pages/migration-secure-properties-placeholder.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 
-In Mule 3, the Secure Properties Placeholder was part of the Security Module. In Mule 4, it is separated in its own Secure Configuration Properties module.
+In Mule runtime engine (Mule) 3, the Secure Properties Placeholder was part of the Security Module. In Mule 4, it is separated in its own Secure Configuration Properties module.
 
 .Example: Complete Secure Properties Placeholder in Mule 3
 [source,xml,linenums]

--- a/modules/ROOT/pages/migration-security-filters.adoc
+++ b/modules/ROOT/pages/migration-security-filters.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 
-In Mule runtime engine (Mule) 3, the Security Filters are part of the Mule Module Security. In Mule 4, security filters are in the xref:connectors::validation/validation-connector.adoc[Mule Validation Module].
+In Mule runtime engine (Mule) 3, the security filters are part of Mule module security. In Mule 4, security filters are in the xref:connectors::validation/validation-connector.adoc[Mule Validation Module].
 
 == IP filters
 
@@ -37,7 +37,7 @@ Where is necessary to set that `ip` variable (or whichever variable suits).
 
 === Filtering by a Range of IPs
 
-In mule 3, we had two ways of defining subnet mask to filter with:
+In Mule 3, we had two ways of defining subnet mask to filter with:
 
 .Example: Filtering by IP range in Mule 3
 [source,xml,linenums]
@@ -66,7 +66,7 @@ Mule 4 also offers whitelist validation, which only allows IPs from an IP filter
 
 == Time Expiration Filters
 
-In Mule 3 you can filter the message if it older than a specifed time from a starting date. For example:
+In Mule 3 you can filter the message if it's older than a specifed time from a starting date. For example:
 
 .Example: Filtering by elapsed time in Mule 3
 [source,xml,linenums]

--- a/modules/ROOT/pages/migration-security-filters.adoc
+++ b/modules/ROOT/pages/migration-security-filters.adoc
@@ -3,16 +3,16 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 
-In Mule 3, the Security Filters where part of the Mule Module Security. In Mule 4, this where migrated to the xref:connectors::validation/validation-connector.adoc[Mule Validation Module].
+In Mule runtime engine (Mule) 3, the Security Filters are part of the Mule Module Security. In Mule 4, security filters are in the xref:connectors::validation/validation-connector.adoc[Mule Validation Module].
 
 == IP filters
 
-In mule 3 we had three different options to filter by IP:
+In Mule 3 you can filter by IP, IP range, or IP range pulus CIDR:
 * `<filters:filter-by-ip>`
 * `<filters:filter-by-ip-range>`
 * `<filters:filter-by-ip-range-cidr>`
 
-=== Filtering By one IP
+=== Filtering By One IP in Mule 3
 
 .Example: Filtering by one IP in Mule 3
 [source,xml,linenums]
@@ -22,7 +22,7 @@ In mule 3 we had three different options to filter by IP:
 
 This will filter those IPs that matches the regex. In mule4:
 
-.Example: Filtering by one IP in Mule 4
+.Example: Filtering by One IP in Mule 4
 [source,xml,linenums]
 ----
 <validation:is-blacklisted-ip blacklist="iplist" ip="#[vars.ip]">
@@ -35,7 +35,7 @@ This will filter those IPs that matches the regex. In mule4:
 
 Where is necessary to set that `ip` variable (or whichever variable suits).
 
-=== Filtering by range of IPs
+=== Filtering by a Range of IPs
 
 In mule 3, we had two ways of defining subnet mask to filter with:
 
@@ -60,14 +60,13 @@ Both are replaced by:
 </validation:ip-filter-list>
 ----
 
-Where is necessary to set that `ip` variable (or whichever variable suits).
+Set the `ip` variable.
 
-[qanda]
-Are there other similar validations added in mule 4? :: Yes, there is also a WhiteList validation, which only allows IPs from a IP Filter List.
+Mule 4 also offers whitelist validation, which only allows IPs from an IP filter list.
 
 == Time Expiration Filters
 
-In mule 3 we could filter the message if it had elapsed some defined time from a starting date. For example:
+In Mule 3 you can filter the message if it older than a specifed time from a starting date. For example:
 
 .Example: Filtering by elapsed time in Mule 3
 [source,xml,linenums]
@@ -83,8 +82,7 @@ In Mule 4, this validation is in the validations module:
 <validation:is-not-elapsed time="1" timeUnit="SECONDS" since="#[vars.startingTime]"/>
 ----
 
-[qanda]
-Are there other similar validations added in mule 4? :: Yes, there is also a Time Elapsed validation, which validates if the time elapsed has exceded a certain amount of time.
+Mule 4 also offers a time-elapsed validation, which validates whether the time elapsed has exceded a specified amount of time.
 
 == See Also
 xref:connectors::validation/validation-documentation.adoc[Validation Connector Technical Reference]

--- a/modules/ROOT/pages/migration-transformers.adoc
+++ b/modules/ROOT/pages/migration-transformers.adoc
@@ -5,7 +5,7 @@ endif::[]
 
 // Contacts/SMEs: Ana Felissati, Pablo La Greca
 
-Mule 4 does not require `transformers` anymore. Now that DataWeave is the default expression language and the repeatable streams feature is supported, most (if not all) scenarios that required a transformer no longer exist.
+Mule runtime engine (Mule) 4 doesn't require `transformers`. DataWeave is the default expression language and the repeatable streams feature is supported, so scenarios that require a transformer no longer exist.
 
 == Migrating Type Transformers
 

--- a/modules/ROOT/pages/migration-transports.adoc
+++ b/modules/ROOT/pages/migration-transports.adoc
@@ -3,14 +3,11 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 
-Mule 3 transports have been replaced by connectors, which follow an
-operation model in Mule 4. Most Mule transports are replaceable by a
-corresponding connector in Mule 4.
+Mule runtime engine (Mule) 3 transports have been replaced by connectors, which follow an
+operation model in Mule 4. Most Mule transports are replaceable by a corresponding connector in Mule 4.
 
-Some migration issues are common to all transports. For transport-specific
-migration documentation, refer to
-xref:migration-connectors.adoc[Migrating Connectors and Modules to Mule 4] and
-its child pages, instead.
+The migration issues explained here are common to all transports. For transport-specific
+migration documentation, see xref:migration-connectors.adoc[Migrating Connectors and Modules to Mule 4].
 
 [[address]]
 == Endpoint Addresses
@@ -63,7 +60,7 @@ provides detail on the exact properties that the connector requires.
 == Service Overrides
 
 In Mule 4, service override customizations through custom Java code are not
-supported in Mule 4.
+supported.
 
 In Mule 3, it is possible to customize the behavior of a transport through a
 connector's `service-overrides` element. This element provides a way to


### PR DESCRIPTION
Translation scrubbing for Japanese:

-- Product name consistency
-- Removing unneeded "will"
-- Fix capitalization errors in titles and where it might confuse Loc team.