### PR TITLE
DOCS-3839-4.1-dw-dateformat-example-kt

### DIFF
--- a/modules/ROOT/pages/dw-core-functions-now.adoc
+++ b/modules/ROOT/pages/dw-core-functions-now.adoc
@@ -10,13 +10,34 @@ endif::[]
 
 Returns a `DateTime` object with the current date and time.
 
+=== Example
+
+This example uses `now()` to return the current date and time as a
+`DateTime` value.
+
+==== Source
+
+[source,DataWeave,linenums]
+----
+%dw 2.0
+output application/json
+---
+{ nowCalled: now() }
+----
+
+==== Output
+
+[source,JSON,linenums]
+----
+{ "nowCalled": "2018-11-26T18:23:06.773-03:00" }
+----
 
 === Example
 
 This example shows uses of the `now()` function with valid
 selectors. It also shows how to get the epoch time with `now() as Number`.
-See also,
-https://docs.mulesoft.com/mule-runtime/4.1/dataweave-selectors[DataWeave Selectors].
+For additional examples, see
+https://docs.mulesoft.com/mule-runtime/4.2/dataweave-types#dw_type_dates[Date and Time (dw::Core Types)].
 
 ==== Source
 
@@ -64,4 +85,3 @@ output application/json
   "offsetSeconds": 0
 }
 ----
-

--- a/modules/ROOT/pages/dw-core-functions-now.adoc
+++ b/modules/ROOT/pages/dw-core-functions-now.adoc
@@ -37,7 +37,7 @@ output application/json
 This example shows uses of the `now()` function with valid
 selectors. It also shows how to get the epoch time with `now() as Number`.
 For additional examples, see
-https://docs.mulesoft.com/mule-runtime/4.2/dataweave-types#dw_type_dates[Date and Time (dw::Core Types)].
+https://docs.mulesoft.com/mule-runtime/4.1/dataweave-types#dw_type_dates[Date and Time (dw::Core Types)].
 
 ==== Source
 


### PR DESCRIPTION
Updating example and adding link to additional examples under https://docs.mulesoft.com/mule-runtime/4.1/dataweave-types#dw_type_dates