### PR TITLE
Update tls-configuration.adoc

### DIFF
--- a/modules/ROOT/pages/tls-configuration.adoc
+++ b/modules/ROOT/pages/tls-configuration.adoc
@@ -96,7 +96,7 @@ keytool -genkey -alias <key-alias> -keystore <keystore-name>.jks
 +
 Replace `<keystore-name>` with the name you want for your keystore. +
 Replace `<key-alias>` with a unique alias of your choice. +
-Keytool generates certificates using the DSA algorithm by default, you can instead specify it to use the RSA algorithm by adding `-keyalg DSA` to the previous command.
+Keytool generates certificates using the DSA algorithm by default, you can instead specify it to use the RSA algorithm by adding `-keyalg RSA` to the previous command.
 
 . Respond to the tool's prompts. The following output shows example responses:
 +


### PR DESCRIPTION
RSA algorithm should be achieved by using -keyalg RSA, not -keyalg DSA, in my opinion. Thus I changed -keyalg DSA to -keyalg RSA.