### PR TITLE
Changing order of ARC and Postman

### DIFF
--- a/modules/ROOT/pages/mule-app-tutorial.adoc
+++ b/modules/ROOT/pages/mule-app-tutorial.adoc
@@ -19,7 +19,7 @@ This is the structure we'll transform.
 
 . Download and install xref:7.2@studio::to-download-and-install-studio.adoc[Anypoint Studio].
 . Create https://anypoint.mulesoft.com/login/#/signin?apintent=exchange[an Anypoint Platform trial account] if you don't have one.
-. Choose a REST API client such as Postman or the Advanced REST client. This tutorial uses the Advanced REST client.
+. Choose a REST API client such as Advanced REST Client or Postman. This tutorial uses the Advanced REST Client.
 
 == Step One: Create a Mule 4 Project
 


### PR DESCRIPTION
I would like Advanced REST Client to be mentioned before Postman. 
Also, C in `Client` is also uppercase.