### PR TITLE
DOCS-10715: "target" affects flow-variable scope

### DIFF
--- a/modules/ROOT/pages/target-variables.adoc
+++ b/modules/ROOT/pages/target-variables.adoc
@@ -12,6 +12,8 @@ You often define variables through these parameters:
 
 It is important to understand that setting a target variable changes the typical course of the message through the flow. Normally, an operation outputs a different message than it receives as input. However, when you set a variable from an operation, the operation outputs to the _next_ component in the flow the same message that it received as input. For example, assume you have a flow consisting of component A, followed by component B with a target value of `myMessage`, and then component C. In this case, component C will receive the same message that B received from A.
 
+Using "target" also changes the scope-behavior of variables
+
 //TODO: ADD GRAPHIC OF A , B,  C
 
 Here, a Read operation stores the payload of `readme.txt` in `myVar`:


### PR DESCRIPTION
see https://mulesoft.slack.com/archives/C02KJHQU0/p1554144498067200

the end result of this is that when using target, variables declared *before* the flow-ref (in an attempt to set the scope as that flow) are isolated from what happens in the sub-flows.

It's been stated that this is the intent, though it forces awkward programming model of returning composite objects just so you can retain what are probably desired mutations of the aforementioned vars. 

The choice is then one of 
a) calling a series of sub-flows ***without using target*** at the top-level (thus risking undesirable top-level payload mutations, as 
as well as breaking established encapsulation expectations)
b) tedious marshaling of data into artificially-constructed container objects **AND** then un-marshaling the data-container object.

All in all, this is a great loss to practitioners, but at the very least the documentation in this section should state clearly that use of target-attribute breaks the vars scope-linkage