### PR TITLE
DOCS-5186-4.2-dw-syntax-error-kt

### DIFF
--- a/modules/ROOT/pages/dataweave-cookbook-extract-data.adoc
+++ b/modules/ROOT/pages/dataweave-cookbook-extract-data.adoc
@@ -191,7 +191,7 @@ To return the values of mulitple matching keys in cases like this, see
 <<multi_value>>.
 
 In the next example, `payload.people.person.address` returns the value of the
-`address` element. (It also uses the `output` directive to transform the JSON 
+`address` element. (It also uses the `output` directive to transform the JSON
 input to XML.)
 
 .DataWeave Script:
@@ -510,8 +510,8 @@ is an object, where the original keys for each value are also extracted.
 === Select All the Descendant Key-Value Pairs
 
 This example uses the `..` and `&amp;` selectors in `myVar.people..&name`
-to select and return an array that contains all descendant objects from 
-`myData` input that contain the key `name`. It also transforms the JSON 
+to select and return an array that contains all descendant objects from
+`myData` input that contain the key `name`. It also transforms the JSON
 input to XML output.
 
 .DataWeave Script:
@@ -889,7 +889,7 @@ output application/json
 ---
 {
   item: {
-    typePresent : payload.product.@type?
+    typePresent : payload.product.@."type"?
   }
 }
 ----


### PR DESCRIPTION
Per feedback received updating Key Present Validator syntax example. Tested in Studio.
`payload.product.@."type"?`