### PR TITLE
DOCS-5985: Fix typo in scheduler-concept.adoc

### DIFF
--- a/modules/ROOT/pages/scheduler-concept.adoc
+++ b/modules/ROOT/pages/scheduler-concept.adoc
@@ -92,7 +92,7 @@ Note that the Scheduler component also supports Quartz Scheduler special charact
 * `?`: No specific value.
 * `-`: Range of values, for example, `1-3`.
 * `,`: Additional values, for example, `1,7`.
-* `/`: Incremental values, for example, `1,7`.
+* `/`: Incremental values, for example, `1/7`.
 * `L`: Last day of the week or month, or last specific day of the month
   (such as `6L` for the last Saturday of the month).
 * `W`: Weekday, which is valid in the month and day-of-the-week fields.


### PR DESCRIPTION
An example used a comma instead of a /