### PR TITLE
DOCS-5078-mmp fix

### DIFF
--- a/modules/ROOT/pages/mmp-concept.adoc
+++ b/modules/ROOT/pages/mmp-concept.adoc
@@ -211,7 +211,7 @@ See xref:how-to-export-resources.adoc[Export Resources] to learn more about work
     <configuration>
         <cloudHubDeployment>
             <uri>https://anypoint.mulesoft.com</uri>
-            <muleVersion>${mule.version}</muleVersion>
+            <muleVersion>${app.runtime}</muleVersion>
             <username>${username}</username>
             <password>${password}</password>
             <applicationName>${cloudhub.application.name}</applicationName>
@@ -337,7 +337,7 @@ Or you can use the Mule Maven Plugin following the instructions xref:exchange::t
     <configuration>
         <runtimeFabricDeployment>
             <uri>https://anypoint.mulesoft.com</uri>
-            <muleVersion>${mule.version}</muleVersion>
+            <muleVersion>${app.runtime}</muleVersion>
             <username>${username}</username>
             <password>${password}</password>
             <applicationName>${runtime.fabric.application.name}</applicationName>
@@ -462,12 +462,12 @@ See how to xref:runtime-fabric::deploy-resource-allocation.adoc[determine resour
 [source,xml,linenums]
 ----
 <plugin>
-  ...
+
   <configuration>
     <standaloneDeployment>
-  	    <muleHome>${mule.home.test}</muleHome>
-        <muleVersion>${mule.version}</muleVersion>
-  	</standaloneDeployment>
+      <muleHome>${mule.home.test}</muleHome>
+      <muleVersion>${app.runtime}</muleVersion>
+    </standaloneDeployment>
   </configuration>
 
 </plugin>
@@ -672,7 +672,7 @@ Below is an example of a CloudHub Deployment using encrypted credentials:
     <configuration>
         <cloudHubDeployment>
             <uri>https://anypoint.mulesoft.com</uri>
-            <muleVersion>${mule.version}</muleVersion>
+            <muleVersion>${app.runtime}</muleVersion>
             <server>my.anypoint.credentials</server>
             <applicationName>${cloudhub.application.name}</applicationName>
             <environment>${environment}</environment>


### PR DESCRIPTION
Replaced ${mule.version} with ${app.runtime}. Fixed indentation.