### PR TITLE
Add warning about application/dw performance

### DIFF
--- a/modules/ROOT/pages/dataweave-formats.adoc
+++ b/modules/ROOT/pages/dataweave-formats.adoc
@@ -539,7 +539,7 @@ transformed to a new format.
 
 [WARNING]
 ====
-This format is intended only as a help for debugging the results of DataWeave transformations.
+This format is intended only to help you debug the results of DataWeave transformations.
 It is significantly slower than other formats. It is not recommended to be used in production applications because it can impact the performance.
 ====
 

--- a/modules/ROOT/pages/dataweave-formats.adoc
+++ b/modules/ROOT/pages/dataweave-formats.adoc
@@ -537,6 +537,12 @@ The DataWeave (weave) format is the canonical format for all transformations.
 This format can help you understand how input data is interpreted before it is
 transformed to a new format.
 
+[WARNING]
+====
+This format is intended only as a help for debugging the results of DataWeave transformations.
+It is significantly slower than other formats. It is not recommended to be used in production applications because it can impact the performance.
+====
+
 This example shows how XML input is expressed in the DataWeave format.
 
 .Input XML


### PR DESCRIPTION
The same warning should be added to all Mule versions with DataWeave (3.7+).