### PR TITLE
multiply is showing a wrong value in reduce example

### DIFF
--- a/modules/ROOT/pages/dw-core-functions-reduce.adoc
+++ b/modules/ROOT/pages/dw-core-functions-reduce.adoc
@@ -101,7 +101,7 @@ This example sets the first element from the first input array to `"z"`, and
 it adds `3` to the sum of the second input array. In `multiply`, it shows how
 to multiply each value in an array by the next
 (`[2,3,3] reduce ((item, acc) -> acc * item)`) to
-produce a final result of `12` (= `2 * 3 * 3`). The final example,
+produce a final result of `18` (= `2 * 3 * 3`). The final example,
 `multiplyAcc`, sets the accumulator to `3` to multiply the result of
 `acc * item` (= `12`) by `3` (that is, `3 (2 * 2  * 3) = 36`), as shown in
 the output.
@@ -125,7 +125,7 @@ output application/json
 
 [source,JSON,linenums]
 ----
-{ "concat": "zabcd", "sum": 18, "multiply": 12, "multiplyAcc": 36 }
+{ "concat": "zabcd", "sum": 18, "multiply": 18, "multiplyAcc": 36 }
 ----
 
 === Example


### PR DESCRIPTION
"multiply" : [2,3,3] reduce ((item, acc) -> acc * item) should give an output as 18 = 2*3*3, but the output is shown as 12 which is really confusing