### PR TITLE
DOCS-2864-4.1-DW-troubleshoot-kt

### DIFF
--- a/modules/ROOT/pages/dataweave-troubleshoot.adoc
+++ b/modules/ROOT/pages/dataweave-troubleshoot.adoc
@@ -1,0 +1,92 @@
+= Troubleshooting a Failing DataWeave Script
+ifndef::env-site,env-github[]
+include::_attributes.adoc[]
+endif::[]
+:keywords: studio, anypoint, esb, transform, transformer, format, aggregate, rename, split, filter convert, xml, json, csv, pojo, java object, metadata, dataweave, data weave, datamapper, dwl, dfl, dw, output structure, input structure, map, mapping
+:page-aliases: dataweave-troubleshooting.adoc
+
+When you troubleshoot a failing script, one challenge to reproducing an error is having the same inputs the script had
+when it executed, especially in production environments where inputs can
+change unexpectedly.
+
+== DataWeave Exceptions
+
+When a function is called with the incorrect kind of argument, it throws the
+exception, `org.mule.weave.v2.exception.UnsupportedTypeCoercionException`.
+Causes of this exception include:
+
+* <<null_arg_not_accepted>>
+* <<mimetype_unset>>
+
+[[null_arg_not_accepted]]
+=== Function Does Not Accept Null Argument
+
+The most common cause of this exception occurs when one of the arguments is
+`Null` and the function does not accept `Null` as an argument. This issue
+results in an error message similar to the following:
+
+[source,weave,linenums]
+----
+You called the function '++' with these arguments:
+  1: Null (null)
+  2: String (" A text")
+
+But it expects one of these combinations:
+  (Array, Array)
+  (Date, Time)
+  (Date, LocalTime)
+  (Date, TimeZone)
+  (LocalDateTime, TimeZone)
+  (LocalTime, Date)
+  (LocalTime, TimeZone)
+  (Object, Object)
+  (String, String)
+  (Time, Date)
+  (TimeZone, LocalDateTime)
+  (TimeZone, Date)
+  (TimeZone, LocalTime)
+
+4| payload.message ++ " A text"
+   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Trace:
+  at main::++ (line: 4, column: 1)
+  at main::main (line: 4, column: 17)
+----
+
+One way to resolve this issue uses the `default` operator. For example,
+using `payload.message default "" ++ " A text"` appends empty text when the
+when the message is null.
+
+[[mimetype_unset]]
+=== MIME Type Is Not Set
+
+When the MIME type is not set, you receive an error message similar to the
+following:
+
+[source,weave, linenums]
+----
+You called the function 'Value Selector' with these arguments:
+  1: String ("{message: 123}")
+  2: Name ("message")
+
+But it expects one of these combinations:
+  (Array, Name)
+  (Array, String)
+  (Date, Name)
+  (DateTime, Name)
+  (LocalDateTime, Name)
+  (LocalTime, Name)
+  (Object, Name)
+  (Object, String)
+  (Period, Name)
+  (Time, Name)
+
+4| payload.message
+   ^^^^^^^^^^^^^^^
+Trace:
+  at main::main (line: 4, column: 1)
+----
+
+When no MIME type is set on the payload, the MIME type defaults to
+`application/java`, and the content is handled as a `String` instead of a
+JSON object.

--- a/modules/ROOT/pages/dataweave-troubleshoot.adoc
+++ b/modules/ROOT/pages/dataweave-troubleshoot.adoc
@@ -53,7 +53,7 @@ Trace:
   at main::main (line: 4, column: 17)
 ----
 
-One way to resolve this issue uses the `default` operator. For example,
+One way to resolve this issue is using the `default` operator. For example,
 using `payload.message default "" ++ " A text"` appends empty text when the
 when the message is null.
 


### PR DESCRIPTION
Adding 4.1 DW Troubleshoot page.
-DataWeave Exceptions.
-Section _Dumping Input Context and the Script into a Folder_ was removed since it's only supported in v4.2
-Added redirect 3.9 dataweave-troubleshooting