### PR TITLE
DOCS-5172-4.2-DW-mapobject-example-kt

### DIFF
--- a/modules/ROOT/pages/dw-core-functions-mapobject.adoc
+++ b/modules/ROOT/pages/dw-core-functions-mapobject.adoc
@@ -99,7 +99,7 @@ Helper function that allows `mapObject` to work with null values.
 
 === Example
 
-Using the previous example, you can test that if the input of the `mapObject` is `null`, the output result is `null` as well. In XML `null` values by default are written as empty tags, that can be changed using the writer property `writeNilOnNull=true`.
+Using the previous example, you can test that if the input of the `mapObject` is `null`, the output result is `null` as well. In XML `null` values are written as empty tags. You can change these values by using the writer property `writeNilOnNull=true`.
 
 ==== Input
 

--- a/modules/ROOT/pages/dw-core-functions-mapobject.adoc
+++ b/modules/ROOT/pages/dw-core-functions-mapobject.adoc
@@ -97,3 +97,25 @@ output application/xml
 
 Helper function that allows `mapObject` to work with null values.
 
+=== Example
+
+Using the previous example, you can test that if the input of the `mapObject` is `null`, the output result is `null` as well.
+
+==== Input
+
+[source,XML,linenums]
+----
+<?xml version='1.0' encoding='UTF-8'?>
+<prices>
+</prices>
+----
+
+==== Output
+
+[source,XML,linenums]
+----
+<?xml version='1.0' encoding='UTF-8'?>
+<prices>
+  null
+</prices>
+----

--- a/modules/ROOT/pages/dw-core-functions-mapobject.adoc
+++ b/modules/ROOT/pages/dw-core-functions-mapobject.adoc
@@ -116,6 +116,5 @@ Using the previous example, you can test that if the input of the `mapObject` is
 ----
 <?xml version='1.0' encoding='UTF-8'?>
 <prices>
-  null
 </prices>
 ----

--- a/modules/ROOT/pages/dw-core-functions-mapobject.adoc
+++ b/modules/ROOT/pages/dw-core-functions-mapobject.adoc
@@ -99,7 +99,7 @@ Helper function that allows `mapObject` to work with null values.
 
 === Example
 
-Using the previous example, you can test that if the input of the `mapObject` is `null`, the output result is `null` as well.
+Using the previous example, you can test that if the input of the `mapObject` is `null`, the output result is `null` as well. In XML `null` values by default are written as empty tags, that can be changed using the writer property `writeNilOnNull=true`.
 
 ==== Input
 


### PR DESCRIPTION
Adding extra example for mapObject Null.