### PR TITLE
DOCS-5984-Swapping out CPU Light with CPU LITE.

### DIFF
--- a/modules/ROOT/pages/execution-engine.adoc
+++ b/modules/ROOT/pages/execution-engine.adoc
@@ -16,11 +16,11 @@ execution, and the engine makes tuning decisions based on that metadata.
 Mule Event processors indicate to the runtime what kind of work they do, which 
 can be one of:
 
-* CPU Light: For quick operations, or Non-Blocking IO, for example, a Logger (`logger`) or HTTP Request operation (`http:request`).
+* CPU_LITE: For quick operations, or Non-Blocking IO, for example, a Logger (`logger`) or HTTP Request operation (`http:request`).
 * Blocking IO: For IO that blocks the calling thread, for example, a Database Select operation (`db:select`).
 * CPU Intensive: For CPU-bound computations, for example, through the Transform Message component (`ee:transform`).
 
-See specific component or module documentation to learn the processing type it supports. If none is specified, the default is *CPU Light*.
+See specific component or module documentation to learn the processing type it supports. If none is specified, the default is *CPU_LITE*.
 
 // link to https://docs.mulesoft.com/mule-sdk/1.1/non-blocking-operations#execution-types
 For connectors created with the Mule SDK, the SDK determines the most 
@@ -48,18 +48,18 @@ Note: By design, it is not possible to change the thread pools configurations in
 
 The key aspects of each thread pool are described in the next sections.
 
-=== CPU Light
+=== CPU_LITE
 
-CPU Light is for a relatively small thread pool (2 threads per available core by default).
+CPU_LITE is for a relatively small thread pool (2 threads per available core by default).
 
-Apart from executing the `CPU_LIGHT` processors, this pool performs the handoff
+Apart from executing the `CPU_LITE` processors, this pool performs the handoff
 of the event between processors in the flow (including the routers) and the 
 response handling for non-blocking IO. 
 
 In an app, when throughput drops or becomes unresponsive, it might be due to some code 
-misusing the `CPU Light` thread pool. This can be quickly checked by taking a 
+misusing the `CPU_LITE` thread pool. This can be quickly checked by taking a 
 thread dump of the runtime and looking for `WAITING` or `BLOCKED` or for 
-long-running processes in the `CPU Light` threads. 
+long-running processes in the `CPU_LITE` threads. 
 
 === CPU Intensive
 
@@ -92,7 +92,7 @@ as required.
 == Back-pressure
 
 Under heavy load, there is a case where the runtime has no resources 
-available to handle a specific event. This issue might occur because the `CPU_LIGHT` 
+available to handle a specific event. This issue might occur because the `CPU_LITE` 
 threads are all busy and cannot perform the handoff of the newly arrived event or 
 because the current flow's `maxConcurrency` has been exceeded already.
 

--- a/modules/ROOT/pages/execution-engine.adoc
+++ b/modules/ROOT/pages/execution-engine.adoc
@@ -16,9 +16,9 @@ execution, and the engine makes tuning decisions based on that metadata.
 Mule Event processors indicate to the runtime what kind of work they do, which 
 can be one of:
 
-* CPU Light: For quick operations, or Non-Blocking IO, for example, a Logger (`logger`) or HTTP Request operation (`http:request`). The applicable string in the logs are `CPU_LIGHT` and `CPU_LIGHT_ASYNC`.
+* CPU Light: For quick operations, or Non-Blocking IO, for example, a Logger (`logger`) or HTTP Request operation (`http:request`). The applicable strings in the logs are `CPU_LIGHT` and `CPU_LIGHT_ASYNC`.
 * Blocking IO: For IO that blocks the calling thread, for example, a Database Select operation (`db:select`). Applicable strings in the logs are `BLOCKING` and `IO`.
-* CPU Intensive: For CPU-bound computations, for example, through the Transform Message component (`ee:transform`). The applicable strings in the logs are `CPU_INTENSIVE`.
+* CPU Intensive: For CPU-bound computations, for example, through the Transform Message component (`ee:transform`). The applicable string in the logs is `CPU_INTENSIVE`.
 
 See specific component or module documentation to learn the processing type it supports. If none is specified, the default is CPU Light.
 

--- a/modules/ROOT/pages/execution-engine.adoc
+++ b/modules/ROOT/pages/execution-engine.adoc
@@ -16,11 +16,11 @@ execution, and the engine makes tuning decisions based on that metadata.
 Mule Event processors indicate to the runtime what kind of work they do, which 
 can be one of:
 
-* CPU_LITE: For quick operations, or Non-Blocking IO, for example, a Logger (`logger`) or HTTP Request operation (`http:request`).
-* Blocking IO: For IO that blocks the calling thread, for example, a Database Select operation (`db:select`).
-* CPU Intensive: For CPU-bound computations, for example, through the Transform Message component (`ee:transform`).
+* CPU Light: For quick operations, or Non-Blocking IO, for example, a Logger (`logger`) or HTTP Request operation (`http:request`). The applicable string in the logs is `CPU_LIGHT`.
+* Blocking IO: For IO that blocks the calling thread, for example, a Database Select operation (`db:select`). Applicable strings in the logs are `BLOCKING` and `IO`.
+* CPU Intensive: For CPU-bound computations, for example, through the Transform Message component (`ee:transform`). The applicable string in the logs is `CPU_INTENSIVE`.
 
-See specific component or module documentation to learn the processing type it supports. If none is specified, the default is *CPU_LITE*.
+See specific component or module documentation to learn the processing type it supports. If none is specified, the default is CPU Light.
 
 // link to https://docs.mulesoft.com/mule-sdk/1.1/non-blocking-operations#execution-types
 For connectors created with the Mule SDK, the SDK determines the most 
@@ -48,18 +48,18 @@ Note: By design, it is not possible to change the thread pools configurations in
 
 The key aspects of each thread pool are described in the next sections.
 
-=== CPU_LITE
+=== CPU Light
 
-CPU_LITE is for a relatively small thread pool (2 threads per available core by default).
+CPU Light is for a relatively small thread pool (2 threads per available core by default).
 
-Apart from executing the `CPU_LITE` processors, this pool performs the handoff
+Apart from executing the CPU Light processors, this pool performs the handoff
 of the event between processors in the flow (including the routers) and the 
 response handling for non-blocking IO. 
 
 In an app, when throughput drops or becomes unresponsive, it might be due to some code 
-misusing the `CPU_LITE` thread pool. This can be quickly checked by taking a 
+misusing the CPU Light thread pool. This can be quickly checked by taking a 
 thread dump of the runtime and looking for `WAITING` or `BLOCKED` or for 
-long-running processes in the `CPU_LITE` threads. 
+long-running processes in the CPU Light threads. 
 
 === CPU Intensive
 
@@ -92,7 +92,7 @@ as required.
 == Back-pressure
 
 Under heavy load, there is a case where the runtime has no resources 
-available to handle a specific event. This issue might occur because the `CPU_LITE` 
+available to handle a specific event. This issue might occur because the CPU Light 
 threads are all busy and cannot perform the handoff of the newly arrived event or 
 because the current flow's `maxConcurrency` has been exceeded already.
 

--- a/modules/ROOT/pages/execution-engine.adoc
+++ b/modules/ROOT/pages/execution-engine.adoc
@@ -18,7 +18,7 @@ can be one of:
 
 * CPU Light: For quick operations, or Non-Blocking IO, for example, a Logger (`logger`) or HTTP Request operation (`http:request`). The applicable string in the logs are `CPU_LIGHT` and `CPU_LIGHT_ASYNC`.
 * Blocking IO: For IO that blocks the calling thread, for example, a Database Select operation (`db:select`). Applicable strings in the logs are `BLOCKING` and `IO`.
-* CPU Intensive: For CPU-bound computations, for example, through the Transform Message component (`ee:transform`). The applicable string in the logs is `CPU_INTENSIVE`.
+* CPU Intensive: For CPU-bound computations, for example, through the Transform Message component (`ee:transform`). The applicable strings in the logs are `CPU_INTENSIVE`.
 
 See specific component or module documentation to learn the processing type it supports. If none is specified, the default is CPU Light.
 

--- a/modules/ROOT/pages/execution-engine.adoc
+++ b/modules/ROOT/pages/execution-engine.adoc
@@ -16,7 +16,7 @@ execution, and the engine makes tuning decisions based on that metadata.
 Mule Event processors indicate to the runtime what kind of work they do, which 
 can be one of:
 
-* CPU Light: For quick operations, or Non-Blocking IO, for example, a Logger (`logger`) or HTTP Request operation (`http:request`). The applicable string in the logs is `CPU_LIGHT`.
+* CPU Light: For quick operations, or Non-Blocking IO, for example, a Logger (`logger`) or HTTP Request operation (`http:request`). The applicable string in the logs are `CPU_LIGHT` and `CPU_LIGHT_ASYNC`.
 * Blocking IO: For IO that blocks the calling thread, for example, a Database Select operation (`db:select`). Applicable strings in the logs are `BLOCKING` and `IO`.
 * CPU Intensive: For CPU-bound computations, for example, through the Transform Message component (`ee:transform`). The applicable string in the logs is `CPU_INTENSIVE`.
 


### PR DESCRIPTION
In the Mule 4 console & logging, I don't see *any* reference to CPU Light, I just see references in Mule4 console and logging to CPU_LITE