### PR TITLE
DOCS-5769-3.9-reliability-patterns-subflow-kt

### DIFF
--- a/modules/ROOT/pages/reliability-patterns.adoc
+++ b/modules/ROOT/pages/reliability-patterns.adoc
@@ -100,7 +100,7 @@ Here is a code example that shows what a complete reliability pattern would look
     </flow>
 
     <!-- This is where the real work of the application will happen. -->
-    <sub-flow name="business-logic-processing" processingStrategy="synchronous">
+    <sub-flow name="business-logic-processing">
         <!--
             This flow is where the actual business-logic is performed.
         -->
@@ -159,7 +159,7 @@ Here is the code for a complete reliability pattern where the the reliable acqui
     </flow>
 
     <!-- This is where the real work of the application will happen. -->
-    <sub-flow name="business-logic-processing" processingStrategy="synchronous">
+    <sub-flow name="business-logic-processing">
         <!--
             This flow is where the actual business-logic is performed.
         -->


### PR DESCRIPTION
Removing incorrect `processingStrategy="synchronous"` from subflow examples since it's causing an error when trying to deploy the applications.
```Attribute 'processingStrategy' is not allowed to appear in element 'sub-flow'```
The processingStrategy is inherited from the main flow to the subsequent subflow. 