### PR TITLE
DOCS-2112-3.9-DW-update-file-sample-kt

### DIFF
--- a/modules/ROOT/pages/dataweave-flat-file-schemas.adoc
+++ b/modules/ROOT/pages/dataweave-flat-file-schemas.adoc
@@ -18,7 +18,7 @@ In DataWeave, you can bind your input or your output to a flat file schema throu
 ====
 If you intend to use a fixed-width format, you can set up your structure directly through an editor in the UI of the Transform Message component, that makes this a lot easier, just select the `Fixed Width` type. See xref:6@studio::input-output-structure-transformation-studio-task.adoc[To Define Input and Output Structure of a Transformation].
 
-Note that flat file schema files are sensitive to indentation. 
+Note that flat file schema files are sensitive to indentation.
 ====
 
 == Types of Components in a Schema
@@ -438,6 +438,7 @@ Besides the choice of top-level form, you also have choices when it comes to rep
   segments:
   - id: 'HeaderFile'
     name: Header File
+    tag: '0'
     values:
     - { idRef: 'Identifier'}
     - { idRef: 'PriorityCode'}
@@ -449,6 +450,7 @@ Besides the choice of top-level form, you also have choices when it comes to rep
     - { idRef: 'FormatCode'}
   - id: 'Ticket'
     name: Ticket
+    tag: '1'
     values:
     - { idRef: 'Identifier'}
     - { idRef: 'TicketTransactionCode'}
@@ -463,6 +465,7 @@ Besides the choice of top-level form, you also have choices when it comes to rep
     - { idRef: 'TraceNumber'}
   - id: 'Check'
     name: Check
+    tag: '2'
     values:
     - { idRef: 'Identifier'}
     - { idRef: 'Bank'}
@@ -476,6 +479,7 @@ Besides the choice of top-level form, you also have choices when it comes to rep
     - { idRef: 'TraceNumber'}
   - id: 'EndFile'
     name: End File
+    tag: '3'
     values:
     - { idRef: 'Identifier'}
     - { idRef: 'NumberOfBatchs'}


### PR DESCRIPTION
Updated _Referenced vs in-lined Definitions_ file example as it was missing _tag_ definition and was causing errors in the result. 