### PR TITLE
Docs 6003 mmp config examples v4.2

### DIFF
--- a/modules/ROOT/examples/mmp-concept-config.xml
+++ b/modules/ROOT/examples/mmp-concept-config.xml
@@ -1,0 +1,4 @@
+  <groupId>org.mule.tools.maven</groupId>
+  <artifactId>mule-maven-plugin</artifactId>
+  <version>3.3.2</version>
+  <extensions>true</extensions>

--- a/modules/ROOT/pages/_partials/mmp-concept.adoc
+++ b/modules/ROOT/pages/_partials/mmp-concept.adoc
@@ -1,10 +1,3 @@
-// tag::pluginConfig[]
-  <groupId>org.mule.tools.maven</groupId>
-  <artifactId>mule-maven-plugin</artifactId>
-  <version>3.3.2</version>
-  <extensions>true</extensions>
-// end::pluginConfig[]
-
 // tag::propertiesParameterDescription[]
 | `properties` | Top-Level element. +
 If you need to set properties for the Mule application you are deploying, you can use the `<properties>` top-level element:

--- a/modules/ROOT/pages/_partials/mmp-concept.adoc
+++ b/modules/ROOT/pages/_partials/mmp-concept.adoc
@@ -1,0 +1,53 @@
+// tag::pluginConfig[]
+  <groupId>org.mule.tools.maven</groupId>
+  <artifactId>mule-maven-plugin</artifactId>
+  <version>3.3.2</version>
+  <extensions>true</extensions>
+// end::pluginConfig[]
+
+// tag::propertiesParameterDescription[]
+| `properties` | Top-Level element. +
+If you need to set properties for the Mule application you are deploying, you can use the `<properties>` top-level element:
+[source,xml,linenums]
+----
+<properties>
+  <key>value</key>
+</properties>
+----
+
+For example:
+[source,xml,linenums]
+----
+<properties>
+  <http.port>8081</http.port>
+</properties>
+----
+// end::propertiesParameterDescription[]
+
+// tag::businessGroupParameterDescription[]
+| `businessGroup` | The Business group path of the deployment. +
+For example:
+[source,xml,linenums]
+----
+<businessGroup>MasterOrg/SubOrg</businessGroup>
+----
+// end::businessGroupParameterDescription[]
+
+// tag::businessGroupIdParameterDescription[]
+| `businessGroupId` | The Business group id of the deployment. +
+This parameter is available in plugin version 3.2.7 and later.
+// end::businessGroupIdParameterDescription[]
+
+// tag::deploymentTimeoutParameterDescription[]
+| `deploymentTimeout` | The allowed elapsed time, in milliseconds, between the start of the deployment process and the confirmation that the artifact has been deployed.
+
+The default value is `1000000`.
+// end::deploymentTimeoutParameterDescription[]
+
+// tag::serverParameterDescription[]
+| `server` | Maven server with Anypoint Platform credentials. This is only needed if you want to use your credentials stored in your Maven `settings.xml` file. This is not the Mule server name.
+// end::serverParameterDescription[]
+
+// tag::skipParameterDescription[]
+|`skip` | Boolean value. When set to true, skips the plugin deployment goal. Its default value is false.
+// end::skipParameterDescription[]

--- a/modules/ROOT/pages/mmp-concept.adoc
+++ b/modules/ROOT/pages/mmp-concept.adoc
@@ -297,7 +297,7 @@ This name is part of the domain of your deployed app. For example, naming your a
 | `artifact` | Absolute file location of the JAR to be deployed. +
 If not set, by default it is the location of the JAR generated at the package phase
 | `environment` | The CloudHub environment to which you want to deploy.
-include::_partials/mmp-concept.adoc[tag=propertiesParameterDescription]
+include::partial$mmp-concept.adoc[tag=propertiesParameterDescription]
 | `workers` | The number of workers. +
 By default, it is set to 1.
 | `workerType` | Size of each worker. +
@@ -331,11 +331,11 @@ Accepted values are:
 * us-east-2      -  US East (Ohio)
 
 The default value is  us-east-1.
-include::_partials/mmp-concept.adoc[tag=businessGroupParameterDescription]
-include::_partials/mmp-concept.adoc[tag=businessGroupIdParameterDescription]
-include::_partials/mmp-concept.adoc[tag=deploymentTimeoutParameterDescription]
-include::_partials/mmp-concept.adoc[tag=serverParameterDescription]
-include::_partials/mmp-concept.adoc[tag=skipParameterDescription]
+include::partial$mmp-concept.adoc[tag=businessGroupParameterDescription]
+include::partial$mmp-concept.adoc[tag=businessGroupIdParameterDescription]
+include::partial$mmp-concept.adoc[tag=deploymentTimeoutParameterDescription]
+include::partial$mmp-concept.adoc[tag=serverParameterDescription]
+include::partial$mmp-concept.adoc[tag=skipParameterDescription]
 |===
 
 == Deploy a Mule Application to Runtime Fabric
@@ -413,12 +413,12 @@ This name is part of the domain of your deployed app.
 | `environment` | The Anypoint Platform environment to which you want to deploy.
 | `clusteringEnabled` | Enable Mule clustering across each replica of the application. It requires to have at least two replicas. +
 By default, is set to false. +
-include::_partials/mmp-concept.adoc[tag=businessGroupParameterDescription]
-include::_partials/mmp-concept.adoc[tag=businessGroupIdParameterDescription]
-include::_partials/mmp-concept.adoc[tag=deploymentTimeoutParameterDescription]
-include::_partials/mmp-concept.adoc[tag=serverParameterDescription]
-include::_partials/mmp-concept.adoc[tag=propertiesParameterDescription]
-include::_partials/mmp-concept.adoc[tag=skipParameterDescription]
+include::partial$mmp-concept.adoc[tag=businessGroupParameterDescription]
+include::partial$mmp-concept.adoc[tag=businessGroupIdParameterDescription]
+include::partial$mmp-concept.adoc[tag=deploymentTimeoutParameterDescription]
+include::partial$mmp-concept.adoc[tag=serverParameterDescription]
+include::partial$mmp-concept.adoc[tag=propertiesParameterDescription]
+include::partial$mmp-concept.adoc[tag=skipParameterDescription]
 | `deploymentSettings` | See the xref:mmp-concept.adoc#deploymentsettings-reference[deploymentSettings Reference] table below for a complete list of parameters that can be configured inside this element.
 |===
 
@@ -528,8 +528,8 @@ If this value does not match the Mule version running in your deployment target,
 
 The Mule Maven Plugin does not download a Mule runtime engine if these values don't match.
 | `muleHome` | The location of the Mule instance in your local machine.
-include::_partials/mmp-concept.adoc[tag=deploymentTimeoutParameterDescription]
-include::_partials/mmp-concept.adoc[tag=skipParameterDescription]
+include::partial$mmp-concept.adoc[tag=deploymentTimeoutParameterDescription]
+include::partial$mmp-concept.adoc[tag=skipParameterDescription]
 
 |===
 
@@ -599,12 +599,12 @@ Valid values are:
 | `username` | Your username for the server where your Mule instances are installed.
 | `password` | Your password for the server where your Mule instances are installed.
 | `environment` | The environment name for the server where your Mule instances are installed.
-include::_partials/mmp-concept.adoc[tag=businessGroupParameterDescription]
-include::_partials/mmp-concept.adoc[tag=businessGroupIdParameterDescription]
-include::_partials/mmp-concept.adoc[tag=deploymentTimeoutParameterDescription]
-include::_partials/mmp-concept.adoc[tag=serverParameterDescription]
-include::_partials/mmp-concept.adoc[tag=propertiesParameterDescription]
-include::_partials/mmp-concept.adoc[tag=skipParameterDescription]
+include::partial$mmp-concept.adoc[tag=businessGroupParameterDescription]
+include::partial$mmp-concept.adoc[tag=businessGroupIdParameterDescription]
+include::partial$mmp-concept.adoc[tag=deploymentTimeoutParameterDescription]
+include::partial$mmp-concept.adoc[tag=serverParameterDescription]
+include::partial$mmp-concept.adoc[tag=propertiesParameterDescription]
+include::partial$mmp-concept.adoc[tag=skipParameterDescription]
 |===
 
 == Deploy a Mule Application Using the Mule Agent
@@ -642,8 +642,8 @@ If this value does not match the Mule version running in your deployment target,
 
 The Mule Maven Plugin does not download a Mule runtime engine if these values don't match.
 | `uri` | The server URI where your Mule instances are installed.
-include::_partials/mmp-concept.adoc[tag=deploymentTimeoutParameterDescription]
-include::_partials/mmp-concept.adoc[tag=skipParameterDescription]
+include::partial$mmp-concept.adoc[tag=deploymentTimeoutParameterDescription]
+include::partial$mmp-concept.adoc[tag=skipParameterDescription]
 |===
 
 == Deploy a Domain

--- a/modules/ROOT/pages/mmp-concept.adoc
+++ b/modules/ROOT/pages/mmp-concept.adoc
@@ -33,10 +33,7 @@ To add the Mule Maven Plugin, you need to add its maven dependency to the projec
 [source,xml,linenums]
 ----
 <plugin>
-  <groupId>org.mule.tools.maven</groupId>
-  <artifactId>mule-maven-plugin</artifactId>
-  <version>3.3.2</version>
-  <extensions>true</extensions>
+include::_partials/mmp-concept.adoc[tag=pluginConfig]
 </plugin>
 ----
 
@@ -243,21 +240,20 @@ See xref:how-to-export-resources.adoc[Export Resources] to learn more about work
 [source,xml,linenums]
 ----
 <plugin>
-  ...
-    <configuration>
-        <cloudHubDeployment>
-            <uri>https://anypoint.mulesoft.com</uri>
-            <muleVersion>${app.runtime}</muleVersion>
-            <username>${username}</username>
-            <password>${password}</password>
-            <applicationName>${cloudhub.application.name}</applicationName>
-            <environment>${environment}</environment>
-            <properties>
-                <key>value</key>
-            </properties>
-        </cloudHubDeployment>
-    </configuration>
-
+include::_partials/mmp-concept.adoc[tag=pluginConfig]
+  <configuration>
+      <cloudHubDeployment>
+          <uri>https://anypoint.mulesoft.com</uri>
+          <muleVersion>${app.runtime}</muleVersion>
+          <username>${username}</username>
+          <password>${password}</password>
+          <applicationName>${cloudhub.application.name}</applicationName>
+          <environment>${environment}</environment>
+          <properties>
+              <key>value</key>
+          </properties>
+      </cloudHubDeployment>
+  </configuration>
 </plugin>
 ----
 +
@@ -302,24 +298,7 @@ This name is part of the domain of your deployed app. For example, naming your a
 | `artifact` | Absolute file location of the JAR to be deployed. +
 If not set, by default it is the location of the JAR generated at the package phase
 | `environment` | The CloudHub environment to which you want to deploy.
-// tag::propertiesParameterDescription[]
-| `properties` | Top-Level element. +
-If you need to set properties for the Mule application you are deploying, you can use the `<properties>` top-level element:
-[source,xml,linenums]
-----
-<properties>
-  <key>value</key>
-</properties>
-----
-
-For example:
-[source,xml,linenums]
-----
-<properties>
-  <http.port>8081</http.port>
-</properties>
-----
-// end::propertiesParameterDescription[]
+include::_partials/mmp-concept.adoc[tag=propertiesParameterDescription]
 | `workers` | The number of workers. +
 By default, it is set to 1.
 | `workerType` | Size of each worker. +
@@ -353,29 +332,11 @@ Accepted values are:
 * us-east-2      -  US East (Ohio)
 
 The default value is  us-east-1.
-// tag::businessGroupParameterDescription[]
-| `businessGroup` | The Business group path of the deployment. +
-For example:
-[source,xml,linenums]
-----
-<businessGroup>MasterOrg/SubOrg</businessGroup>
-----
-// end::businessGroupParameterDescription[]
-// tag::businessGroupIdParameterDescription[]
-| `businessGroupId` | The Business group id of the deployment. +
-This parameter is available in plugin version 3.2.7 and later.
-// end::businessGroupIdParameterDescription[]
-// tag::deploymentTimeoutParameterDescription[]
-| `deploymentTimeout` | The allowed elapsed time, in milliseconds, between the start of the deployment process and the confirmation that the artifact has been deployed.
-
-The default value is `1000000`.
-// end::deploymentTimeoutParameterDescription[]
-// tag::serverParameterDescription[]
-| `server` | Maven server with Anypoint Platform credentials. This is only needed if you want to use your credentials stored in your Maven `settings.xml` file. This is not the Mule server name.
-// end::serverParameterDescription[]
-// tag::skipParameterDescription[]
-|`skip` | Boolean value. When set to true, skips the plugin deployment goal. Its default value is false.
-// end::skipParameterDescription[]
+include::_partials/mmp-concept.adoc[tag=businessGroupParameterDescription]
+include::_partials/mmp-concept.adoc[tag=businessGroupIdParameterDescription]
+include::_partials/mmp-concept.adoc[tag=deploymentTimeoutParameterDescription]
+include::_partials/mmp-concept.adoc[tag=serverParameterDescription]
+include::_partials/mmp-concept.adoc[tag=skipParameterDescription]
 |===
 
 == Deploy a Mule Application to Runtime Fabric
@@ -399,27 +360,26 @@ Studio allows you to select only two project types when uploading an application
 [source,xml,linenums]
 ----
 <plugin>
-  ...
-    <configuration>
-        <runtimeFabricDeployment>
-            <uri>https://anypoint.mulesoft.com</uri>
-            <muleVersion>${app.runtime}</muleVersion>
-            <username>${username}</username>
-            <password>${password}</password>
-            <applicationName>${runtime.fabric.application.name}</applicationName>
-            <environment>${environment}</environment>
-            <provider>${provider}</provider>
-            <properties>
-                <key>value</key>
-            </properties>
-            <deploymentSettings>
-                <publicUrl>${app.url}</publicUrl>
-                <cpuReserved>500m</cpuReserved>
-                <memoryReserved>800Mi</memoryReserved>
-            </deploymentSettings>
-        </runtimeFabricDeployment>
-    </configuration>
-
+include::_partials/mmp-concept.adoc[tag=pluginConfig]
+  <configuration>
+      <runtimeFabricDeployment>
+          <uri>https://anypoint.mulesoft.com</uri>
+          <muleVersion>${app.runtime}</muleVersion>
+          <username>${username}</username>
+          <password>${password}</password>
+          <applicationName>${runtime.fabric.application.name}</applicationName>
+          <environment>${environment}</environment>
+          <provider>${provider}</provider>
+          <properties>
+              <key>value</key>
+          </properties>
+          <deploymentSettings>
+              <publicUrl>${app.url}</publicUrl>
+              <cpuReserved>500m</cpuReserved>
+              <memoryReserved>800Mi</memoryReserved>
+          </deploymentSettings>
+      </runtimeFabricDeployment>
+  </configuration>
 </plugin>
 ----
 +
@@ -455,12 +415,12 @@ This name is part of the domain of your deployed app.
 | `environment` | The Anypoint Platform environment to which you want to deploy.
 | `clusteringEnabled` | Enable Mule clustering across each replica of the application. It requires to have at least two replicas. +
 By default, is set to false. +
-include::mule-runtime:ROOT:page$mmp-concept.adoc[tag=businessGroupParameterDescription]
-include::mule-runtime:ROOT:page$mmp-concept.adoc[tag=businessGroupIdParameterDescription]
-include::mule-runtime:ROOT:page$mmp-concept.adoc[tag=deploymentTimeoutParameterDescription]
-include::mule-runtime:ROOT:page$mmp-concept.adoc[tag=serverParameterDescription]
-include::mule-runtime:ROOT:page$mmp-concept.adoc[tag=propertiesParameterDescription]
-include::mule-runtime:ROOT:page$mmp-concept.adoc[tag=skipParameterDescription]
+include::_partials/mmp-concept.adoc[tag=businessGroupParameterDescription]
+include::_partials/mmp-concept.adoc[tag=businessGroupIdParameterDescription]
+include::_partials/mmp-concept.adoc[tag=deploymentTimeoutParameterDescription]
+include::_partials/mmp-concept.adoc[tag=serverParameterDescription]
+include::_partials/mmp-concept.adoc[tag=propertiesParameterDescription]
+include::_partials/mmp-concept.adoc[tag=skipParameterDescription]
 | `deploymentSettings` | See the xref:mmp-concept.adoc#deploymentsettings-reference[deploymentSettings Reference] table below for a complete list of parameters that can be configured inside this element.
 |===
 
@@ -542,14 +502,13 @@ For example:
 [source,xml,linenums]
 ----
 <plugin>
-
+include::_partials/mmp-concept.adoc[tag=pluginConfig]
   <configuration>
     <standaloneDeployment>
       <muleHome>${mule.home.test}</muleHome>
       <muleVersion>${app.runtime}</muleVersion>
     </standaloneDeployment>
   </configuration>
-
 </plugin>
 ----
 +
@@ -572,8 +531,8 @@ If this value does not match the runtime version running in your deployment targ
 
 The Mule Maven Plugin does not download a Mule runtime if these values don't match.
 | `muleHome` | The location of the Mule Runtime instance in your local machine.
-include::mule-runtime:ROOT:page$mmp-concept.adoc[tag=deploymentTimeoutParameterDescription]
-include::mule-runtime:ROOT:page$mmp-concept.adoc[tag=skipParameterDescription]
+include::_partials/mmp-concept.adoc[tag=deploymentTimeoutParameterDescription]
+include::_partials/mmp-concept.adoc[tag=skipParameterDescription]
 
 |===
 
@@ -594,22 +553,21 @@ include::mule-runtime:ROOT:page$mmp-concept.adoc[tag=skipParameterDescription]
 [source,xml,linenums]
 ----
 <plugin>
-  ...
-    <configuration>
-      <armDeployment>
-        <muleVersion>${app.runtime}</muleVersion>
-        <uri>https://anypoint.mulesoft.com</uri>
-        <target>${target}</target>
-        <targetType>${target.type}</targetType>
-        <username>${username}</username>
-        <password>${password}</password>
-        <environment>${environment}</environment>
-        <properties>
-          <key>value</key>
-        </properties>
-      </armDeployment>
-    </configuration>
-
+include::_partials/mmp-concept.adoc[tag=pluginConfig]
+  <configuration>
+    <armDeployment>
+      <muleVersion>${app.runtime}</muleVersion>
+      <uri>https://anypoint.mulesoft.com</uri>
+      <target>${target}</target>
+      <targetType>${target.type}</targetType>
+      <username>${username}</username>
+      <password>${password}</password>
+      <environment>${environment}</environment>
+      <properties>
+        <key>value</key>
+      </properties>
+    </armDeployment>
+  </configuration>
 </plugin>
 ----
 +
@@ -645,12 +603,12 @@ Valid values are:
 | `username` | Your username for the server where your Mule runtime instances are installed.
 | `password` | Your password for the server where your Mule runtime instances are installed.
 | `environment` | The environment name for the server where your Mule runtime instances are installed.
-include::mule-runtime:ROOT:page$mmp-concept.adoc[tag=businessGroupParameterDescription]
-include::mule-runtime:ROOT:page$mmp-concept.adoc[tag=businessGroupIdParameterDescription]
-include::mule-runtime:ROOT:page$mmp-concept.adoc[tag=deploymentTimeoutParameterDescription]
-include::mule-runtime:ROOT:page$mmp-concept.adoc[tag=serverParameterDescription]
-include::mule-runtime:ROOT:page$mmp-concept.adoc[tag=propertiesParameterDescription]
-include::mule-runtime:ROOT:page$mmp-concept.adoc[tag=skipParameterDescription]
+include::_partials/mmp-concept.adoc[tag=businessGroupParameterDescription]
+include::_partials/mmp-concept.adoc[tag=businessGroupIdParameterDescription]
+include::_partials/mmp-concept.adoc[tag=deploymentTimeoutParameterDescription]
+include::_partials/mmp-concept.adoc[tag=serverParameterDescription]
+include::_partials/mmp-concept.adoc[tag=propertiesParameterDescription]
+include::_partials/mmp-concept.adoc[tag=skipParameterDescription]
 |===
 
 == Deploy a Mule Application Using the Mule Agent
@@ -661,13 +619,12 @@ include::mule-runtime:ROOT:page$mmp-concept.adoc[tag=skipParameterDescription]
 [source,xml,linenums]
 ----
 <plugin>
-  ...
+include::_partials/mmp-concept.adoc[tag=pluginConfig]
   <configuration>
     <agentDeployment>
       <uri>http://localhost:9999/</uri>
     </agentDeployment>
   </configuration>
-
 </plugin>
 ----
 +
@@ -690,8 +647,8 @@ If this value does not match the runtime version running in your deployment targ
 
 The Mule Maven Plugin does not download a Mule runtime if these values don't match.
 | `uri` | The server URI where your Mule runtime instances are installed.
-include::mule-runtime:ROOT:page$mmp-concept.adoc[tag=deploymentTimeoutParameterDescription]
-include::mule-runtime:ROOT:page$mmp-concept.adoc[tag=skipParameterDescription]
+include::_partials/mmp-concept.adoc[tag=deploymentTimeoutParameterDescription]
+include::_partials/mmp-concept.adoc[tag=skipParameterDescription]
 |===
 
 == Deploy a Domain
@@ -706,14 +663,13 @@ To deploy a domain, use the same configuration and deployment steps you use when
 [source,xml,linenums]
 ----
 <plugin>
-
+include::_partials/mmp-concept.adoc[tag=pluginConfig]
   <configuration>
     <standaloneDeployment>
       <muleHome>${mule.home.test}</muleHome>
       <muleVersion>${app.runtime}</muleVersion>
     </standaloneDeployment>
   </configuration>
-
 </plugin>
 ----
 +
@@ -786,20 +742,19 @@ Below is an example of a CloudHub Deployment using encrypted credentials:
 [source,xml,linenums]
 ----
 <plugin>
-  ...
-    <configuration>
-        <cloudHubDeployment>
-            <uri>https://anypoint.mulesoft.com</uri>
-            <muleVersion>${app.runtime}</muleVersion>
-            <server>my.anypoint.credentials</server>
-            <applicationName>${cloudhub.application.name}</applicationName>
-            <environment>${environment}</environment>
-            <properties>
-                <key>value</key>
-            </properties>
-        </cloudHubDeployment>
-    </configuration>
-
+include::_partials/mmp-concept.adoc[tag=pluginConfig]
+  <configuration>
+      <cloudHubDeployment>
+          <uri>https://anypoint.mulesoft.com</uri>
+          <muleVersion>${app.runtime}</muleVersion>
+          <server>my.anypoint.credentials</server>
+          <applicationName>${cloudhub.application.name}</applicationName>
+          <environment>${environment}</environment>
+          <properties>
+              <key>value</key>
+          </properties>
+      </cloudHubDeployment>
+  </configuration>
 </plugin>
 ----
 
@@ -856,7 +811,7 @@ You can skip the plugin execution by setting the `skip` parameter to true inside
 [source,xml,linenums]
 ----
 <plugin>
-  ...
+include::_partials/mmp-concept.adoc[tag=pluginConfig]
   <configuration>
     <standaloneDeployment>
       <muleHome>${mule.home.test}</muleHome>
@@ -873,10 +828,7 @@ You can skip the status verification of your deployed app by setting the `skipDe
 [source,xml,linenums]
 ----
 <plugin>
-  <groupId>org.mule.tools.maven</groupId>
-  <artifactId>mule-maven-plugin</artifactId>
-  <version>${mule.maven.plugin.version}</version>
-  <extensions>true</extensions>
+include::_partials/mmp-concept.adoc[tag=pluginConfig]
   <configuration>
     <runtimeFabricDeployment>
       ...
@@ -918,17 +870,17 @@ See the configuration example below:
 [source,xml,linenums]
 ----
 <plugin>
-  ...
-    <configuration>
-      <armDeployment>
-          <target>${target}</target>
-          <targetType>${target.type}</targetType>
-          <username>${username}</username>
-          <password>${password}</password>
-          <environment>${environment}</environment>
-          <armInsecure>true</armInsecure>
-      </armDeployment>
-    </configuration>
+include::_partials/mmp-concept.adoc[tag=pluginConfig]
+  <configuration>
+    <armDeployment>
+        <target>${target}</target>
+        <targetType>${target.type}</targetType>
+        <username>${username}</username>
+        <password>${password}</password>
+        <environment>${environment}</environment>
+        <armInsecure>true</armInsecure>
+    </armDeployment>
+  </configuration>
 </plugin>
 ----
 

--- a/modules/ROOT/pages/mmp-concept.adoc
+++ b/modules/ROOT/pages/mmp-concept.adoc
@@ -3,9 +3,9 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 
-The Mule Maven Plugin enables you to integrate the packaging, testing, and deployment of your Mule applications with your Maven lifecycle. The plugin enables you to deploy your Mule application to different deployment targets such as standalone runtimes, clustered instances, and CloudHub.
+The Mule Maven plugin enables you to integrate the packaging, testing, and deployment of your Mule applications with your Maven lifecycle. With the plugin, you can deploy your Mule application to different deployment targets, such as standalone Mule instances, clustered instances, and CloudHub.
 
-The Mule Maven Plugin supports both Community and Enterprise editions.
+The Mule Maven plugin is compatible with Mule runtime engine(Enterprise Edition) and with Mule Kernel (Community Edition).
 
 == Compatibility
 
@@ -14,7 +14,7 @@ The Mule Maven Plugin supports both Community and Enterprise editions.
 
 == Goals Overview
 
-The Mule Maven Plugin has three goals:
+The Mule Maven plugin has three goals:
 
 * `xref:mmp-concept.adoc#package-goal[package]`
 +
@@ -28,7 +28,7 @@ Automatically removes your application from any of the application deployment ta
 
 == Add the Mule Maven Plugin to a Mule Project
 
-To add the Mule Maven Plugin, you need to add its maven dependency to the project:
+To add the Mule Maven plugin, you need to add its maven dependency to the project:
 
 [source,xml,linenums]
 ----
@@ -49,14 +49,14 @@ From this repository:
 </pluginRepositories>
 ----
 
-This enables the Mule Maven Plugin in your project.
+This enables the Mule Maven plugin in your project.
 
 [IMPORTANT]
 Enable extensions. If `<extensions>true</extensions>` is not present, the plugin does not work.
 
 == Mule Application Packaging
 
-The Mule Maven Plugin can package your Mule application into a deployable JAR file that you can later deploy to a running Mule Runtime. +
+The Mule Maven Plugin can package your Mule application into a deployable JAR file that you can later deploy to a running Mule runtime engine. +
 The package contains the application and all its dependencies whether those be JAR files required by the application or by its plugins.
 
 Every Mule application has two descriptors. These descriptors tell the plugin how to handle your Mule application's dependencies.
@@ -69,12 +69,12 @@ This file describes all the dependencies required by the package to work properl
 
 === Package a Mule Application
 
-. Make sure you added the Mule Maven Plugin to your `pom.xml` file.
-. From the command line in your project's folder, run the package goal:
+. Make sure you added the Mule Maven plugin to your `pom.xml` file.
+. From the command line in your project's folder, execute the package goal:
 +
 [source,console,linenums]
 ----
-$ mvn clean package
+mvn clean package
 ----
 
 The plugin packages your application and creates the deployable JAR file into the target directory within your project's folder. +
@@ -86,7 +86,7 @@ To generate a JAR file that can be imported into Anypoint Studio, you need to pa
 From the command line in your project's folder, run:
 [source,console,linenums]
 ----
-$ mvn clean package -DattachMuleSources
+mvn clean package -DattachMuleSources
 ----
 
 The `-DattachMuleSources` parameter tells the plugin to add a `mule-src` folder inside the `META-INF` directory with an exact copy of your application structure at design time. This option also packages project modules and dependencies required to create a functioning Mule deployable archive file that can be deployed into a Mule runtime engine.
@@ -98,7 +98,7 @@ You can skip bundling the actual modules and external dependencies required to r
 From the command line in your project's folder, run:
 [source,console,linenums]
 ----
-$ mvn clean package -DlightweightPackage
+mvn clean package -DlightweightPackage
 ----
 
 When you specify this parameter, the plugin creates a lightweight JAR file that does not include any dependencies declared in the Mule application's `pom.xml` file. This JAR file cannot be deployed to a Mule runtime engine, it only offers a way to archive just the Mule application's source files. The result of this Maven parameter is the same as unchecking *Include project modules and dependencies* when exporting the Mule application from Anypoint Studio.
@@ -110,7 +110,7 @@ You can also combine the parameters together to create a lightweight Mule applic
 From the command line in your project's folder, run:
 [source,console,linenums]
 ----
-$ mvn clean package -DattachMuleSources -DlightweightPackage
+mvn clean package -DattachMuleSources -DlightweightPackage
 ----
 == Mule Application Structure Reference
 
@@ -197,7 +197,7 @@ This folder also contains files describing metadata being referenced in the `mul
 
 == Mule Application Deployment
 
-The Mule Maven Plugin allows you to automate the deployment of your Mule application to any of the application deployment targets (CloudHub, Runtime Fabric, or On-Premises). +
+The Mule Maven plugin allows you to automate the deployment of your Mule application to any of the application deployment targets (CloudHub, Runtime Fabric, or On-Premises). +
 
 By default, this plugin allows you to deploy using five different deployment strategies:
 
@@ -213,7 +213,7 @@ This deployment strategy only works if all your Mule instances live under the sa
 * Standalone runtime deployment. +
 Deploy to a Mule instance running on your machine.
 
-When deploying an application using the Mule Maven Plugin you need to specify a valid deployment configuration in your `pom.xml` file. +
+When deploying an application using the Mule Maven plugin you need to specify a valid deployment configuration in your `pom.xml` file. +
 You can set up a deployment configuration using their dedicated deployment references.
 
 == Deploy a Mule Application to CloudHub
@@ -234,8 +234,8 @@ See xref:how-to-export-resources.adoc[Export Resources] to learn more about work
 
 === Deploying to CloudHub
 
-. Make sure you added the Mule Maven Plugin to your `pom.xml` file.
-. Inside the plugin element, add a configuration for your CloudHub deployment as shown below:
+. Make sure you added the Mule Maven plugin to your `pom.xml` file.
+. Inside the `plugin` element, add a configuration for your CloudHub deployment, replacing the placeholder values with your CloudHub information:
 +
 [source,xml,linenums]
 ----
@@ -257,12 +257,11 @@ include::_partials/mmp-concept.adoc[tag=pluginConfig]
 </plugin>
 ----
 +
-The example is using placeholder values. Configure each value with your CloudHub information.
-. From the command line in your project's folder, package the app and run the deploy goal:
+. From the command line in your project's folder, package the app and execute the deploy goal:
 +
 [source,console,linenums]
 ----
-$ mvn clean package deploy -DmuleDeploy
+mvn clean package deploy -DmuleDeploy
 ----
 
 === Redeploying to CloudHub
@@ -276,10 +275,10 @@ To undeploy an app, run the following command:
 
 [source,console,linenums]
 ----
-$ mvn mule:undeploy
+mvn mule:undeploy
 ----
 
-The undeploy command also deletes the app in Mule Maven Plugin 3.3.0 and later versions.
+The undeploy command also deletes the app in Mule Maven plugin 3.3.0 and later versions.
 
 === CloudHub Deployment Reference
 
@@ -289,8 +288,8 @@ The undeploy command also deletes the app in Mule Maven Plugin 3.3.0 and later v
 |`cloudHubDeployment` | Top-Level Element.
 | `uri` | Your Anypoint Platform URI. +
 If not set, by default this value is set to +https://anypoint.mulesoft.com+.
-| `muleVersion` | The Mule runtime version that will run in your CloudHub instance. +
-You need to ensure that this value is equal to or higher than the minimum required runtime version of your application.
+| `muleVersion` | The Mule version that will run in your CloudHub instance. +
+You need to ensure that this value is equal to or higher than the minimum required Mule version of your application.
 | `username` | Your CloudHub username.
 | `password` | Your CloudHub password.
 | `applicationName` | The name of your application in CloudHub. +
@@ -354,8 +353,8 @@ Studio allows you to select only two project types when uploading an application
 [[deploying-to-rtf]]
 === Deploying to Runtime Fabric
 
-. Make sure you added the Mule Maven Plugin to your `pom.xml` file.
-. Inside the plugin element, add a configuration for your Runtime Fabric deployment as shown below:
+. Make sure you added the Mule Maven plugin to your `pom.xml` file.
+. Inside the `plugin` element, add a configuration for your Runtime Fabric deployment, replacing the placeholder values with your Runtime Fabric information:
 +
 [source,xml,linenums]
 ----
@@ -383,12 +382,11 @@ include::_partials/mmp-concept.adoc[tag=pluginConfig]
 </plugin>
 ----
 +
-The example is using placeholder values. Configure each value with your Runtime Fabric information.
-. From the command line in your project's folder, package the application and run the deploy goal:
+. From the command line in your project's folder, package the application and execute the deploy goal:
 +
 [source,bash,linenums]
 ----
-$ mvn clean package deploy -DmuleDeploy
+mvn clean package deploy -DmuleDeploy
 ----
 
 === Redeploying to Runtime Fabric
@@ -404,8 +402,8 @@ Runtime Fabric rewrites the application you had deployed.
 |`runtimeFabricDeployment` | Top-Level Element.
 | `uri` | Your Anypoint Platform URI. +
 If not set, by default this value is set to +https://anypoint.mulesoft.com+.
-| `muleVersion` | The Mule runtime version that will run in your Runtime Fabric instance. +
-You need to ensure that this value is equal to or higher than the minimum required runtime version of your application.
+| `muleVersion` | The Mule version that will run in your Runtime Fabric instance. +
+You need to ensure that this value is equal to or higher than the minimum required Mule version of your application.
 | `username` | Your Anypoint Platform username.
 | `password` | Your Anypoint Platform password.
 | `applicationName` | The name of your application deployed in Exchange. +
@@ -494,10 +492,10 @@ For example:
 ----
 |===
 
-== Deploy a Mule Application to a Standalone Mule Runtime
+== Deploy a Mule Application to a Standalone Mule Runtime Engine
 
-. Make sure you added the Mule Maven Plugin to your `pom.xml` file.
-. Inside the plugin element, add a configuration for your standalone deployment as shown below:
+. Make sure you added the Mule Maven plugin to your `pom.xml` file.
+. Inside the `plugin` element, add a configuration for your standalone deployment, replacing the placeholder values with your local Mule runtime engine information:
 +
 [source,xml,linenums]
 ----
@@ -512,12 +510,11 @@ include::_partials/mmp-concept.adoc[tag=pluginConfig]
 </plugin>
 ----
 +
-The example is using placeholder values. Configure each value with your local Mule runtime information.
-. From the command line in your project's folder, package the application and run the deploy goal:
+. From the command line in your project's folder, package the application and execute the deploy goal:
 +
 [source,console,linenums]
 ----
-$ mvn clean package deploy -DmuleDeploy
+mvn clean package deploy -DmuleDeploy
 ----
 
 === Standalone Deployment Reference
@@ -526,11 +523,11 @@ $ mvn clean package deploy -DmuleDeploy
 |===
 |Parameter | Description
 |`standaloneDeployment` | Top-Level Element.
-| `muleVersion` | The Mule runtime version running in your local machine instance. +
-If this value does not match the runtime version running in your deployment target, the plugin raises an exception.
+| `muleVersion` | The Mule version running in your local machine instance. +
+If this value does not match the Mule version running in your deployment target, the plugin raises an exception.
 
-The Mule Maven Plugin does not download a Mule runtime if these values don't match.
-| `muleHome` | The location of the Mule Runtime instance in your local machine.
+The Mule Maven Plugin does not download a Mule runtime engine if these values don't match.
+| `muleHome` | The location of the Mule instance in your local machine.
 include::_partials/mmp-concept.adoc[tag=deploymentTimeoutParameterDescription]
 include::_partials/mmp-concept.adoc[tag=skipParameterDescription]
 
@@ -547,8 +544,8 @@ include::_partials/mmp-concept.adoc[tag=skipParameterDescription]
 
 === Deploying Using the Runtime Manager REST API
 
-. Make sure you added the Mule Maven Plugin to your `pom.xml` file.
-. Inside the plugin element, add a configuration for your Runtime Manager deployment as shown below:
+. Make sure you added the Mule Maven plugin to your `pom.xml` file.
+. Inside the `plugin` element, add a configuration for your Runtime Manager deployment, replacing the placeholder values with your Runtime Manager information:
 +
 [source,xml,linenums]
 ----
@@ -571,12 +568,11 @@ include::_partials/mmp-concept.adoc[tag=pluginConfig]
 </plugin>
 ----
 +
-The example is using placeholder values. Configure each value with your Runtime Manager information.
-. From the command line in your project's folder, package the application and run the deploy goal:
+. From the command line in your project's folder, package the application and execute the deploy goal:
 +
 [source,console,linenums]
 ----
-$ mvn clean package deploy -DmuleDeploy
+mvn clean package deploy -DmuleDeploy
 ----
 
 === Runtime Manager REST API Deployment Reference
@@ -585,13 +581,13 @@ $ mvn clean package deploy -DmuleDeploy
 |===
 |Parameter | Description
 |`armDeployment` | Top-Level Element.
-| `muleVersion` | The runtime version required for your application to run in your deployment target. +
-If this value does not match the runtime version running in your deployment target, the plugin raises an exception.
+| `muleVersion` | The Mule version required for your application to run in your deployment target. +
+If this value does not match the Mule version running in your deployment target, the plugin raises an exception.
 
-The Mule Maven Plugin does not download a Mule runtime if these values don't match.
-| `uri` | The server URI where your Mule runtime instances are installed. +
+The Mule Maven Plugin does not download a Mule runtime engine if these values don't match.
+| `uri` | The server URI where your Mule instances are installed. +
 If not set, by default this value is set to +https://anypoint.mulesoft.com+.
-| `target` | The server name for the server where your Mule runtime instances are installed.
+| `target` | The server name for the server where your Mule instances are installed.
 | `targetType` | The type of target to which you are deploying.
 
 Valid values are:
@@ -600,9 +596,9 @@ Valid values are:
 * serverGroup
 * cluster
 
-| `username` | Your username for the server where your Mule runtime instances are installed.
-| `password` | Your password for the server where your Mule runtime instances are installed.
-| `environment` | The environment name for the server where your Mule runtime instances are installed.
+| `username` | Your username for the server where your Mule instances are installed.
+| `password` | Your password for the server where your Mule instances are installed.
+| `environment` | The environment name for the server where your Mule instances are installed.
 include::_partials/mmp-concept.adoc[tag=businessGroupParameterDescription]
 include::_partials/mmp-concept.adoc[tag=businessGroupIdParameterDescription]
 include::_partials/mmp-concept.adoc[tag=deploymentTimeoutParameterDescription]
@@ -613,8 +609,8 @@ include::_partials/mmp-concept.adoc[tag=skipParameterDescription]
 
 == Deploy a Mule Application Using the Mule Agent
 
-. Make sure you added the Mule Maven Plugin to your `pom.xml` file.
-. Inside the plugin element, add a configuration for your Mule Agent deployment as shown below:
+. Make sure you added the Mule Maven plugin to your `pom.xml` file.
+. Inside the `plugin` element, add a configuration for your Mule Agent deployment, replacing the URI value with your remote server information:
 +
 [source,xml,linenums]
 ----
@@ -628,12 +624,11 @@ include::_partials/mmp-concept.adoc[tag=pluginConfig]
 </plugin>
 ----
 +
-The example is using placeholder values. Configure the URI value with your remote server information.
-. From the command line in your project's folder, package the application and run the deploy goal:
+. From the command line in your project's folder, package the application and execute the deploy goal:
 +
 [source,console,linenums]
 ----
-$ mvn clean package deploy -DmuleDeploy
+mvn clean package deploy -DmuleDeploy
 ----
 
 === Mule Agent Deployment Reference
@@ -642,23 +637,23 @@ $ mvn clean package deploy -DmuleDeploy
 |===
 |Parameter | Description
 |`agentDeployment` | Top-Level Element.
-| `muleVersion` | The runtime version required for your application to run in your deployment target. +
-If this value does not match the runtime version running in your deployment target, the plugin raises an exception.
+| `muleVersion` | The Mule version required for your application to run in your deployment target. +
+If this value does not match the Mule version running in your deployment target, the plugin raises an exception.
 
-The Mule Maven Plugin does not download a Mule runtime if these values don't match.
-| `uri` | The server URI where your Mule runtime instances are installed.
+The Mule Maven Plugin does not download a Mule runtime engine if these values don't match.
+| `uri` | The server URI where your Mule instances are installed.
 include::_partials/mmp-concept.adoc[tag=deploymentTimeoutParameterDescription]
 include::_partials/mmp-concept.adoc[tag=skipParameterDescription]
 |===
 
 == Deploy a Domain
 
-The Mule Maven Plugin supports deploying domains to standalone Mule instances and also when using the Mule agent.
+The Mule Maven plugin supports deploying domains only when using the standalone deployment strategy, or the Mule agent deployment strategy.
 
 To deploy a domain, use the same configuration and deployment steps you use when deploying an application. For example, to deploy a domain to a standalone instance:
 
-. Add the Mule Maven Plugin to your `pom.xml` file.
-. Inside the plugin element, add a configuration for your standalone deployment. For example:
+. Add the Mule Maven plugin to your `pom.xml` file.
+. Inside the `plugin` element, add a configuration for your standalone deployment, replacing the placeholder values with your local Mule runtime engine information:
 +
 [source,xml,linenums]
 ----
@@ -673,12 +668,11 @@ include::_partials/mmp-concept.adoc[tag=pluginConfig]
 </plugin>
 ----
 +
-The example is using placeholder values. Configure each value with your local Mule runtime engine information.
-. From the command line in your project's folder, package the domain and run the deploy goal:
+. From the command line in your project's folder, package the domain and execute the deploy goal:
 +
 [source,console,linenums]
 ----
-$ mvn clean package deploy -DmuleDeploy
+mvn clean package deploy -DmuleDeploy
 ----
 
 == Encrypting Credentials
@@ -689,7 +683,7 @@ To use encrypted credentials when deploying, you need to set up your Maven maste
 . Create a master password for your Maven configuration.
 +
 ----
-$ mvn --encrypt-master-password <yourMasterPassword>
+mvn --encrypt-master-password <yourMasterPassword>
 ----
 +
 Maven returns your master password encrypted:
@@ -710,7 +704,7 @@ Maven returns your master password encrypted:
 . Encrypt your Anypoint platform password:
 +
 ----
-$ mvn --encrypt-password <yourAnypointPlatformPassword>
+mvn --encrypt-password <yourAnypointPlatformPassword>
 ----
 +
 Maven returns your Anypoint platform password encrypted:
@@ -758,13 +752,26 @@ include::_partials/mmp-concept.adoc[tag=pluginConfig]
 </plugin>
 ----
 
-NOTE: Make sure that username and password are not set in the deployment configuration, as they have precedence over the defined server id.
+NOTE: Make sure that the username and password are not set in the deployment configuration, or they will overwrite the defined server ID.
 
-== Mule Maven Plugin Goals Description
+== Mule Maven Plugin Goals
 
-The Mule Maven Plugin has three goals that are explained below: Package, Deploy and Undeploy.
+The Mule Maven plugin has three goals: package, deploy, and undeploy. Each goal accepts parameters that are unique to the desired plugin behavior.
 
-Each goal accepts different parameters that change the plugin behavior. When you provide a parameter from the command line, you have to prepend `-D` to the parameter name.
+To provide a parameter from the command line, prepend `-D` to the parameter name.
+
+=== Package Goal
+
+This goal generates the application JAR file. The package goal binds by default to the http://maven.apache.org/ref/3.6.1/maven-core/lifecycles.html[Maven lifecycle phase]: `package`.
+
+Optional Parameters
+[%header%autowidth.spread,cols="a,a,a"]
+|===
+|Name | Type | Description
+|`onlyMuleSources` | boolean | Generates the application JAR file containing only the source code. This property is just for sharing purposes.
+|`attachMuleSources` | boolean | Attaches the source code inside the generated JAR file.
+|`lightweightPackage` | boolean | Doesn't generate the repository with all the application dependencies inside the JAR file. This property is just for sharing purposes.
+|===
 
 For example, to execute the `package` goal and set the `attachMuleSources` parameter, you run the following command:
 [source,console,linenums]
@@ -772,37 +779,35 @@ For example, to execute the `package` goal and set the `attachMuleSources` param
 mvn package -DattachMuleSources
 ----
 
-=== Package Goal
-
-This goal generates the application JAR file.
-Bind's by default to the http://maven.apache.org/ref/3.6.1/maven-core/lifecycles.html[lifecycle phase]: `package`
-
-.Optional parameters
-[%header%autowidth.spread,cols="a,a,a"]
-|===
-|Parameter | Type | Description
-|`onlyMuleSources` | boolean | Generates the application JAR file containing only the source code. This property is just for sharing purposes.
-|`attachMuleSources` | boolean | Attaches the source code inside the generated JAR file.
-|`lightweightPackage` | boolean | Doesn't generate the repository with all the application dependencies inside the JAR file. This property is just for sharing purpose.
-|===
-
 === Deploy Goal
 
-This goal uploads and deploys the application JAR file to any of the application deployment targets.
-Bind's by default to the http://maven.apache.org/ref/3.6.1/maven-core/lifecycles.html[lifecycle phase]: `deploy`
+This goal uploads and deploys the application JAR file to any of the application deployment targets. The deploy goal binds by default to the http://maven.apache.org/ref/3.6.1/maven-core/lifecycles.html[Maven lifecycle phase]: `deploy`.
 
-.Optional parameters
+Optional Parameters
 [%header%autowidth.spread,cols="a,a,a"]
 |===
-|Parameter | Type | Description
+|Name | Type | Description
 |`artifact` | String | Path to the application JAR file to be deployed. By default is set to the application `target` folder.
-|`muleDeploy` | boolean | Instructs the plugin to deploy using the deployment strategy defined in the plugin configuration. If it is not set, the plugin uploads the artifacts to the repository defined in the `distributionManagement` section on the application's `pom.xml` file.
+|`muleDeploy` | boolean | Instructs the plugin to deploy using the deployment strategy defined in the plugin configuration. If the `muleDeploy` parameter is not set, the plugin uploads the artifacts to the repository defined in the `distributionManagement` section of the application's `pom.xml` file.
 |===
+
+For example, to execute the `deploy` goal and set the `muleDeploy` parameter, you run the following command:
+[source,console,linenums]
+----
+mvn deploy -DmuleDeploy
+----
 
 === Undeploy Goal
 
-This goal removes an application from any of the application deployment targets.
-Uses the information from the plugin configuration to remove the application from the defined deployment targets.
+This goal removes an application from any of the application deployment targets. It uses the information from the plugin configuration to remove the application from the defined deployment target.
+
+To execute the `undeploy` goal, run the following command:
+[source,console,linenums]
+----
+mvn mule:undeploy
+----
+
+The undeploy goal also deletes the app in Mule Maven plugin 3.3.0 and later versions.
 
 == Skipping Plugin Execution
 

--- a/modules/ROOT/pages/mmp-concept.adoc
+++ b/modules/ROOT/pages/mmp-concept.adoc
@@ -33,7 +33,7 @@ To add the Mule Maven plugin, you need to add its maven dependency to the projec
 [source,xml,linenums]
 ----
 <plugin>
-include::_partials/mmp-concept.adoc[tag=pluginConfig]
+include::example$mmp-concept-config.xml[]
 </plugin>
 ----
 
@@ -42,10 +42,10 @@ From this repository:
 [source,xml,linenums]
 ----
 <pluginRepositories>
-    <pluginRepository>
-        <id>mule-public</id>
-        <url>https://repository.mulesoft.org/nexus/content/repositories/releases</url>
-    </pluginRepository>
+  <pluginRepository>
+    <id>mule-public</id>
+    <url>https://repository.mulesoft.org/nexus/content/repositories/releases</url>
+  </pluginRepository>
 </pluginRepositories>
 ----
 
@@ -240,19 +240,19 @@ See xref:how-to-export-resources.adoc[Export Resources] to learn more about work
 [source,xml,linenums]
 ----
 <plugin>
-include::_partials/mmp-concept.adoc[tag=pluginConfig]
+include::example$mmp-concept-config.xml[]
   <configuration>
-      <cloudHubDeployment>
-          <uri>https://anypoint.mulesoft.com</uri>
-          <muleVersion>${app.runtime}</muleVersion>
-          <username>${username}</username>
-          <password>${password}</password>
-          <applicationName>${cloudhub.application.name}</applicationName>
-          <environment>${environment}</environment>
-          <properties>
-              <key>value</key>
-          </properties>
-      </cloudHubDeployment>
+    <cloudHubDeployment>
+      <uri>https://anypoint.mulesoft.com</uri>
+      <muleVersion>${app.runtime}</muleVersion>
+      <username>${username}</username>
+      <password>${password}</password>
+      <applicationName>${cloudhub.application.name}</applicationName>
+      <environment>${environment}</environment>
+      <properties>
+        <key>value</key>
+      </properties>
+    </cloudHubDeployment>
   </configuration>
 </plugin>
 ----
@@ -359,25 +359,25 @@ Studio allows you to select only two project types when uploading an application
 [source,xml,linenums]
 ----
 <plugin>
-include::_partials/mmp-concept.adoc[tag=pluginConfig]
+include::example$mmp-concept-config.xml[]
   <configuration>
-      <runtimeFabricDeployment>
-          <uri>https://anypoint.mulesoft.com</uri>
-          <muleVersion>${app.runtime}</muleVersion>
-          <username>${username}</username>
-          <password>${password}</password>
-          <applicationName>${runtime.fabric.application.name}</applicationName>
-          <environment>${environment}</environment>
-          <provider>${provider}</provider>
-          <properties>
-              <key>value</key>
-          </properties>
-          <deploymentSettings>
-              <publicUrl>${app.url}</publicUrl>
-              <cpuReserved>500m</cpuReserved>
-              <memoryReserved>800Mi</memoryReserved>
-          </deploymentSettings>
-      </runtimeFabricDeployment>
+    <runtimeFabricDeployment>
+      <uri>https://anypoint.mulesoft.com</uri>
+      <muleVersion>${app.runtime}</muleVersion>
+      <username>${username}</username>
+      <password>${password}</password>
+      <applicationName>${runtime.fabric.application.name}</applicationName>
+      <environment>${environment}</environment>
+      <provider>${provider}</provider>
+      <properties>
+        <key>value</key>
+      </properties>
+      <deploymentSettings>
+        <publicUrl>${app.url}</publicUrl>
+        <cpuReserved>500m</cpuReserved>
+        <memoryReserved>800Mi</memoryReserved>
+      </deploymentSettings>
+    </runtimeFabricDeployment>
   </configuration>
 </plugin>
 ----
@@ -500,7 +500,7 @@ For example:
 [source,xml,linenums]
 ----
 <plugin>
-include::_partials/mmp-concept.adoc[tag=pluginConfig]
+include::example$mmp-concept-config.xml[]
   <configuration>
     <standaloneDeployment>
       <muleHome>${mule.home.test}</muleHome>
@@ -550,7 +550,7 @@ include::_partials/mmp-concept.adoc[tag=skipParameterDescription]
 [source,xml,linenums]
 ----
 <plugin>
-include::_partials/mmp-concept.adoc[tag=pluginConfig]
+include::example$mmp-concept-config.xml[]
   <configuration>
     <armDeployment>
       <muleVersion>${app.runtime}</muleVersion>
@@ -615,7 +615,7 @@ include::_partials/mmp-concept.adoc[tag=skipParameterDescription]
 [source,xml,linenums]
 ----
 <plugin>
-include::_partials/mmp-concept.adoc[tag=pluginConfig]
+include::example$mmp-concept-config.xml[]
   <configuration>
     <agentDeployment>
       <uri>http://localhost:9999/</uri>
@@ -658,7 +658,7 @@ To deploy a domain, use the same configuration and deployment steps you use when
 [source,xml,linenums]
 ----
 <plugin>
-include::_partials/mmp-concept.adoc[tag=pluginConfig]
+include::example$mmp-concept-config.xml[]
   <configuration>
     <standaloneDeployment>
       <muleHome>${mule.home.test}</muleHome>
@@ -736,7 +736,7 @@ Below is an example of a CloudHub Deployment using encrypted credentials:
 [source,xml,linenums]
 ----
 <plugin>
-include::_partials/mmp-concept.adoc[tag=pluginConfig]
+include::example$mmp-concept-config.xml[]
   <configuration>
       <cloudHubDeployment>
           <uri>https://anypoint.mulesoft.com</uri>
@@ -816,7 +816,7 @@ You can skip the plugin execution by setting the `skip` parameter to true inside
 [source,xml,linenums]
 ----
 <plugin>
-include::_partials/mmp-concept.adoc[tag=pluginConfig]
+include::example$mmp-concept-config.xml[]
   <configuration>
     <standaloneDeployment>
       <muleHome>${mule.home.test}</muleHome>
@@ -833,7 +833,7 @@ You can skip the status verification of your deployed app by setting the `skipDe
 [source,xml,linenums]
 ----
 <plugin>
-include::_partials/mmp-concept.adoc[tag=pluginConfig]
+include::example$mmp-concept-config.xml[]
   <configuration>
     <runtimeFabricDeployment>
       ...
@@ -875,7 +875,7 @@ See the configuration example below:
 [source,xml,linenums]
 ----
 <plugin>
-include::_partials/mmp-concept.adoc[tag=pluginConfig]
+include::example$mmp-concept-config.xml[]
   <configuration>
     <armDeployment>
         <target>${target}</target>

--- a/modules/ROOT/pages/mmp-concept.adoc
+++ b/modules/ROOT/pages/mmp-concept.adoc
@@ -655,7 +655,7 @@ include::_partials/mmp-concept.adoc[tag=skipParameterDescription]
 
 The Mule Maven Plugin supports deploying domains to standalone Mule instances and also when using the Mule agent.
 
-To deploy a domain, use the same configuration and deployment steps you use when deploying an application. For example, to deploy a domain to a Standalone instance:
+To deploy a domain, use the same configuration and deployment steps you use when deploying an application. For example, to deploy a domain to a standalone instance:
 
 . Add the Mule Maven Plugin to your `pom.xml` file.
 . Inside the plugin element, add a configuration for your standalone deployment. For example:
@@ -681,7 +681,7 @@ The example is using placeholder values. Configure each value with your local Mu
 $ mvn clean package deploy -DmuleDeploy
 ----
 
-== Encrypting credentials
+== Encrypting Credentials
 
 Encrypted credentials are available in all platform deployments: CloudHub, Runtime Fabric, and Runtime Manager.
 To use encrypted credentials when deploying, you need to set up your Maven master encrypted password and your `settings-security.xml` file.


### PR DESCRIPTION
Adding plugin config to examples. 
Moved reusable content to _partials/mmp-concept.adoc.
Updated mmp-concept.adoc to reuse content properly.  