### PR TITLE
Update anypoint-connectors.adoc

### DIFF
--- a/modules/ROOT/pages/anypoint-connectors.adoc
+++ b/modules/ROOT/pages/anypoint-connectors.adoc
@@ -72,7 +72,7 @@ MuleSoft maintains https://anypoint.mulesoft.com/exchange/?search=select[Select 
 |*Premium*
 |
 
-MuleSoft maintains https://anypoint.mulesoft.com/exchange/?search=premium[Premium connectors]; you must have an active CloudHub Premium plan or an Enterprise subscription with an entitlement for the specific connector you wish to use.
+MuleSoft maintains https://anypoint.mulesoft.com/exchange/?search=premium[Premium connectors]; Premium Connectors must be purchased as add-ons to the subscription.
 |===
 
 == Develop Your Own Connector

--- a/modules/ROOT/pages/anypoint-connectors.adoc
+++ b/modules/ROOT/pages/anypoint-connectors.adoc
@@ -72,7 +72,7 @@ MuleSoft maintains https://anypoint.mulesoft.com/exchange/?search=select[Select 
 |*Premium*
 |
 
-MuleSoft maintains https://anypoint.mulesoft.com/exchange/?search=premium[Premium connectors]; Premium Connectors must be purchased as add-ons to the subscription.
+MuleSoft maintains https://anypoint.mulesoft.com/exchange/?search=category:"Level"="Premium"[Premium connectors]. You must purchase Premium connectors as add-ons to your subscription.
 |===
 
 == Develop Your Own Connector


### PR DESCRIPTION
Replace note on premium connectors regarding “active CloudHub Premium plan” with the fact that Premium Connectors must be purchased as Add-Ons to the subscription.