### PR TITLE
DOCS-6733 Incorrect syntax

### DIFF
--- a/modules/ROOT/pages/runtime-installation-task.adoc
+++ b/modules/ROOT/pages/runtime-installation-task.adoc
@@ -27,14 +27,14 @@ Example for version 4.1.5 in the `Downloads` directory:
 +
 [source,console]
 ----
-$ env:MULE_HOME=C:\Downloads\mule-enterprise-standalone-4.1.5\
+$ env:MULE_HOME=C:\Downloads\mule-enterprise-standalone-4.1.5
 ----
 +
 * On Linux/Unix environments:
 +
 [source,console]
 ----
-$ export MULE_HOME=~/Downloads/mule-enterprise-standalone-4.1.5/
+$ export MULE_HOME=~/Downloads/mule-enterprise-standalone-4.1.5
 ----
 
 == Running Mule


### PR DESCRIPTION
Removing additional `/` and `\` characters that cause an error when setting the environment variables.