### PR TITLE
Fixed typo in groupId for mule-java-module.

### DIFF
--- a/modules/ROOT/pages/intro-java-integration.adoc
+++ b/modules/ROOT/pages/intro-java-integration.adoc
@@ -124,7 +124,7 @@ To use the Java module, simply add it to your application using the Studio palet
 [source,xml,linenums]
 ----
 <dependency>
-  <groupId>org.mule.modules</groupId>
+  <groupId>org.mule.module</groupId>
   <artifactId>mule-java-module</artifactId>
   <version>1.0.0</version> <!-- or newer -->
   <classifier>mule-plugin</classifier>

--- a/modules/ROOT/pages/migration-mel.adoc
+++ b/modules/ROOT/pages/migration-mel.adoc
@@ -220,7 +220,7 @@ To use the Java module, simply add it to your app using the Studio palette, or a
 [source,xml,linenums]
 ----
 <dependency>
-  <groupId>org.mule.modules</groupId>
+  <groupId>org.mule.module</groupId>
   <artifactId>mule-java-module</artifactId>
   <version>1.0.0</version> <!-- or newer -->
   <classifier>mule-plugin</classifier>


### PR DESCRIPTION
The groupId for mule-java-module is `org.mule.module`.
This might be a typo in the mule-java-module pom.xml since most other modules are located under `org.mule.modules` but as it is the documentation is incorrect..

See 
https://repository.mulesoft.org/nexus/content/repositories/releases/org/mule/module/mule-java-module/