### PR TITLE
DOCS-4755: modified signatures and examples

### DIFF
--- a/modules/ROOT/pages/dw-core-functions-minusminus.adoc
+++ b/modules/ROOT/pages/dw-core-functions-minusminus.adoc
@@ -8,19 +8,21 @@ endif::[]
 [[minusminus1]]
 == &#45;&#45;&#40;Array<S&#62;, Array<Any&#62;&#41;: Array<S&#62;
 
-Removes specified items from a list (an array).
+Removes specified items from an array.
 
 
 |===
 | Name   | Description
 
-| `source` | The list (an `Array` type).
-| `toRemove` | Items to remove from the list.
+| `source` | The source array whose items might be removed (an `Array` type). Can have repeating elements. 
+| `toRemove` | The array of items from which to remove from the source array. Need not have repeating elements. 
 |===
+
+Note: The result of the `--` operator is the same as applying the `-` operators repeatedy to each element of the `toRemove` array. 
 
 === Example
 
-This example removes a items from a list.
+This example removes some items from a source array.
 
 ==== Source
 
@@ -41,11 +43,29 @@ output application/json
 }
 ----
 
+Note: The result is the same as 
+==== Source
 
+[source,DataWeave, linenums]
+----
+%dw 2.0
+output application/json
+---
+{ "a" : [0, 1, 1, 2] - 1 - 2 }
+----
+
+==== Output
+
+[source,JSON,linenums]
+----
+{
+  "a": [0]
+}
+----
 [[minusminus2]]
 == &#45;&#45;&#40;{ &#40;K&#41;?: V }, Object&#41;: { &#40;K&#41;?: V }
 
-Removes specified key-value pairs from an object.
+Removes key-value pairs from a source object (the first parameter) if the same key/value appears in the second parameter's object. 
 
 
 === Parameters
@@ -53,10 +73,16 @@ Removes specified key-value pairs from an object.
 [%header, cols="1,3"]
 |===
 | Name   | Description
-| `source` | The object.
-| `toRemove` | Objects to remove from the source object.
+| `source` | The source object whose key/values might be removed (of type `Object`).
+| `toRemove` | The key/value pairs to remove from the source object (of type `Object`). The key/values in this second object to need not repeat; every matching key/value is removed from the source object. 
 |===
 
+Note: For a key/value to be removed from the source object, both the key and value must be identical, not just the key. 
+
+
+
+[[minusminus2]]
+== &#45;&#45;&#40;{ &#40;K&#41;?: V }, Object&#41;: { &#40;K&#41;?: V }
 === Example
 
 This example removes a key-value pair from the source object.
@@ -70,7 +96,9 @@ output application/json
 ---
 {
    "hello" : "world",
-   "name" : "DW"
+   "name" : "DW",
+   "hello" : "world",
+   "hello" : "there"
 } -- { "hello" : "world"}
 ----
 
@@ -79,7 +107,8 @@ output application/json
 [source,JSON,linenums]
 ----
 {
-   "name": "DW"
+   "name": "DW",
+   "hello" : "there"
 }
 ----
 
@@ -87,7 +116,7 @@ output application/json
 [[minusminus3]]
 == &#45;&#45;&#40;Object, Array<String&#62;&#41;
 
-Removes specified key-value pairs from an object.
+Removes all key/values from the source object that match a key in the second parameter's array. 
 
 
 === Parameters
@@ -112,6 +141,7 @@ output application/json
 ---
 {
    "yes" : "no",
+   "yes" : "OK",
    "good" : "bad",
    "old" : "new"
 } -- ["yes", "old"]
@@ -130,7 +160,7 @@ output application/json
 [[minusminus4]]
 == &#45;&#45;&#40;Object, Array<Key&#62;&#41;
 
-Removes specified key-value pairs from an object.
+Removes specified key-value pairs from an object if the key is in the second parameter array.
 
 
 === Parameters
@@ -139,12 +169,12 @@ Removes specified key-value pairs from an object.
 |===
 | Name   | Description
 | `source` | The source object (an `Object` type).
-| `keys` | A keys for the key-value pairs to remove from the source object.
+| `keys` | An array of keys to specify the key-value pairs to remove from the source object.
 |===
 
 === Example
 
-This example specifies the key-value pair to remove from the source object.
+This example specifies the key to remove from the source object.
 
 ==== Source
 

--- a/modules/ROOT/pages/dw-core-functions-minusminus.adoc
+++ b/modules/ROOT/pages/dw-core-functions-minusminus.adoc
@@ -14,11 +14,11 @@ Removes specified items from an array.
 |===
 | Name   | Description
 
-| `source` | The source array whose items might be removed (an `Array` type). Can have repeating elements. 
-| `toRemove` | The array of items from which to remove from the source array. Need not have repeating elements. 
+| `source` | The source array whose items might be removed (an `Array` type). Can have repeating elements.
+| `toRemove` | The array of items from which to remove from the source array. Need not have repeating elements.
 |===
 
-Note: The result of the `--` operator is the same as applying the `-` operators repeatedy to each element of the `toRemove` array. 
+Note: The result of the `--` operator is the same as applying the `-` operators repeatedy to each element of the `toRemove` array.
 
 === Example
 
@@ -43,7 +43,7 @@ output application/json
 }
 ----
 
-Note: The result is the same as 
+Note: The result is the same as
 ==== Source
 
 [source,DataWeave, linenums]
@@ -65,7 +65,7 @@ output application/json
 [[minusminus2]]
 == &#45;&#45;&#40;{ &#40;K&#41;?: V }, Object&#41;: { &#40;K&#41;?: V }
 
-Removes key-value pairs from a source object (the first parameter) if the same key/value appears in the second parameter's object. 
+Removes key-value pairs from a source object (the first parameter) if the same key-value pairs appear in the second parameter's object.
 
 
 === Parameters
@@ -74,10 +74,10 @@ Removes key-value pairs from a source object (the first parameter) if the same k
 |===
 | Name   | Description
 | `source` | The source object whose key/values might be removed (of type `Object`).
-| `toRemove` | The key/value pairs to remove from the source object (of type `Object`). The key/values in this second object to need not repeat; every matching key/value is removed from the source object. 
+| `toRemove` | The key-value pairs to remove from the source object (of type `Object`). The key-values pairs in this second object to need not repeat; every matching key-value pair is removed from the source object.
 |===
 
-Note: For a key/value to be removed from the source object, both the key and value must be identical, not just the key. 
+Note: For a key-value pair to be removed from the source object, both the key and value must be identical, not just the key.
 
 
 
@@ -116,7 +116,7 @@ output application/json
 [[minusminus3]]
 == &#45;&#45;&#40;Object, Array<String&#62;&#41;
 
-Removes all key/values from the source object that match a key in the second parameter's array. 
+Removes all key-values from the source object that match a key in the second parameter's array.
 
 
 === Parameters
@@ -197,4 +197,3 @@ output application/json
    "name": "DW"
 }
 ----
-


### PR DESCRIPTION
The signatures of minusminus3 was wrong. Also added more key/values to the examples to show how the operator deals with repeating keys or repeating key/values.