### PR TITLE
Remove reconnect notifier in mule 4

### DIFF
--- a/modules/ROOT/pages/reconnection-strategy-reference.adoc
+++ b/modules/ROOT/pages/reconnection-strategy-reference.adoc
@@ -85,20 +85,4 @@ For example:
 </jms:activemq-connector>
 ----
 
-== Reconnect Notifier
 
-A reconnect notifier is called for each reconnection attempt and is also configurable. You can create a custom reconnect notifier that implements the `org.mule.api.retry.RetryNotifier` interface.
-
-The Reconnector notifier element fires a `ConnectionNotification` upon each reconnection attempt.
-There are no attributes or child elements for the notifier element.
-
-For example:
-
-[source,xml,linenums]
-----
-<jms:activemq-connector name="AMQConnector">
-    <reconnect>
-        <reconnect-notifier/>
-    </reconnect>
-</jms:activemq-connector>
-----


### PR DESCRIPTION
Based on a talk with Esteban Wasinger, in mule 4 the reconnection notifier is no available.