### PR TITLE
remove link: 4 of 7

### DIFF
--- a/modules/ROOT/pages/choice-flow-control-reference.adoc
+++ b/modules/ROOT/pages/choice-flow-control-reference.adoc
@@ -241,9 +241,6 @@ Note: Attribute not required in Mule Standalone configuration.
 |===
 =====
 
-[TIP]
-To run and test this example, you might find it useful to take a look at xref:general:getting-started:content-based-routing.adoc[Content-Based Routing]. There you'll find details about the configuration of the other processors in the flow, as well as instructions on how to send requests to it.
-
 == Changing the Default Route
 
 You can change the choice flow control configuration to identify a different default routing option.

--- a/modules/ROOT/pages/flow-references.adoc
+++ b/modules/ROOT/pages/flow-references.adoc
@@ -82,12 +82,9 @@ A representation of a subflow in XML looks something like this.
 </sub-flow>
 ----
 
-Note that the Flow Reference connector points to the +sub-flow+ node named "subFlow"
+Note that the Flow Reference connector points to the +sub-flow+ node named subFlow.
 
 =====
-
-For a detailed example in both Studio and XML about how to work with subflows, make sure to check the _Adding a Subflow_ section in our xref:general:getting-started:content-based-routing.adoc[Content-Based Routing].
-
 
 == See Also
 

--- a/modules/ROOT/pages/glossary.adoc
+++ b/modules/ROOT/pages/glossary.adoc
@@ -40,7 +40,7 @@ A special packaging of the Anypoint Platform is available for running on your ow
 
 === API Designer
 
-Web-based graphical environment for designing, documenting, and testing APIs (see xref:general:getting-started:design-an-api.adoc[Design an API in API Designer])
+Web-based graphical environment for designing, documenting, and testing APIs.
 
 === API Manager
 

--- a/modules/ROOT/pages/scatter-gather.adoc
+++ b/modules/ROOT/pages/scatter-gather.adoc
@@ -305,7 +305,3 @@ Like the All router, this configuration ensures that the routes are invoked sequ
 
 [NOTE]
 Defining a threading profile of only one thread may yield below-par performance results in some situations, since the single thread used by Scatter-Gather is shared across all messages in the flow. If you find that this is the case, it may be desirable to fall back to using the All router for sequential processing. As of Mule version 3.6.0 this issue is fixed.
-
-== See Also
-
-* Learn more about xref:general:getting-started:content-based-routing.adoc[Content-Based Routing]


### PR DESCRIPTION
removing link to getting-started/content-based-routing.adoc Removing from multiple branches so multiple PRs.

mulesoft/docs-general#38 requires these deletions.