### PR TITLE
DOCS-6003: Make CloudHub deployment example work

### DIFF
--- a/modules/ROOT/pages/mmp-concept.adoc
+++ b/modules/ROOT/pages/mmp-concept.adoc
@@ -208,6 +208,11 @@ See xref:how-to-export-resources.adoc[Export Resources] to learn more about work
 ----
 <plugin>
   ...
+  <plugin>
+    <groupId>org.mule.tools.maven</groupId>
+    <artifactId>mule-maven-plugin</artifactId>
+    <version>${mule.maven.plugin.version}</version>
+    <extensions>true</extensions>
     <configuration>
         <cloudHubDeployment>
             <uri>https://anypoint.mulesoft.com</uri>
@@ -216,12 +221,14 @@ See xref:how-to-export-resources.adoc[Export Resources] to learn more about work
             <password>${password}</password>
             <applicationName>${cloudhub.application.name}</applicationName>
             <environment>${environment}</environment>
+            <workerType>MICRO</workerType>
             <properties>
                 <key>value</key>
             </properties>
         </cloudHubDeployment>
     </configuration>
-
+  </plugin>
+  ...
 </plugin>
 ----
 +


### PR DESCRIPTION
1) Without the context of the plugin many customers have problems applying this configuration. It should be added to all the examples.
2) Specifically for CloudHub deployments, it will fail without the <workerType> element.