### PR TITLE
Clarified how reduce works and changed val to elt

### DIFF
--- a/modules/ROOT/pages/dw-core-functions-reduce.adoc
+++ b/modules/ROOT/pages/dw-core-functions-reduce.adoc
@@ -6,12 +6,11 @@ endif::[]
 
 
 [[reduce1]]
-== reduce&#40;Array<T&#62;, &#40;item: T, accumulator: T&#41; &#45;&#62; T&#41;: T &#124; Null
+== reduce&#40;Array<T&#62;, &#40;element: T, accumulator: T&#41; &#45;&#62; T&#41;: T &#124; Null
 
-Applies the reduction function for each element in the input array.
+For each element of the input array, in order, applies the reduction lambda expression (function) then replaces the accumulator with the new result. The lambda expression can use both the current input array element and the current accumulator value. 
 
-
-Note that if the array is empty and no default value is set on the
+Note: If the array is empty and no default value is set on the
 accumulator, a null value is returned.
 
 === Parameters
@@ -19,8 +18,15 @@ accumulator, a null value is returned.
 [%header, cols="1,3"]
 |===
 | Name   | Description
-| `item` | Item in the given list. It provides the value to reduce. Can also be referenced as `&#36;`.
-| `acc` | An accumulator (also referenced as `&#36;&#36;`) to apply to items in the input array. It starts with the first value of the array by default.
+| `element` | The current element from the array. Can also be referenced as `&#36;`. If this parameter is not named in the lambda expression.
+| `acc` | The accumulator. Can also be referenced as `&#36;&#36;`. Used to store the result of the lambda expression after each iteration of the reduce operation. 
+
+The accumulator parameter can be set to an intial value using the syntax `acc = initValue`. In this case the lambda expression is called with the first element of the input array, then the result is set as the new accumulator value. 
+
+If an initial value for the accumulator is not set, the accumulator is set to the first element of the input array, and then the lamba expression is called with the second element of the input array.
+
+The inital value of the accumulator and the lambda expression dictate the type of result produced by the reduce function. If the accumulator is set to `acc = {}`, then usually the result will be of type Object. If the accumulator is set to `acc = []`, then usually the result will be of type Array. If the accumulator is set to `acc = ""`, then the result will usually be a String. 
+
 |===
 
 === Example
@@ -36,7 +42,7 @@ output application/json
 ---
  {
     "sum" : [0, 1, 2, 3, 4, 5] reduce ($$ + $),
-    "sum" : [0, 1, 2, 3, 4, 5] reduce ((val, acc) -> acc + val)
+    "sum" : [0, 1, 2, 3, 4, 5] reduce ((elt, acc) -> acc + elt)
  }
 ----
 
@@ -64,7 +70,7 @@ output application/json
 ---
 {
    "concat" : ["a", "b", "c", "d"] reduce ($$ ++ $),
-   "concat" : ["a", "b", "c", "d"] reduce ((val, acc) -> acc ++ val)
+   "concat" : ["a", "b", "c", "d"] reduce ((elt, acc) -> acc ++ elt)
 }
 ----
 
@@ -90,8 +96,8 @@ This example sets the first elements of the arrays to `"z"` and `3`.
 output application/json
 ---
 {
-   "concat" : ["a", "b", "c", "d"] reduce ((item, acc = "z") -> acc ++ item),
-   "sum": [0, 1, 2, 3, 4, 5] reduce ((val, acc = 3) -> acc + val)
+   "concat" : ["a", "b", "c", "d"] reduce ((elt, acc = "z") -> acc ++ elt),
+   "sum": [0, 1, 2, 3, 4, 5] reduce ((elt, acc = 3) -> acc + elt)
 }
 ----
 
@@ -127,29 +133,29 @@ var in0 =
 {
   "a" : [0, 1, 2, 3, 4, 5] reduce $$,
   "b": ["a", "b", "c", "d", "e"] reduce $$,
-  "c": [{ "letter": "a" }, { "letter": "b" }, { "letter": "c" }] reduce ((val, acc = "z") -> acc ++ val.letter),
+  "c": [{ "letter": "a" }, { "letter": "b" }, { "letter": "c" }] reduce ((elt, acc = "z") -> acc ++ elt.letter),
   "d": [{ letter: "a" }, { letter: "b" }, { letter: "c" }] reduce $$,
   "e": [true, false, false, true, true] reduce ($$ and $),
-  "f": [true, false, false, true, true] reduce ((val, acc) -> acc and val),
-  "g": [true, false, false, true, true] reduce ((val, acc = false) -> acc and val),
+  "f": [true, false, false, true, true] reduce ((elt, acc) -> acc and elt),
+  "g": [true, false, false, true, true] reduce ((elt, acc = false) -> acc and elt),
   "h": [true, false, false, true, true] reduce $$,
   "i": in0.a reduce ($$ + $),
-  "j": in0.a reduce ((val, acc) -> acc + val),
-  "k": in0.a reduce ((val, acc = 3) -> acc + val),
+  "j": in0.a reduce ((elt, acc) -> acc + elt),
+  "k": in0.a reduce ((elt, acc = 3) -> acc + elt),
   "l": in0.a reduce $$,
   "m": in0.b reduce ($$ ++ $),
-  "n": in0.b reduce ((val, acc) -> acc ++ val),
-  "o": in0.b reduce ((val, acc = "z") -> acc ++ val),
+  "n": in0.b reduce ((elt, acc) -> acc ++ elt),
+  "o": in0.b reduce ((elt, acc = "z") -> acc ++ elt),
   "p": in0.b reduce $$,
-  "q": in0.c reduce ((val, acc = "z") -> acc ++ val.letter),
+  "q": in0.c reduce ((elt, acc = "z") -> acc ++ elt.letter),
   "r": in0.c reduce $$,
   "s": in0.d reduce ($$ and $),
-  "t": in0.d reduce ((val, acc) -> acc and val),
-  "u": in0.d reduce ((val, acc = false) -> acc and val),
+  "t": in0.d reduce ((elt, acc) -> acc and elt),
+  "u": in0.d reduce ((elt, acc = false) -> acc and elt),
   "v": in0.d reduce $$,
-  "w": ([0, 1, 2, 3, 4] reduce ((val, acc = {}) -> acc ++ { a: val })) pluck $,
+  "w": ([0, 1, 2, 3, 4] reduce ((elt, acc = {}) -> acc ++ { a: elt })) pluck $,
   "x": [] reduce $$,
-  "y": [] reduce ((val,acc = 0) -> acc + val)
+  "y": [] reduce ((elt,acc = 0) -> acc + elt)
 }
 ----
 


### PR DESCRIPTION
The reduce operator works over each element of an input array. Rather than calling them values (val), they should be called elements of the array.