### PR TITLE
DOCS-6476-4.2-redirects-consume-publish-api-kt

### DIFF
--- a/modules/ROOT/pages/build-application-from-api.adoc
+++ b/modules/ROOT/pages/build-application-from-api.adoc
@@ -3,6 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 :keywords: build, application, api, specification
+:page-aliases: publishing-a-rest-api.adoc, publishing-a-soap-api.adoc
 
 During your app development lifecycle, you can build Mule REST or SOAP APIs from an API specification using APIkit.  You develop APIs based on the following modeling languages:
 

--- a/modules/ROOT/pages/consume-data-from-an-api.adoc
+++ b/modules/ROOT/pages/consume-data-from-an-api.adoc
@@ -2,6 +2,7 @@
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
+:page-aliases: consuming-a-rest-api.adoc, consuming-a-soap-api.adoc
 
 After you build your application, you can start consuming data from an API. Review the following processes to consume data from a SOAP or REST API.
 


### PR DESCRIPTION
Page Aliases for:

location = /mule-runtime/4.2/publishing-a-rest-api { return 301 /mule-runtime/4.2/build-application-from-api; }
location = /mule-runtime/4.2/publishing-a-soap-api { return 301 /mule-runtime/4.2/build-application-from-api; }
location = /mule-runtime/4.2/consuming-a-rest-api { return 301 /mule-runtime/4.2/consume-data-from-an-api; }
location = /mule-runtime/4.2/consuming-a-soap-api { return 301 /mule-runtime/4.2/consume-data-from-an-api; }