### PR TITLE
DOCS-5331-4.1-consuming-soap-api-kt

### DIFF
--- a/modules/ROOT/pages/consuming-a-soap-api.adoc
+++ b/modules/ROOT/pages/consuming-a-soap-api.adoc
@@ -1,0 +1,17 @@
+= Consuming a SOAP API
+ifndef::env-site,env-github[]
+include::_attributes.adoc[]
+endif::[]
+:keywords: anypoint, studio, connectors, soap, wsdl, api
+
+If you want to consume an API that does not already have its own Anypoint Connector, use the *Web Service Consumer* connector to consume any SOAP API from within your Mule application.
+
+Using the information contained in the API's WSDL, this connector enables you to configure a few details to establish the connection you need for consuming a service from within your Mule application. +
+First, identify the location of the Web service's WSDL file, then ask the Web Service Consumer to configure itself from the WSDL – host, port, address.
+
+Learn more about the xref:connectors::web-service/web-service-consumer.adoc[Web Service Consumer] connector.
+
+
+== See Also
+
+* xref:publishing-a-soap-api.adoc[Publishing a SOAP API]

--- a/modules/ROOT/pages/consuming-a-soap-api.adoc
+++ b/modules/ROOT/pages/consuming-a-soap-api.adoc
@@ -6,7 +6,7 @@ endif::[]
 
 If you want to consume an API that does not have its own Anypoint Connector, you can use the Web Service Consumer connector.
 
-Using the information contained in the API's WSDL, this connector enables you to configure a few details to establish the connection you need for consuming a service from within your Mule application:
+Using the information contained in the API's WSDL, this connector provides the connection configuration you need for consuming a service from within your Mule application:
 
 . Identify the location of the Web service's WSDL file.
 

--- a/modules/ROOT/pages/consuming-a-soap-api.adoc
+++ b/modules/ROOT/pages/consuming-a-soap-api.adoc
@@ -4,13 +4,13 @@ include::_attributes.adoc[]
 endif::[]
 :keywords: anypoint, studio, connectors, soap, wsdl, api
 
-If you want to consume an API that does not have its own Anypoint Connector, you can use the Web Service Consumer connector.
+If you want to consume a SOAP API that does not have its own Anypoint Connector, you can use the Web Service Consumer connector.
 
-Using the information contained in the API's WSDL, this connector provides the connection configuration you need for consuming a service from within your Mule application:
+Using the information contained in the API's WSDL, the connector provides the connection configuration you need for consuming a service from within your Mule application:
 
-. Identify the location of the Web service's WSDL file.
+. First, identify the location of the Web service's WSDL file.
 
-. Request the Web Service Consumer to configure itself from the WSDL – host, port, address.
+. Then at design time, the connector helps you to configure the parameters by using the metadata retrieved from the WSDL – host, port, address.
 
 Learn more about the xref:connectors::web-service/web-service-consumer.adoc[Web Service Consumer] connector.
 

--- a/modules/ROOT/pages/consuming-a-soap-api.adoc
+++ b/modules/ROOT/pages/consuming-a-soap-api.adoc
@@ -4,10 +4,13 @@ include::_attributes.adoc[]
 endif::[]
 :keywords: anypoint, studio, connectors, soap, wsdl, api
 
-If you want to consume an API that does not already have its own Anypoint Connector, use the *Web Service Consumer* connector to consume any SOAP API from within your Mule application.
+If you want to consume an API that does not have its own Anypoint Connector, you can use the Web Service Consumer connector.
 
-Using the information contained in the API's WSDL, this connector enables you to configure a few details to establish the connection you need for consuming a service from within your Mule application. +
-First, identify the location of the Web service's WSDL file, then ask the Web Service Consumer to configure itself from the WSDL – host, port, address.
+Using the information contained in the API's WSDL, this connector enables you to configure a few details to establish the connection you need for consuming a service from within your Mule application:
+
+. Identify the location of the Web service's WSDL file.
+
+. Request the Web Service Consumer to configure itself from the WSDL – host, port, address.
 
 Learn more about the xref:connectors::web-service/web-service-consumer.adoc[Web Service Consumer] connector.
 


### PR DESCRIPTION
Migrate 3.9 to 4.1 version
-Improve wording, styling and paragraph.
-Updated Web Service Consumer link to new doc.
-Added See Also link section.