### PR TITLE
DOCS 10767 - updating cloudhub deployment

### DIFF
--- a/modules/ROOT/pages/mmp-concept.adoc
+++ b/modules/ROOT/pages/mmp-concept.adoc
@@ -252,6 +252,8 @@ See xref:how-to-export-resources.adoc[Export Resources] to learn more about work
             <username>${username}</username>
             <password>${password}</password>
             <applicationName>${cloudhub.application.name}</applicationName>
+            <businessGroup>${anypoint.businessgroup}</businessGroup>
+            <businessGroupId>${anypoint.businessGroupId}</businessGroupId>            
             <environment>${environment}</environment>
             <properties>
                 <key>value</key>


### PR DESCRIPTION
While deploying application to cloudhub when one only has access to a sub business group specifying the exact hierarchy of the business group with the businessgroupId resolves the **access rights** issue