### PR TITLE
Remove reference to Mule 2.2.2

### DIFF
--- a/modules/ROOT/pages/global-settings-configuration.adoc
+++ b/modules/ROOT/pages/global-settings-configuration.adoc
@@ -41,7 +41,7 @@ Specifies defaults and general settings for the Mule application instance.
 *Type*: `string` +
 *Required*: no +
 *Default*: none
-|`shutdownTimeout` |(As of Mule 2.2.2) The time in milliseconds to wait for any in-progress messages to finish processing before Mule shuts down. After this threshold has been reached, Mule starts interrupting threads, and messages can be lost. If you have a very large number of services in the same Mule instance, if you have components that take more than a couple seconds to process, or if you are using large payloads and/or slower transports, you should increase this value to allow more time for graceful shutdown. The value you specify is applied to services and separately to dispatchers, so the default value of 5000 milliseconds specifies that Mule has ten seconds to process and dispatch messages gracefully after shutdown is initiated. +
+|`shutdownTimeout` |The time in milliseconds to wait for any in-progress messages to finish processing before Mule shuts down. After this threshold has been reached, Mule starts interrupting threads, and messages can be lost. If you have a very large number of services in the same Mule instance, if you have components that take more than a couple seconds to process, or if you are using large payloads and/or slower transports, you should increase this value to allow more time for graceful shutdown. The value you specify is applied to services and separately to dispatchers, so the default value of 5000 milliseconds specifies that Mule has ten seconds to process and dispatch messages gracefully after shutdown is initiated. +
 *Type*: `integer` +
 *Required*: no +
 *Default*: `5000`


### PR DESCRIPTION
This should be removed from all previous Mule versions docs too.