### PR TITLE
Update runtime-installation-task.adoc

### DIFF
--- a/modules/ROOT/pages/runtime-installation-task.adoc
+++ b/modules/ROOT/pages/runtime-installation-task.adoc
@@ -28,14 +28,14 @@ Example for version 4.2.0 in the `Downloads` directory:
 +
 [source,console]
 ----
-$ env:MULE_HOME=C:\Downloads\mule-enterprise-standalone-4.2.0\
+$ env:MULE_HOME=C:\Downloads\mule-enterprise-standalone-4.2.0
 ----
 +
 * On Linux/Unix environments:
 +
 [source,console]
 ----
-$ export MULE_HOME=~/Downloads/mule-enterprise-standalone-4.2.0/
+$ export MULE_HOME=~/Downloads/mule-enterprise-standalone-4.2.0
 ----
 
 == Running Mule


### PR DESCRIPTION
The commands for establishing environment variables contains an additional back slash "\\" for Windows and forward slash "/" for the other OS, which then incurs in JAVA error when trying to run the command using the variable as follows:

- COMMAND:
%MULE_HOME%\bin\mule.bat

- ERROR: 
"C:\jdk8u232-b09\bin\java.exe" -Dmule.home="C:\MuleSoft\mule-enterprise-standalone-4.2.2\" -cp .;"C:\MuleSoft\mule-enterprise-standalone-4.2.2\\\conf";"C:\MuleSoft\mule-enterprise-standalone-4.2.2\\\lib\launcher\groovy-all-2.4.15-indy.jar";"C:\MuleSoft\mule-enterprise-standalone-4.2.2\\\lib\boot\commons-cli-1.2.jar" org.codehaus.groovy.tools.GroovyStarter --main groovy.ui.GroovyMain --conf "C:\MuleSoft\mule-enterprise-standalone-4.2.2\\\bin\launcher.conf"