### PR TITLE
DOCS-4432 4.1-redirect update securing-kt

### DIFF
--- a/modules/ROOT/pages/securing.adoc
+++ b/modules/ROOT/pages/securing.adoc
@@ -2,6 +2,9 @@
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
+:keywords: security, securing
+:page-aliases: mule-security.adoc
+
 
 * xref:secure-configuration-properties.adoc[Secure Configuration Properties]
 * xref:cryptography.adoc[Cryptography Module]


### PR DESCRIPTION
Redirect from 3.9 _mule-security_ to 4.1 _securing_