### PR TITLE
Clearly state that credentials are for Nexus repo

### DIFF
--- a/modules/ROOT/pages/configuring-maven-to-work-with-mule-esb.adoc
+++ b/modules/ROOT/pages/configuring-maven-to-work-with-mule-esb.adoc
@@ -4,7 +4,7 @@ include::_attributes.adoc[]
 endif::[]
 :keywords: anypoint, studio, maven
 
-When working with Maven to build Mule applications _outside_ of Anypoint Studio, you need to configure your Maven installation to work successfully with Mule. This page covers how to maintain your POM file to add or adjust dependencies and point to the correct MuleSoft repositories, and how to modify your Maven `settings.xml` file to include credentials and profiles for Enterprise repositories.
+When working with Maven to build Mule applications _outside_ of Anypoint Studio, you need to configure your Maven installation to work successfully with Mule. This page covers how to maintain your POM file to add or adjust dependencies and point to the correct MuleSoft repositories, and how to modify your Maven `settings.xml` file to include Nexus credentials and profiles for Enterprise repositories.
 
 Once you have modified your Maven installation, you can install Mule plugins and develop applications that reference the Mule open source or Enterprise repositories.
 
@@ -19,7 +19,7 @@ Before you can start using Maven to create new Mule projects from the command li
 . Ensure that Maven is installed in a directory that does not include spaces.
 
 . Create or maintain your  `pom.xml` files for your applications to include references to the MuleSoft open-source repositories and any connectors, modules, or other extensions that you need to include in each application. +
-If you are using Enterprise Edition, modify the `settings.xml` file to point to the Enterprise Customer repository and provide your credentials.
+If you are using Enterprise Edition, modify the `settings.xml` file to point to the Enterprise Customer repository and provide your Nexus credentials.
 +
 Anypoint Exchange provides Maven dependency information. +
 Click a connector asset and click Dependency Snippets to list the Maven pom.xml file dependency.
@@ -116,7 +116,7 @@ This repository includes third party libraries used by Mule components. If Maven
 
 === Referencing MuleSoft's Enterprise Repositories
 
-This section assumes that you have acquired an http://www.mulesoft.com/mule-esb-support-esb-license-subscription[Enterprise License] and credentials for the https://repository.mulesoft.org/nexus-ee/content/repositories/releases-ee/[MuleSoft Enterprise Maven customer repository], which allows you to access Mule Enterprise modules, connectors, and other components not included in the trial or community versions. If you are a MuleSoft customer and do not have access to the repository, contact https://www.mulesoft.com/support-login[MuleSoft Support] and request enterprise credentials.
+This section assumes that you have acquired an http://www.mulesoft.com/mule-esb-support-esb-license-subscription[Enterprise License] and credentials for the https://repository.mulesoft.org/nexus-ee/content/repositories/releases-ee/[MuleSoft Enterprise Maven customer repository], which allows you to access Mule Enterprise modules, connectors, and other components not included in the trial or community versions. If you are a MuleSoft customer and do not have access to the repository, contact https://www.mulesoft.com/support-login[MuleSoft Support] and request Nexus enterprise credentials.
 
 To configure Maven to access the MuleSoft Customer Repository, you need to make additions to the `settings.xml` config file on all workstations that require access. Your `.m2` directory may already contain a configuration file called `settings.xml`. Note that this file is not mandatory; Maven uses default parameters if the file is not present. If you don't have a `settings.xml` file at all, create it inside the `~/.m2` folder. Read more about the `settings.xml` file in the http://maven.apache.org/settings.html[Maven documentation].
 


### PR DESCRIPTION
Some customers are getting mistaken about this credentials. They think they need to set Anypoint Platform credentials in their settings.xml file. It's better to clearly differenciate this mentioning that those are Nexus credentials.