### PR TITLE
DOCS-3504-4.1-raise-error-component-kt

### DIFF
--- a/modules/ROOT/pages/raise-error-component-reference.adoc
+++ b/modules/ROOT/pages/raise-error-component-reference.adoc
@@ -6,7 +6,7 @@ endif::[]
 
 This Core component generates a Mule Error, as if a failure had occurred, which allows you to customize its description and type.
 
-Note that you only this component to raise core runtime errors, such as `MULE:SECURITY`, `MULE:CONNECTIVITY`, etc, or custom ones.
+Use this component to only raise core runtime errors, such as `MULE:SECURITY`, `MULE:CONNECTIVITY`, etc, or custom ones.
 You cannot raise an error from another connector or module like `FILE:FILE_NOT_FOUND`, `JSON:INVALID_SCHEMA`.
 
 For core runtime errors type, you must use the implicit namespace and identifier, you can only customize its description message. +

--- a/modules/ROOT/pages/raise-error-component-reference.adoc
+++ b/modules/ROOT/pages/raise-error-component-reference.adoc
@@ -10,7 +10,7 @@ Use this component to only raise core runtime errors, such as `MULE:SECURITY`, `
 You cannot raise an error from another connector or module like `FILE:FILE_NOT_FOUND`, `JSON:INVALID_SCHEMA`. You cannot use a connector's existing namespace.
 
 For core runtime errors type, you must use the implicit namespace and identifier, you can only customize the error's description message. +
-For custom error types, you are forced to declare a namespace. The namespace of an error type should help you identify the origin of an error. +
+For custom error types, declare a new namespace. The namespace of an error type should help you identify the origin of an error. +
 You cannot use existing namespaces from connectors or modules, since these have their defined namespaces.
 Once you declare a custom namespace by using it in a `raise-error`, you can use it in other
 `raise-error` components and custom types.

--- a/modules/ROOT/pages/raise-error-component-reference.adoc
+++ b/modules/ROOT/pages/raise-error-component-reference.adoc
@@ -7,11 +7,11 @@ endif::[]
 This Core component generates a Mule Error, as if a failure had occurred, which allows you to customize its description and type.
 
 Use this component to only raise core runtime errors, such as `MULE:SECURITY`, `MULE:CONNECTIVITY`, etc, or custom ones.
-You cannot raise an error from another connector or module like `FILE:FILE_NOT_FOUND`, `JSON:INVALID_SCHEMA`. In fact, you can not use their existing namespace.
+You cannot raise an error from another connector or module like `FILE:FILE_NOT_FOUND`, `JSON:INVALID_SCHEMA`. You cannot use a connector's existing namespace.
 
 For core runtime errors type, you must use the implicit namespace and identifier, you can only customize its description message. +
 For custom error types, you are forced to declare a namespace. The namespace of an error type should help you identify the origin of an error. +
-You can not use existing namespaces from connectors or modules, since these have their defined namespaces.
+You cannot use existing namespaces from connectors or modules, since these have their defined namespaces.
 Once you declare a custom namespace by using it in a `raise-error`, you can use it in other
 `raise-error` components and custom types.
 

--- a/modules/ROOT/pages/raise-error-component-reference.adoc
+++ b/modules/ROOT/pages/raise-error-component-reference.adoc
@@ -4,21 +4,15 @@ include::_attributes.adoc[]
 endif::[]
 :keywords: mule, esb, studio, raise, error
 
-This Core component generates a xref:mule-error-concept.adoc[Mule Error], as if a failure had occurred, which allows you to customize its description and type.
+This Core component generates a Mule Error, as if a failure had occurred, which allows you to customize its description and type.
 
-Note that you can only use core types, such as `SECURITY` or custom ones. You cannot raise an
-error from another module like `FILE:FILE_NOT_FOUND`.
+Note that you only this component to raise core runtime errors, such as `MULE:SECURITY`, `MULE:CONNECTIVITY`, etc, or custom ones.
+You cannot raise an error from another connector or module like `FILE:FILE_NOT_FOUND`, `JSON:INVALID_SCHEMA`.
 
-Core errors must use the implicit namespace, while custom ones are forced to declare one.
-The custom error namespace must not be used elsewhere in your app, meaning that you cannot
-use `HTTP` as a namespace if you are using HTTP operations.
-Once you declare a custom namespace by using it in a `raise-error`, you can use it in other
+For core runtime errors type, you must use the implicit namespace and identifier, you can only customize its description message. +
+For custom error types, you are forced to declare one namespace. The namespace of an error type can help you identify the origin of an error. +
+The custom error namespace must not be used elsewhere in your app, meaning that you cannot use `HTTP` as a namespace if you are using HTTP operations for example. Once you declare a custom namespace by using it in a `raise-error`, you can use it in other
 `raise-error` components and custom types.
-
-Use the Raise Error component when you want your application to throw customized errors, besides the default automatic errors that are returned.
-As an example, if your application uses a HTTP connector and an error occurs, the connector throws its default automatic errors, for example `HTTP: NOT_FOUND` so you can not create a customized error using the same system namespace `HTTP`, for example `HTTP:MY_ERROR`. As a result, you have to create your own namespace for your customized error, for example `MYERROR:400HTTP`. Once set, and if there is an issue with the app connector, it will throw both the automatic default error and your own customized one.
-Review each connector documentation to identify the list of error types that a connector can throw when an app fails.
-
 
 The following example flow produces an `ACCOUNT:INSUFFICIENT_FUNDS` error when a
 transfer amount surpasses the available balance, preventing the transfer from
@@ -39,6 +33,14 @@ expression with failure details.
 </flow>
 ----
 
+This example raises an error with a static description and features a custom type using
+the `ORDERS` namespace:
+
+[source,xml,linenums]
+----
+ <raise-error description="Email is invalid. Cannot complete transaction." type="ORDER:INVALID_DATA"/>
+----
+
 == Raise Error Configuration
 
 [%header,cols="1,1,2,2"]
@@ -53,10 +55,5 @@ expression with failure details.
 
 |===
 
-This example raises an error with a static description and features a custom type using
-the `ORDERS` namespace:
-
-[source,xml,linenums]
-----
- <raise-error description="Email is invalid. Cannot complete transaction." type="ORDER:INVALID_DATA"/>
-----
+== See also
+xref:mule-error-concept.adoc[Mule Error]

--- a/modules/ROOT/pages/raise-error-component-reference.adoc
+++ b/modules/ROOT/pages/raise-error-component-reference.adoc
@@ -7,11 +7,12 @@ endif::[]
 This Core component generates a Mule Error, as if a failure had occurred, which allows you to customize its description and type.
 
 Use this component to only raise core runtime errors, such as `MULE:SECURITY`, `MULE:CONNECTIVITY`, etc, or custom ones.
-You cannot raise an error from another connector or module like `FILE:FILE_NOT_FOUND`, `JSON:INVALID_SCHEMA`.
+You cannot raise an error from another connector or module like `FILE:FILE_NOT_FOUND`, `JSON:INVALID_SCHEMA`. In fact, you can not use their existing namespace.
 
 For core runtime errors type, you must use the implicit namespace and identifier, you can only customize its description message. +
-For custom error types, you are forced to declare one namespace. The namespace of an error type can help you identify the origin of an error. +
-The custom error namespace must not be used elsewhere in your app, meaning that you cannot use `HTTP` as a namespace if you are using HTTP operations for example. Once you declare a custom namespace by using it in a `raise-error`, you can use it in other
+For custom error types, you are forced to declare a namespace. The namespace of an error type should help you identify the origin of an error. +
+You can not use existing namespaces from connectors or modules, since these have their defined namespaces.
+Once you declare a custom namespace by using it in a `raise-error`, you can use it in other
 `raise-error` components and custom types.
 
 The following example flow produces an `ACCOUNT:INSUFFICIENT_FUNDS` error when a
@@ -34,7 +35,7 @@ expression with failure details.
 ----
 
 This example raises an error with a static description and features a custom type using
-the `ORDERS` namespace:
+the `ORDER` namespace:
 
 [source,xml,linenums]
 ----

--- a/modules/ROOT/pages/raise-error-component-reference.adoc
+++ b/modules/ROOT/pages/raise-error-component-reference.adoc
@@ -9,7 +9,7 @@ This Core component generates a Mule Error, as if a failure had occurred, which 
 Use this component to only raise core runtime errors, such as `MULE:SECURITY`, `MULE:CONNECTIVITY`, etc, or custom ones.
 You cannot raise an error from another connector or module like `FILE:FILE_NOT_FOUND`, `JSON:INVALID_SCHEMA`. You cannot use a connector's existing namespace.
 
-For core runtime errors type, you must use the implicit namespace and identifier, you can only customize its description message. +
+For core runtime errors type, you must use the implicit namespace and identifier, you can only customize the error's description message. +
 For custom error types, you are forced to declare a namespace. The namespace of an error type should help you identify the origin of an error. +
 You cannot use existing namespaces from connectors or modules, since these have their defined namespaces.
 Once you declare a custom namespace by using it in a `raise-error`, you can use it in other

--- a/modules/ROOT/pages/raise-error-component-reference.adoc
+++ b/modules/ROOT/pages/raise-error-component-reference.adoc
@@ -11,9 +11,14 @@ error from another module like `FILE:FILE_NOT_FOUND`.
 
 Core errors must use the implicit namespace, while custom ones are forced to declare one.
 The custom error namespace must not be used elsewhere in your app, meaning that you cannot
-use `HTTP` as a namespace if you are using HTTP operations, for example. Once you
-declare a custom namespace by using it in a `raise-error`, you can use it in other
+use `HTTP` as a namespace if you are using HTTP operations.
+Once you declare a custom namespace by using it in a `raise-error`, you can use it in other
 `raise-error` components and custom types.
+
+Use the Raise Error component when you want your application to throw customized errors, besides the default automatic errors that are returned.
+As an example, if your application uses a HTTP connector and an error occurs, the connector throws its default automatic errors, for example `HTTP: NOT_FOUND` so you can not create a customized error using the same system namespace `HTTP`, for example `HTTP:MY_ERROR`. As a result, you have to create your own namespace for your customized error, for example `MYERROR:400HTTP`. Once set, and if there is an issue with the app connector, it will throw both the automatic default error and your own customized one.
+Review each connector documentation to identify the list of error types that a connector can throw when an app fails.
+
 
 The following example flow produces an `ACCOUNT:INSUFFICIENT_FUNDS` error when a
 transfer amount surpasses the available balance, preventing the transfer from


### PR DESCRIPTION
Per feedback received from user that wanted to have an example of how to fire a HTTP 400 error. Added a new paragraph explaining additional information regarding the component. 