### PR TITLE
Corrects encryption algorithm for the example

### DIFF
--- a/modules/ROOT/pages/dw-crypto-functions-hashwith.adoc
+++ b/modules/ROOT/pages/dw-crypto-functions-hashwith.adoc
@@ -42,7 +42,7 @@ This example uses the MD2 algorithm to encrypt a binary value.
 import dw::Crypto
 output application/json
 ---
-{ "md2" : Crypto::hashWith("hello" as Binary, "SHA-256") }
+{ "md2" : Crypto::hashWith("hello" as Binary, "MD2") }
 ----
 
 ==== Output


### PR DESCRIPTION
It was using SHA-256 but the rest of the documentation was mentioning MD2