### PR TITLE
DOCS 4888 Cluster Support for Connectors update

### DIFF
--- a/modules/ROOT/pages/mule-high-availability-ha-clusters.adoc
+++ b/modules/ROOT/pages/mule-high-availability-ha-clusters.adoc
@@ -150,7 +150,7 @@ Listener-based connectors read data using a protocol that fully supports concurr
 Listener-based connectors are supported in clusters as described below:
 
 * Listener-based connectors fully support multiple readers and writers. No special considerations apply either to input or to output.
-* Note that, in a cluster, VM connector queues are a shared, cluster-wide resource. The cluster will automatically synchronize access to the VM connector queues. Because of this, a message written to a VM queue can be processed by any cluster node. This makes VM ideal for sharing work among cluster nodes.
+* Note that, in a cluster, VM connector queues are a shared, cluster-wide resource. The cluster will automatically synchronize access to the VM connector queues. Because of this, any cluster node can process a message written to a VM queue. This makes VM ideal for sharing work among cluster nodes.
 
 === Resource-based Connectors
 Resource-based connectors read data from a resource that allows multiple concurrent accessors, but does not natively coordinate their use of the resource. Examples of resource-based connectors include File, FTP, SFTP, E-mail, and JDBC.

--- a/modules/ROOT/pages/mule-high-availability-ha-clusters.adoc
+++ b/modules/ROOT/pages/mule-high-availability-ha-clusters.adoc
@@ -134,31 +134,42 @@ You must use XA transactions to move messages between dissimilar connectors that
 
 == Cluster Support for Connectors
 
-All Mule connectors are supported within a cluster. Because of differences in the way different connectors access inbound traffic, the details of this support vary. In general, outbound traffic acts the same way inside and outside a cluster – the differences are highlighted below.
+All Mule connectors are supported within a cluster. Because of differences in the way different connectors access inbound traffic, the details of this support vary. In general, outbound traffic acts the same way inside and outside a cluster. Mule runtimes support three basic types of connectors:
 
-Mule runtime engines support three basic types of connectors:
+=== Socket-based Connectors
+Socket-based connectors read input sent to network sockets that Mule owns. Examples include TCP, UDP, and HTTP[S].
 
-* Socket-based connector: reads input sent to network sockets that Mule owns. +
-Examples include TCP, UDP, and HTTP[S].
-* Listener-based connector: reads data using a protocol that fully supports concurrent multiple accessors. +
-Examples include JMS and VM.
-* Resource-based connector: reads data from a resource that allows multiple concurrent accessors, but does not natively coordinate their use of the resource. +
-For instance, suppose multiple programs are processing files in the same shared directory by reading, processing, and then deleting the files. These programs must use an explicit, application-level locking strategy to prevent the same file from being processed more than once. Examples of resource-based connectors include File, FTP, SFTP, E-mail, and JDBC.
+Socket-based connectors are supported in clusters as described below:
 
-All three basic types of connectors are supported in clusters in different ways, as described below.
+* Since each clustered Mule runtime runs on a different network node, each instance receives only the socket-based traffic sent to its node. Incoming socket-based traffic should be <<Clustering and Load Balancing>> to distribute it among the clustered instances.
+* Output to socket-based connectors is written to a specific host/port combination. If the host/port combination is an external host, no special considerations apply. If it is a port on the local host, consider using that port on the load balancer instead to better distribute traffic among the cluster.
 
-* Socket-based
-** Because each clustered Mule runtime engine runs on a different network node, each instance receives only the socket-based traffic sent to its node. You need to apply clustering and load balancing to distribute incoming socket-based traffic among the clustered instances.
-** Output to socket-based connectors is written to a specific host/port combination. If the host/port combination is an external host, no special considerations apply. If it is a port on the local host, consider using that port on the load balancer instead to better distribute traffic among the cluster.
-* Listener-based
-** Listener-based connectors fully support multiple readers and writers. No special considerations apply either to input or to output.
-** Note that, in a cluster, VM connector queues are a shared, cluster-wide resource. The cluster will automatically synchronize access to the VM connector queues. Because of this, a message written to a VM queue can be processed by any cluster node. This makes VM ideal for sharing work among cluster nodes.
-* Resource-based
-** Mule high availability (HA) Clustering automatically coordinates access to each resource, ensuring that only one clustered instance accesses each resource at a time. Because of this, it is generally a good idea to immediately write messages read from a resource-based connector to VM queues. This allows the other cluster nodes to take part in processing the messages.
-** There are no special considerations in writing to resource-based clustered connectors:
-*** When writing to file-based connectors (File, FTP, SFTP), Mule will generate unique file names.
-*** When writing to JDBC, Mule can generate unique keys.
-*** Writing e-mail is effectively listener-based rather than resource-based.
+=== Listener-based Connectors
+Listener-based connectors read data using a protocol that fully supports concurrent multiple accessors. Examples include JMS and VM.
+
+Listener-based connectors are supported in clusters as described below:
+
+* Listener-based connectors fully support multiple readers and writers. No special considerations apply either to input or to output.
+* Note that, in a cluster, VM connector queues are a shared, cluster-wide resource. The cluster will automatically synchronize access to the VM connector queues. Because of this, a message written to a VM queue can be processed by any cluster node. This makes VM ideal for sharing work among cluster nodes.
+
+=== Resource-based Connectors
+Resource-based connectors read data from a resource that allows multiple concurrent accessors, but does not natively coordinate their use of the resource. Examples of resource-based connectors include File, FTP, SFTP, E-mail, and JDBC.
+
+Resource-based connectors are supported in clusters as described below:
+
+* Mule HA Clustering automatically coordinates access to each resource only for nodes within the cluster, ensuring that only one clustered instance accesses each resource at a time. Because of this, it is generally a good idea to immediately write messages read from a resource-based connector to VM queues. This allows the other cluster nodes to take part in processing the messages.
++
+[NOTE]
+====
+If you run other applications (either Mule applications outside the cluster or non-Mule applications) that access the same resources as the nodes in the cluster, you must implement logic to lock those resources.
+
+For example, if multiple programs are processing files in the same shared directory by reading, modifying, and then deleting the files. These programs must use an explicit, application-level locking strategy to prevent the same file from being processed more than once.
+====
+
+* There are no special considerations in writing to resource-based clustered connectors:
+** When writing to file-based connectors (File, FTP, SFTP), Mule will generate unique file names.
+** When writing to JDBC, Mule can generate unique keys.
+** Writing e-mail is effectively listener-based rather than resource-based.
 
 == Clustering and Reliable Applications
 


### PR DESCRIPTION
Bringing changes to this section from v4.1 to v4.2 PR #474

Improved and reorganized section: Cluster Support for Connectors.
-All info related to a specific transport type is inside its 
corresponding section. 
-Added [NOTE] clarifying that a locking strategy needs to be used when a 
resource is accessed by multiple apps, outside the cluster.