### PR TITLE
DOCS-6319-4.2-scheduler-attribute-kt

### DIFF
--- a/modules/ROOT/pages/scheduler-xml-reference.adoc
+++ b/modules/ROOT/pages/scheduler-xml-reference.adoc
@@ -14,7 +14,7 @@ A XML for the Scheduler has these elements:
 |===
 |Attribute |Description |Example
 |`disallowedConcurrentExecution`
-|Skips the next scheduled flow execution if the last one has not ended. Next attempt to execute will be after another frequency period. Default value is `true`
+|Skips the next scheduled flow execution if the last one has not ended. Next attempt to execute will be after another frequency period. Default value is `true`.
 |`disallowConcurrentExecution="true"`
 |===
 

--- a/modules/ROOT/pages/scheduler-xml-reference.adoc
+++ b/modules/ROOT/pages/scheduler-xml-reference.adoc
@@ -14,7 +14,7 @@ A XML for the Scheduler has these elements:
 |===
 |Attribute |Description |Example
 |`disallowedConcurrentExecution`
-|Triggers next scheduler only if the last execution ended.
+|Skips the next scheduled flow execution if the last one has not ended. Default value is `true`
 |`disallowConcurrentExecution="true"`
 |===
 

--- a/modules/ROOT/pages/scheduler-xml-reference.adoc
+++ b/modules/ROOT/pages/scheduler-xml-reference.adoc
@@ -14,7 +14,7 @@ A XML for the Scheduler has these elements:
 |===
 |Attribute |Description |Example
 |`disallowedConcurrentExecution`
-|Skips the next scheduled flow execution if the last one has not ended. Default value is `true`
+|Skips the next scheduled flow execution if the last one has not ended. Next attempt to execute will be after another frequency period. Default value is `true`
 |`disallowConcurrentExecution="true"`
 |===
 

--- a/modules/ROOT/pages/scheduler-xml-reference.adoc
+++ b/modules/ROOT/pages/scheduler-xml-reference.adoc
@@ -9,7 +9,7 @@ A XML for the Scheduler has these elements:
 * `scheduling-strategy` block inside `scheduler`.
 * `fixed-frequency` or `cron` element inside the `scheduling-strategy` block.
 
-== Properties of Scheduler (`<scheduler>`)
+== `<scheduler>` Properties
 [%header,cols="34,33,33"]
 |===
 |Attribute |Description |Example
@@ -34,7 +34,7 @@ A XML for the Scheduler has these elements:
 </mule>
 ----
 
-== Properties of Fixed Frequency (`<fixed-frequency>`)
+== `<fixed-frequency>` Properties
 
 [%header,cols="34,33,33"]
 |===
@@ -73,7 +73,7 @@ MILLISECONDS, SECONDS, MINUTES, HOURS, DAYS
 </mule>
 ----
 
-== Properties of Cron (`<cron>`)
+== `<cron>` Properties
 
 For more complex scheduling strategies, you can use a cron expression.
 

--- a/modules/ROOT/pages/scheduler-xml-reference.adoc
+++ b/modules/ROOT/pages/scheduler-xml-reference.adoc
@@ -9,6 +9,31 @@ A XML for the Scheduler has these elements:
 * `scheduling-strategy` block inside `scheduler`.
 * `fixed-frequency` or `cron` element inside the `scheduling-strategy` block.
 
+== Properties of Scheduler (`<scheduler>`)
+[%header,cols="34,33,33"]
+|===
+|Attribute |Description |Example
+|`disallowedConcurrentExecution`
+|Triggers next scheduler only if the last execution ended.
+|`disallowConcurrentExecution="true"`
+|===
+
+[source,xml,linenums]
+----
+<?xml version="1.0" encoding="UTF-8"?>
+<mule xmlns="http://www.mulesoft.org/schema/mule/core"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd">
+    <flow name="componentsFlow">
+      <scheduler doc:name="Scheduler" disallowConcurrentExecution="true">
+        <scheduling-strategy >
+          <fixed-frequency frequency="1000"/>
+        </scheduling-strategy>
+      </scheduler>
+    </flow>
+</mule>
+----
+
 == Properties of Fixed Frequency (`<fixed-frequency>`)
 
 [%header,cols="34,33,33"]


### PR DESCRIPTION
Per feedback received, adding `disallowedConcurrentExecution` attribute under scheduler reference documentation.
- Added table definition and example code
Also, verified under MuleSoft HC https://help.mulesoft.com/s/question/0D72T000003rnJWSAY/mule-4-scheduller-with-lengthy-jobs