### PR TITLE
XA Database example is incorrect

### DIFF
--- a/modules/ROOT/pages/using-bitronix-to-manage-transactions.adoc
+++ b/modules/ROOT/pages/using-bitronix-to-manage-transactions.adoc
@@ -146,10 +146,9 @@ Bitronix integration provides a datasource connection pool for the xref:database
         <spring:property name="databaseName" value="dbName"/>
     </spring:bean>
 
-    <db:generic-config name="DBDefaultPool" dataSource-ref="PostgresDataSource"/>
-
-
     <bti:xa-data-source-pool name="bitronixDataSource" minPoolSize="5" maxPoolSize="15" maxIdleTime="40" acquireIncrement="2" preparedStatementCacheSize="6" acquireTimeoutSeconds="50" dataSource-ref="PostgresDataSource"/>
+
+    <db:generic-config name="DBDefaultPool" dataSource-ref="bitronixDataSource"/>
 
 </mule>
 ----


### PR DESCRIPTION
The database configuration should reference the <bti:xa-data-source-pool> instead of the Spring bean.
This page should be fixed also for the previous Mule versions.