### PR TITLE
DOCS-5723-4.2-application-deployment-kt

### DIFF
--- a/modules/ROOT/pages/application-deployment.adoc
+++ b/modules/ROOT/pages/application-deployment.adoc
@@ -8,9 +8,9 @@ Learn how to deploy, undeploy and update Mule runtime engine (Mule) applications
 
 == Starting Mule
 
-Start Mule from a command line tool by running `$MULE_HOME/bin/mule` or start Mule as a service. By default, applications in the `$MULE_HOME/apps` directory are deployed, new or updated applications don't start until Mule restarts.
+Start Mule from a command line tool by running `$MULE_HOME/bin/mule` or start Mule as a service. By default, applications in the `$MULE_HOME/apps` directory are deployed.
 
-Use the `mule.deploy.applications` property to start Mule by specifying an app or multiple apps to run (separated by a colon - **:**). Mule 4 respects the order when starting the applications.
+Use the `mule.deploy.applications` property to start Mule by specifying an app or multiple apps to run (separated by a colon - **:**). Mule 4 respects the order when starting the applications. New or updated applications don't start until Mule restarts.
 
 Start Mule by specifying an app to run, for example:
 

--- a/modules/ROOT/pages/application-deployment.adoc
+++ b/modules/ROOT/pages/application-deployment.adoc
@@ -26,7 +26,7 @@ Start Mule by specifying multiple apps to run, for example:
 ----
 mule -M-Dmule.deploy.applications=foo:xoo
 ----
-Where `foo` is a Mule app at `$MULE_HOME/apps/foo` and `xoo` is another Mule app at `$MULE_HOME/apps/xoo`
+Where `foo` is a Mule app at `$MULE_HOME/apps/foo` and `xoo` is another Mule app at `$MULE_HOME/apps/xoo`.
 
 If you start Mule by specifying an app using the `mule.deploy.applications` property, the hot deployment process works only for the specified app.
 

--- a/modules/ROOT/pages/application-deployment.adoc
+++ b/modules/ROOT/pages/application-deployment.adoc
@@ -4,15 +4,15 @@ include::_attributes.adoc[]
 endif::[]
 :keywords: deploy, application, applications, runtime, amc, cloudhub, on premises, on premise
 
-Learn how to deploy, undeploy and update Mule runtime engine (Mule) applications:
+Learn how to deploy, undeploy and update Mule runtime engine (Mule) applications.
 
 == Starting Mule
 
-Start Mule from a command line by running `$MULE_HOME/bin/mule` or starting Mule as a service. By default, applications in the `$MULE_HOME/apps` directory are deployed, new or updated applications don't start until Mule restarts.
+Start Mule from a command line tool by running `$MULE_HOME/bin/mule` or start Mule as a service. By default, applications in the `$MULE_HOME/apps` directory are deployed, new or updated applications don't start until Mule restarts.
 
 Use the `mule.deploy.applications` property to start Mule by specifying an app or multiple apps to run (separated by a colon - **:**). Mule 4 respects the order when starting the applications.
 
-Start Mule by specifying an app to run:
+Start Mule by specifying an app to run, for example:
 
 ----
 mule -M-Dmule.deploy.applications=foo
@@ -22,7 +22,7 @@ Where `foo` is a Mule app at `$MULE_HOME/apps/foo`.
 
 From this moment, Mule checks every three seconds for the `$MULE_HOME/apps/foo/mule-config.xml` updates. You can update the application `jar` contents and modify this file so Mule reloads the config and class modifications.
 
-Start Mule by specifying multiple apps to run:
+Start Mule by specifying multiple apps to run, for example:
 ----
 mule -M-Dmule.deploy.applications=foo:xoo
 ----

--- a/modules/ROOT/pages/application-deployment.adoc
+++ b/modules/ROOT/pages/application-deployment.adoc
@@ -4,9 +4,13 @@ include::_attributes.adoc[]
 endif::[]
 :keywords: deploy, application, applications, runtime, amc, cloudhub, on premises, on premise
 
+Learn how to deploy, undeploy and update Mule runtime engine (Mule) applications:
+
 == Starting Mule
 
-Start Mule by running `<MULE_HOME>/bin/mule` or starting Mule as a service. By default, applications in the `<MULE_HOME>/apps` directory are deployed. You can also designate specific applications to start (separated by a colon - **:**) and Mule 4 respects the order when starting the applications. In this scenario, only the specified applications start.
+Start Mule from a command line by running `$MULE_HOME/bin/mule` or starting Mule as a service. By default, applications in the `$MULE_HOME/apps` directory are deployed, new or updated applications don't start until Mule restarts.
+
+Use the `mule.deploy.applications` property to start Mule by specifying an app or multiple apps to run (separated by a colon - **:**). Mule 4 respects the order when starting the applications.
 
 Start Mule by specifying an app to run:
 
@@ -18,7 +22,14 @@ Where `foo` is a Mule app at `$MULE_HOME/apps/foo`.
 
 From this moment, Mule checks every three seconds for the `$MULE_HOME/apps/foo/mule-config.xml` updates. You can update the application `jar` contents and modify this file so Mule reloads the config and class modifications.
 
-Hot deployment doesn’t work when using the `mule.deploy.applications` property.  Only applications in the `apps` directory are deployed, new or updated applications don't start until Mule restarts.
+Start Mule by specifying multiple apps to run:
+----
+mule -M-Dmule.deploy.applications=foo:xoo
+----
+Where `foo` is a Mule app at `$MULE_HOME/apps/foo` and `xoo` is another Mule app at `$MULE_HOME/apps/xoo`
+
+If you start Mule by specifying an app using the `mule.deploy.applications` property, the hot deployment process works only for the specified app.
+
 
 == Deploying Applications
 

--- a/modules/ROOT/pages/application-deployment.adoc
+++ b/modules/ROOT/pages/application-deployment.adoc
@@ -10,7 +10,7 @@ Learn how to deploy, undeploy and update Mule runtime engine (Mule) applications
 
 Start Mule from a command line tool by running `$MULE_HOME/bin/mule` or start Mule as a service. By default, applications in the `$MULE_HOME/apps` directory are deployed.
 
-Use the `mule.deploy.applications` property to start Mule by specifying an app or multiple apps to run (separated by a colon - **:**). Mule 4 respects the order when starting the applications. New or updated applications don't start until Mule restarts.
+Use the `mule.deploy.applications` property to start Mule by specifying an app or multiple apps to run (separated by a colon `:`). Mule 4 respects the order when starting the applications. New or updated applications don't start until Mule restarts.
 
 Start Mule by specifying an app to run, for example:
 

--- a/modules/ROOT/pages/hot-deployment.adoc
+++ b/modules/ROOT/pages/hot-deployment.adoc
@@ -19,12 +19,16 @@ The application's configuration files are monitored, which means that if there a
 
 == How Hot Deployment works
 
-Mule checks every three seconds for updated configuration files under the `$MULE_HOME/apps` directory, and when it finds one, it reloads the configuration file and the JARs in that applications `java` source directory. To reload an application, you can:
+Mule checks every three seconds for updated configuration files under the `$MULE_HOME/apps` directory, and when it finds one, it reloads the configuration file and the JARs in that applications `java` source directory.
+If you start Mule by specifying an app using the `mule.deploy.applications` property, the hot deployment process works only for the specified app. 
+
+To reload an application, you can:
 
 * Touch the anchor file of that application.
 * Touch or update any of the Mule configuration files declared in the xref:intro-packaging#app_descriptor[`mule-artifact.json`] file.
 
 For example, if you want to modify one of your custom classes, make your changes to the custom class, copy the updated class to the java directory, then touch the anchor file.
+
 
 == See Also
 * xref:application-deployment.adoc[Application Deployment]


### PR DESCRIPTION
Due to external feedback received, I updated  the`application-deployment` and `hot-deployment` docs paragraphs with correct data regarding using `mule.deploy.applications` property  and how the Hot Deployment process works with it.


