### PR TITLE
removing link: 2 of 7

### DIFF
--- a/modules/ROOT/pages/choice-flow-control-reference.adoc
+++ b/modules/ROOT/pages/choice-flow-control-reference.adoc
@@ -247,9 +247,6 @@ Note: Attribute not required in Mule Standalone configuration.
 |===
 =====
 
-[TIP]
-To run and test this example, you might find it useful to take a look at xref:general:getting-started:content-based-routing.adoc[Content-Based Routing]. There you'll find details about the configuration of the other building blocks in the flow, as well as instructions on how to send requests to it.
-
 == Changing the Default Route
 
 You can change the choice flow control configuration to identify a different default routing option.

--- a/modules/ROOT/pages/flow-references.adoc
+++ b/modules/ROOT/pages/flow-references.adoc
@@ -82,12 +82,8 @@ A representation of a subflow in XML looks something like this.
 </sub-flow>
 ----
 
-Note that the Flow Reference connector points to the +sub-flow+ node named "subFlow"
-
+Note that the Flow Reference connector points to the +sub-flow+ node named subFlow.
 =====
-
-For a detailed example in both Studio and XML about how to work with subflows, make sure to check the _Adding a Subflow_ section in our xref:general:getting-started:content-based-routing.adoc[Content-Based Routing].
-
 
 == See Also
 


### PR DESCRIPTION
removing link to getting-started/content-based-routing.adoc Removing from multiple branches so multiple PRs.

mulesoft/docs-general#38 requires these deletions.