### PR TITLE
DOCS-2131-4.1-configuration-mule-app-kt

### DIFF
--- a/modules/ROOT/pages/intro-configuration.adoc
+++ b/modules/ROOT/pages/intro-configuration.adoc
@@ -3,9 +3,11 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 
-In Mule 3, Spring property placeholders are often used to configure apps dynamically for the environment in which they are deployed. Mule 4 contains a built-in mechanism for this that allows you to set default values and avoid the need to learn Spring.
+In Mule 3, Spring property placeholders are often used to configure apps dynamically for the environment in which they are deployed. Mule 4 contains a built-in mechanism for this that allows you to set default values and avoid the need to learn Spring. +
 
-These properties are stored in a YAML file:
+Mule 3 supports `.properties` configuration files, while Mule 4 supports both `.yaml` and `.properties`  configuration files. The recommended approach is to use `.yaml` configuration files, because it allows the addition of type validations and autocompletion.
+
+Example of a `.yaml` configuration file:
 [source,yaml]
 ----
 http:
@@ -13,13 +15,21 @@ http:
   port: "10000"
 ----
 
-You can add the YAML file to your Mule app through the Global Element called Configuration Properties. The XML for it looks like this:
+You can add the YAML file to your Mule app through the Configuration Properties Global Element. The XML configuration looks like this:
 [source,xml,linenums]
 ----
 <configuration-properties file="myConfiguration.yaml" />
 ----
 
-MuleSoft highly recommends that you do not package the configuration files for all the environments inside your app. Instead, you should use this file to provide defaults, then use Runtime Manager to override each of these properties at deployment time.
+In Mule 3, when you create a new application via Anypoint Studio, it automatically adds a default `mule-app.properties` file that you can use to add your properties for the application. However, in Mule 4 this file is no longer automatically created. +
+If you choose to create a custom `.properties` file, you also need to configure it in your Mule app via the Configuration Properties Global Element. The XML configuration looks like this:
+
+[source,xml,linenums]
+----
+<configuration-properties file="myConfiguration.properties"/>
+----
+
+MuleSoft highly recommends that you do not package the configuration files for all the environments inside your app. Instead, you should use a `.yaml` file to provide defaults, then use Runtime Manager to override each of these properties at deployment time.
 
 
 == See Also

--- a/modules/ROOT/pages/intro-configuration.adoc
+++ b/modules/ROOT/pages/intro-configuration.adoc
@@ -3,11 +3,11 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 
-In Mule 3, Spring property placeholders are often used to configure apps dynamically for the environment in which they are deployed. Mule 4 contains a built-in mechanism for this that allows you to set default values and avoid the need to learn Spring. +
+Although Mule 3 required you to know how to use Spring property placeholders to configure apps dynamically for the environment in which they are deployed, Mule 4 contains a built-in mechanism that enables you to set default values in a YAML file. +
 
 Mule 3 supports `.properties` configuration files, while Mule 4 supports both `.yaml` and `.properties`  configuration files. The recommended approach is to use `.yaml` configuration files, because it allows the addition of type validations and autocompletion.
 
-Example of a `.yaml` configuration file:
+Following is an example of a `.yaml` configuration file:
 [source,yaml]
 ----
 http:
@@ -21,7 +21,7 @@ You can add the YAML file to your Mule app through the Configuration Properties 
 <configuration-properties file="myConfiguration.yaml" />
 ----
 
-In Mule 3, when you create a new application via Anypoint Studio, it automatically adds a default `mule-app.properties` file that you can use to add your properties for the application. However, in Mule 4 this file is no longer automatically created. +
+In Mule 4, creating a new application via Anypoint Studio no longer automatically adds the default `mule-app.properties` file added in Mule 3. +
 If you choose to create a custom `.properties` file, you also need to configure it in your Mule app via the Configuration Properties Global Element. The XML configuration looks like this:
 
 [source,xml,linenums]
@@ -29,7 +29,7 @@ If you choose to create a custom `.properties` file, you also need to configure 
 <configuration-properties file="myConfiguration.properties"/>
 ----
 
-MuleSoft highly recommends that you do not package the configuration files for all the environments inside your app. Instead, you should use a `.yaml` file to provide defaults, then use Runtime Manager to override each of these properties at deployment time.
+MuleSoft recommends that you not package the configuration files for all the environments inside your app. Instead, you should use a `.yaml` file to provide defaults, and then use Runtime Manager to override each of these properties at deployment time.
 
 
 == See Also


### PR DESCRIPTION
Due to internal feedback received I updated the doc file to indicate that in Mule 3.x when you create a new application, Studio automatically adds a `mule-app.properties` file while in Mule 4.x this file is not created anymore. Clients can now create a yaml or properties file and both have to be configured using the Global Elements Configuration Properties.

