### PR TITLE
v3.8: Added a larger list of characters that DW trims

### DIFF
--- a/modules/ROOT/pages/dataweave-operators.adoc
+++ b/modules/ROOT/pages/dataweave-operators.adoc
@@ -2103,7 +2103,7 @@ Returns the provided string transformed into its singular form.
 == Trim
 .(':string') => ':string'
 
-Removes any excess spaces at the start and end of a string.
+Removes any excess whitespaces at the start and end of a string, this also includes newlines, tabs, carriage returns, ...
 
 .Transform
 [source,dataweave,linenums]


### PR DESCRIPTION
Mention 'whitespaces' instead of 'spaces' since DW 1.0 trim will also remove tabs, newlines, carriage returns, ...