### PR TITLE
redirect for removed topic from getting-started

### DIFF
--- a/modules/ROOT/pages/choice-router-concept.adoc
+++ b/modules/ROOT/pages/choice-router-concept.adoc
@@ -2,6 +2,7 @@
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
+:page-aliases: general:getting-started:content-based-routing.adoc
 
 The Choice router dynamically routes messages through a flow according to a set of DataWeave expressions that evaluate message content. Each expression is associated with a different routing option. The effect is to add conditional processing to a flow, similar to an `if`/`then`/`else` code block in most programming languages.
 


### PR DESCRIPTION
PR https://github.com/mulesoft/docs-general/pull/38 removes a topic from general/getting-started, this PR contains the redirect.