### PR TITLE
DOCS-5238-4.2-dw-log-function-kt

### DIFF
--- a/modules/ROOT/pages/dw-core-functions-log.adoc
+++ b/modules/ROOT/pages/dw-core-functions-log.adoc
@@ -37,7 +37,7 @@ While the Logger component's `LoggerMessageProcessor` simply returns the value `
 %dw 2.0
 output application/json
 ---
-"WARNING" log("Houston, we have a problem.")
+log("WARNING", "Houston, we have a problem.")
 ----
 
 ==== Output

--- a/modules/ROOT/pages/dw-core-functions-log.adoc
+++ b/modules/ROOT/pages/dw-core-functions-log.adoc
@@ -12,9 +12,9 @@ Without changing the value of the input, `log` returns the input as a system
 log.
 
 
-This function can be used to debug DataWeave scripts until a proper
+Use this function to debug DataWeave scripts until a proper
 debugger is incorporated. The Logger component outputs the results
-through `DefaultLoggingService` through the Logger component
+through `DefaultLoggingService` in the console.
 
 === Parameters
 
@@ -27,11 +27,8 @@ through `DefaultLoggingService` through the Logger component
 
 === Example
 
-This example logs the specified message. The `DefaultLoggingService` for the
-Logger component returns the message
-`WARNING - "Houston, we have a problem."` In
-the console, while the component's `LoggerMessageProcessor` simply returns
-`"Houston, we have a problem."`, without the `WARNING` prefix.
+The following example logs the specified message. In the console, the Logger component's `DefaultLoggingService` returns the message `WARNING - "Houston, we have a problem."` MuleSoft adds the dash `-` between the prefix and value. +
+While the Logger component's `LoggerMessageProcessor` simply returns the value `"Houston, we have a problem."`, without the `WARNING` prefix.
 
 ==== Source
 
@@ -49,4 +46,3 @@ output application/json
 ----
 WARNING - "Houston, we have a problem."
 ----
-


### PR DESCRIPTION
Updating example explanation per customer feedback. Indicating that Mulesoft adds the dash between the prefix and value when the message returns in the Logger component's `DefaultLoggingService`