### PR TITLE
DOCS-5989: Remove record variable term

### DIFF
--- a/modules/ROOT/pages/batch-processing-concept.adoc
+++ b/modules/ROOT/pages/batch-processing-concept.adoc
@@ -69,7 +69,7 @@ After all the records have passed through all batch steps, the runtime ends the 
 
 === Error Handling
 
-Batch jobs can handle any record-level failure that might occur in processing to prevent the failure of a complete batch job. Further, you can set or remove variables on individual records so that during batch processing, Mule can route or otherwise act upon records in a batch job according to a record variable. See xref:batch-error-handling-faq.adoc[Handling Errors During Batch Job] for more information.
+Batch jobs can handle any record-level failure that might occur in processing to prevent the failure of a complete batch job. Further, you can set or remove variables on individual records so that during batch processing, Mule can route or otherwise act upon records in a batch job according to the variable assigned above. See xref:batch-error-handling-faq.adoc[Handling Errors During Batch Job] for more information.
 
 
 === Batch Job vs. Batch Job Instance


### PR DESCRIPTION
As record variables are no longer valid in Mule 4, replaced it with variable