### PR TITLE
Add necessary page-aliases for links from the products

### DIFF
--- a/modules/ROOT/pages/batch-filters-and-batch-aggregator.adoc
+++ b/modules/ROOT/pages/batch-filters-and-batch-aggregator.adoc
@@ -2,6 +2,7 @@
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
+:page-aliases: batch-aggregator-concept.adoc, filter-records-batch-faq.adoc
 
 You can refine the work that a batch step performs upon the records it processes.
 

--- a/modules/ROOT/pages/batch-processing-concept.adoc
+++ b/modules/ROOT/pages/batch-processing-concept.adoc
@@ -3,6 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 :keywords: connectors, anypoint, studio, batch, batch processing
+:page-aliases: batch-job-concept.adoc, batch-execution-order-faq.adoc
 
 [NOTE]
 Batch processing is exclusive to Mule Enterprise runtimes.
@@ -29,8 +30,8 @@ Within a Mule application, batch processing provides a construct for
 asynchronously processing larger-than-memory data sets that are split
 into individual records. Batch jobs allow for the description of a reliable
 process that automatically splits up source data and stores it into persistent
-queues, which makes it possible to process large data sets while providing 
-reliability. In the event that the application is redeployed or Mule crashes, 
+queues, which makes it possible to process large data sets while providing
+reliability. In the event that the application is redeployed or Mule crashes,
 the job execution is able to resume at the point it stopped.
 
 image::batch-main3.png[]

--- a/modules/ROOT/pages/for-each-scope-concept.adoc
+++ b/modules/ROOT/pages/for-each-scope-concept.adoc
@@ -2,6 +2,7 @@
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
+:page-aliases: for-each-scope-xml-reference.adoc
 
 The For Each scope splits a payload into elements and processes them one by one through the components that you place in the scope.
 It is similar to a `for-each`/`for` loop code block in most programming languages and can process any collection, including lists and arrays.


### PR DESCRIPTION
These changes are necessary to handle old paths used from Studio to link to the documentation.

