### PR TITLE
DOCS-2079-3.9-notification-mule-vault-kt

### DIFF
--- a/modules/ROOT/pages/mule-credentials-vault.adoc
+++ b/modules/ROOT/pages/mule-credentials-vault.adoc
@@ -344,7 +344,11 @@ Administrative commands such as the `ps` command in UN*X or the `tasklist` comma
 
 Though the scenarios just mentioned satisfy most of the use cases, there are situations where you need to hide the secret encryption key value from other users of the operating system, that is, you must not show the secret encryption key as a JVM parameter, since it is visible to anyone having access to the process.
 
-A solution for this is to implement a custom secure property placeholder that can read the encryption key in a different way, for example from a file located in a protected folder. This custom implementation must extend `org.mule.modules.security.placeholder.SecurePropertyPlaceholderModule`.
+One solution for this is to implement a custom secure property placeholder that can read the encryption key in a different way, for example from a file located in a protected folder. This custom implementation must extend `org.mule.modules.security.placeholder.SecurePropertyPlaceholderModule`.
+
+Another solution is to set the `mule.runtime.verbose` flag to `false` at Mule startup in order to a void that encryption keys are logged with the system properties.
+
+`./mule -M-Dmule.key=mykey -M-Dmule.runtime.verbose=false`
 
 ==== Using a Custom Secure Property Placeholder
 

--- a/modules/ROOT/pages/mule-credentials-vault.adoc
+++ b/modules/ROOT/pages/mule-credentials-vault.adoc
@@ -344,10 +344,9 @@ Administrative commands such as the `ps` command in UN*X or the `tasklist` comma
 
 Though the scenarios just mentioned satisfy most of the use cases, there are situations where you need to hide the secret encryption key value from other users of the operating system, that is, you must not show the secret encryption key as a JVM parameter, since it is visible to anyone having access to the process.
 
-One solution for this is to implement a custom secure property placeholder that can read the encryption key in a different way, for example from a file located in a protected folder. This custom implementation must extend `org.mule.modules.security.placeholder.SecurePropertyPlaceholderModule`.
+One way to secure the secret encryption key value is to implement a custom secure property placeholder that can read the encryption key in a different way: for example, from a file located in a protected folder. This custom implementation must extend `org.mule.modules.security.placeholder.SecurePropertyPlaceholderModule`.
 
-Another solution is to set the `mule.runtime.verbose` flag to `false` at Mule startup in order to a void that encryption keys are logged with the system properties.
-
+Another solution is to set the `mule.runtime.verbose` flag to `false` at Mule startup, so that encryption keys are not logged with the system properties.
 `./mule -M-Dmule.key=mykey -M-Dmule.runtime.verbose=false`
 
 ==== Using a Custom Secure Property Placeholder
@@ -428,4 +427,4 @@ When the Ops Team Lead starts the Mule runtime, the lead must provide a value fo
 
 * Access the xref:anypoint-enterprise-security-example-application.adoc[example application] which demonstrate Anypoint Enterprise Security in action.
 
-* To configure password encryption in Maven see Apache's https://maven.apache.org/guides/mini/guide-encryption.html[mini-guide] on server password encryption
+* To configure password encryption in Maven, see Apache's https://maven.apache.org/guides/mini/guide-encryption.html[mini-guide] on server password encryption


### PR DESCRIPTION
Per internal feedback received and KB created: https://help.mulesoft.com/s/article/How-to-prevent-system-properties-being-logged-at-startup

Added a clarification note that users can also set `mule.runtime.verbose` to `false` during Mule startup in order to avoid that encryption keys are logged with the system properties.



