### PR TITLE
DOCS-6606-4.1-Intro-Mule-4-update-kt

### DIFF
--- a/modules/ROOT/pages/intro-overview.adoc
+++ b/modules/ROOT/pages/intro-overview.adoc
@@ -3,9 +3,9 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 
-If you are a user that already knows Mule 3 and recently migrated to Mule 4, review the following introduction overview to learn the main changes for this version. +
+If you are a user that already knows Mule 3 and recently migrated to Mule 4, review the following introduction to learn the main changes in Mule 4. +
 
-If you are an experienced Mule 4 user, jump directly to our xref:index.adoc[Mule Runtime] documentation instead.
+If you are an experienced Mule 4 user, go directly to our xref:index.adoc[Mule Runtime] documentation instead.
 
 Mule 4 simplifies the expression language and reduces management complexity so that you can speed up the on-ramping process and deliver applications faster than in Mule 3.
 
@@ -13,10 +13,17 @@ Conceptually, you can think of Mule 4 as an evolution of Mule 3. Many of the cor
 
 This overview takes you through the high-level changes in Mule 4 so that you can quickly learn the basics. It covers these topics:
 
-* xref:intro-mule-message.adoc[Mule Message] - the Mule Message structure has evolved to make it easier to work with properties and to provide more consistency across connectors.
-* xref:intro-expressions.adoc[Expression language] - the Mule Expression Language has been replaced with the DataWeave language so that you work with data and learn Mule more easily.
-* xref:intro-connectors.adoc[Connectors] - the approach to connectivity was unified in Mule 4. Mule 3 transports were replaced with new operation-oriented connectors that are easier to use, have better out-of-the-box defaults, and provide new advanced capabilities.
-* xref:intro-error-handlers.adoc[Error Handling] - easier and more powerful error handling with a new Try scope.
-* xref:intro-dataweave2.adoc[DataWeave] - DataWeave includes minor changes to simplify the syntax and make it easier to learn.
-* xref:intro-studio.adoc[Studio 7] - features a simplified palette, improved Maven integration, and many other usability improvements.
-* xref:intro-engine.adoc[Runtime engine] - the internal execution engine has been updated with a new self-tuning and non-blocking reactive engine. This allows for better performance and scalability out-of-the-box.
+* xref:intro-mule-message.adoc[Mule Message] +
+The Mule Message structure has evolved to make it easier to work with properties and to provide more consistency across connectors.
+* xref:intro-expressions.adoc[Expression language] +
+The Mule Expression Language has been replaced with the DataWeave language so that you work with data and learn Mule more easily.
+* xref:intro-connectors.adoc[Connectors] +
+The approach to connectivity was unified in Mule 4. Mule 3 transports were replaced with new operation-oriented connectors that are easier to use, have better out-of-the-box defaults, and provide new advanced capabilities.
+* xref:intro-error-handlers.adoc[Error Handling] +
+Easier and more powerful error handling with a new Try scope.
+* xref:intro-dataweave2.adoc[DataWeave] +
+DataWeave includes minor changes to simplify the syntax and make it easier to learn.
+* xref:intro-studio.adoc[Studio 7] +
+Features a simplified palette, improved Maven integration, and many other usability improvements.
+* xref:intro-engine.adoc[Runtime engine] +
+The internal execution engine has been updated with a new self-tuning and non-blocking reactive engine. This allows for better performance and scalability out-of-the-box.

--- a/modules/ROOT/pages/intro-overview.adoc
+++ b/modules/ROOT/pages/intro-overview.adoc
@@ -1,7 +1,11 @@
-= Introduction to Mule 4
+= Introduction to Mule 4 for Mule 3 Users
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
+
+If you are a user that already knows Mule 3 and recently migrated to Mule 4, review the following introduction overview to learn the main changes for this version. +
+
+If you are an experienced Mule 4 user, jump directly to our xref:index.adoc[Mule Runtime] documentation instead.
 
 Mule 4 simplifies the expression language and reduces management complexity so that you can speed up the on-ramping process and deliver applications faster than in Mule 3.
 


### PR DESCRIPTION
Per feedback received, I updated the intro text to clarify that this doc is for Mule 3 users that migrated to Mule 4 and give introduction context of Mule 4 changes.