### PR TITLE
Update dataweave-formats.adoc, correct JSON skipNullOn section

### DIFF
--- a/modules/ROOT/pages/dataweave-formats.adoc
+++ b/modules/ROOT/pages/dataweave-formats.adoc
@@ -1490,9 +1490,33 @@ set to three different values: `elements`, `attributes`, or `everywhere`.
 
 When set to:
 
-* `elements`: A key:value pair with a null value is ignored.
-* `attributes`: An XML attribute with a null value is skipped.
-* `everywhere`: Apply this rule to both elements and attributes.
+* `arrays`: Any null value inside arrays is skipped.
+* `objects`: An object key with a null value is skipped.
+* `everywhere`: Apply this rule to both arrays and objects.
+
+.Example: output Directive
+[source,dataweave,linenums]
+----
+output application/json skipNullOn="arrays"
+----
+
+.Example JSON Input
+[source,json,linenums]
+-----
+[
+  null,
+  null,
+  5,
+  {"skipped": null, "kept":12}
+]
+-----
+.Example for JSON output
+In this case, the object key `skipped` is not eliminated.
+[source,json,linenums]
+----
+[ 5,
+   {"skipped": null,"kept": 12}]
+----
 
 === Defining a Metadata Type (for JSON)
 


### PR DESCRIPTION
The skipNullOn section for JSON had a description copied from the XML section. It has been updated to match runtime behaviour and now refers to arrays, objects instead of elements, attributes.

Included is one small examples.