### PR TITLE
DOCS-5185-4.2-dw-fun-syntax-error-kt

### DIFF
--- a/modules/ROOT/pages/dataweave-language-introduction.adoc
+++ b/modules/ROOT/pages/dataweave-language-introduction.adoc
@@ -130,7 +130,7 @@ ns ns1 http://www.123.com
 ----
 %dw 2.0
 output application/json
-fun toUser = (user) -> {firstName: user.name, lastName: user.lastName}
+fun toUser(user) = {firstName: user.name, lastName: user.lastName}
 ---
 {
   user: toUser(payload)
@@ -278,10 +278,10 @@ with `f`. Notice that you do not need to escape the double quote in this case.
 * `/``: For a string that is surrounded by backticks (supported in DataWeave
 2.0), you need escape any backtick that is part of the string, for example,
 ``'"\`\$\\``.
-* `\`: Because the backslash is the character you use to escape other special 
-characters, you need to escape it with a separate backslash to use it in 
+* `\`: Because the backslash is the character you use to escape other special
+characters, you need to escape it with a separate backslash to use it in
 a string, for example,`\\`.
-* `\n`: For inserting a new line. 
+* `\n`: For inserting a new line.
 * `\t`: For inserting a tab.
 * `\u`: For inserting a unicode character, such as `\u25c4`.
 


### PR DESCRIPTION
Per feedback received updating fun syntax error. Tested in Studio
`fun toUser(user) = {firstName: user.name, lastName: user.lastName}`