### PR TITLE
Docs 5127 remove link to removed doc v3.5

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -4,7 +4,6 @@
 * xref:installing-an-enterprise-license.adoc[Installing an Enterprise License]
  ** xref:extending-mule.adoc[Extending Mule]
 * xref:mule-fundamentals.adoc[Mule Fundamentals]
- ** xref:general:getting-started:build-a-hello-world-application.adoc[Build a Hello World Mule Application]
  ** xref:mule-concepts.adoc[Mule Concepts]
   *** xref:elements-in-a-mule-flow.adoc[Elements in a Mule Flow]
    **** xref:mule-connectors.adoc[Mule Connectors]


### PR DESCRIPTION
One of several doc PRs to remove out-of-date link.