### PR TITLE
DOCS-2754-3.9-MEL-time-functions-descriptions-kt

### DIFF
--- a/modules/ROOT/pages/mule-expression-language-date-and-time-functions.adoc
+++ b/modules/ROOT/pages/mule-expression-language-date-and-time-functions.adoc
@@ -402,7 +402,7 @@ Equivalent to http://docs.oracle.com/javase/8/docs/api/java/util/Calendar.html#a
 |===
 |Function |Description |Return Type
 |`withTimeZone(timezone);` a|
-Changes the current DateTime to match a defined timezone. Effectively changing the dateTime and the timezone of the instance.
+Changes the timezone of the instance. Effectively changing only the timezone of the instance.
 [%header,cols="20,80"]
 !===
 !Argument !Type
@@ -421,7 +421,7 @@ This allows chaining: server.dateTime.plusWeeks(1).plusDays(1)
 ==========================
 
 |`changeTimeZone(timezone)` a|
-Changes the timezone of the instance. Effectively changing only the timezone of the instance.
+Changes the current DateTime to match a defined timezone. Effectively changing the dateTime and the timezone of the instance.
 [%header,cols="20,80"]
 !===
 !Argument !Type

--- a/modules/ROOT/pages/mule-expression-language-date-and-time-functions.adoc
+++ b/modules/ROOT/pages/mule-expression-language-date-and-time-functions.adoc
@@ -402,7 +402,7 @@ Equivalent to http://docs.oracle.com/javase/8/docs/api/java/util/Calendar.html#a
 |===
 |Function |Description |Return Type
 |`withTimeZone(timezone);` a|
-Changes the timezone of the instance. Effectively changing only the timezone of the instance.
+Changes only the timezone of the instance.
 [%header,cols="20,80"]
 !===
 !Argument !Type
@@ -421,7 +421,7 @@ This allows chaining: server.dateTime.plusWeeks(1).plusDays(1)
 ==========================
 
 |`changeTimeZone(timezone)` a|
-Changes the current DateTime to match a defined timezone. Effectively changing the dateTime and the timezone of the instance.
+Changes the timezone of the instance, and then changes the current DateTime to match the updated timezone.
 [%header,cols="20,80"]
 !===
 !Argument !Type


### PR DESCRIPTION
Due to internal feedback received, I updated the MEL descriptions in the documentation for `withTimeZone` and `changeTimeZone` functions since they might be inverted.

Currently the description for these functions are:
`withTimeZone`: Changes the current DateTime to match a defined timezone. *Effectively changing the dateTime and the timezone of the instance.
`changeTimeZone`: Changes the timezone of the instance. Effectively changing only the timezone of the instance.
But in the tests I made you can see that withTimeZone doesn't change the dateTime but does change the timezone. And when using changeTimeZone both dateTime and timezone are modified.

server.dateTime --> 2019-09-17T10:21:03.716-03:00
server.dateTime.withTimeZone('America/Los_Angeles') --> 2019-09-17T10:21:03.722-07:00
server.dateTime.changeTimeZone('America/Los_Angeles') --> 2019-09-17T06:21:03.728-07:00

INFO  2019-09-17 10:21:03,719 [[mel].HTTP_Listener_Configuration.worker.01] org.mule.api.processor.LoggerMessageProcessor: Timezone 2019-09-17T10:21:03.716-03:00
INFO  2019-09-17 10:21:03,726 [[mel].HTTP_Listener_Configuration.worker.01] org.mule.api.processor.LoggerMessageProcessor: WithTimeZone 2019-09-17T10:21:03.722-07:00
INFO  2019-09-17 10:21:03,729 [[mel].HTTP_Listener_Configuration.worker.01] org.mule.api.processor.LoggerMessageProcessor: ChangeTimeZone 2019-09-17T06:21:03.728-07:00

