### PR TITLE
Update migration-patterns-reconnection-strategies.adoc

### DIFF
--- a/modules/ROOT/pages/migration-patterns-reconnection-strategies.adoc
+++ b/modules/ROOT/pages/migration-patterns-reconnection-strategies.adoc
@@ -66,7 +66,7 @@ In Mule 3, the same reconnection strategy at the config element was used both at
 
 In Mule 4 this behavior is kept by default, but you also get the chance to specify a different strategy at the operation or Message Source level:
 
-.Mule 4 Examples: Reconnection Settings (for a SQL database)
+.Mule 4 Examples: Reconnection Settings (for an HTTP request)
 [source,xml,linenums]
 ----
 <flow name="reconnectionDemo">


### PR DESCRIPTION
The second example is for an HTTP request connector, not an SQL connector.