### PR TITLE
DOCS-7031-4.2-security-lp-kt

### DIFF
--- a/modules/ROOT/pages/securing.adoc
+++ b/modules/ROOT/pages/securing.adoc
@@ -10,7 +10,7 @@ Security is an important aspect that you must take into account for your applica
 Businesses must ensure that the valuable information they store and make available through software applications and Web services is secure. Locked away and protected from unauthorized users and malicious attackers, protected resources, such as credit card information or Social Security numbers, must still be accessible to authorized legitimate users and systems in order to conduct business transactions. +
 
 To provide secure access to information, applications and services can apply a variety of security measures. Mule runtime engine provides several tools and methods that enable developers to protect applications according to security requirements, prevent security breaches and facilitate authorized access to data.
-Going from securing your application configuration properties to using cryptography capabilities, configuring FIPS 140-2 certified environment, securing flows with Spring Security, configuring TLS cryptographic protocol, obtaining access to protected resource using Oath Authorization Grant Types and configuring the Mule Secure Token Service. 
+Going from securing your application configuration properties to using cryptography capabilities, configuring FIPS 140-2 certified environment, securing flows with Spring Security, configuring TLS cryptographic protocol, obtaining access to protected resource using Oath Authorization Grant Types and configuring the Mule Secure Token Service.
 
 
 == Secure Configuration Properties
@@ -50,7 +50,7 @@ Spring Security provides a number of authentication and authorization providers 
 * xref:setting-up-ldap-provider-for-spring-security.adoc[Configure LDAP Provider for Spring Security] +
 Perform component authorization, or use it as a Mule security provider.
 * xref:component-authorization-using-spring-security.adoc[Component Authorization Using Spring Security] +
-Configure authorization over Mule components using Spring Security features, such as the Authentication Manager or configuring secure components in asynchronous systems.
+Configure authorization using Spring Security features on your Mule components, so that users with different roles can only invoke certain methods.
 
 == TLS Configuration
 TLS is a cryptographic protocol that provides communications security for your Mule app. Mule 4.x supports Transport Layer Security (TLS) 1.1 and 1.2.

--- a/modules/ROOT/pages/securing.adoc
+++ b/modules/ROOT/pages/securing.adoc
@@ -5,47 +5,51 @@ endif::[]
 :keywords: security, securing
 :page-aliases: mule-security.adoc, configuring-security.adoc
 
-Security is an important aspect that you must take into account for your applications. +
+It is critical to ensure that the valuable information that a business stores and makes available through software applications and web services is secure, protected from unauthorized users and malicious attackers. But it is also critical that these protected resources, such as credit card information or Social Security numbers, be immediately accessible to authorized, legitimate users and systems to conduct business transactions. +
 
-Businesses must ensure that the valuable information they store and make available through software applications and Web services is secure. Locked away and protected from unauthorized users and malicious attackers, protected resources, such as credit card information or Social Security numbers, must still be accessible to authorized legitimate users and systems in order to conduct business transactions. +
+To provide secure access to information, applications and services can apply a variety of security measures. Mule runtime engine (Mule) provides several tools and methods that enables you to protect applications:
 
-To provide secure access to information, applications and services can apply a variety of security measures. Mule runtime engine provides several tools and methods that enable developers to protect applications according to security requirements, prevent security breaches and facilitate authorized access to data.
-Going from securing your application configuration properties to using cryptography capabilities, configuring FIPS 140-2 certified environment, securing flows with Spring Security, configuring TLS cryptographic protocol, obtaining access to protected resource using Oath Authorization Grant Types and configuring the Mule Secure Token Service.
+* Securing application configuration properties
+* Using the Cryptography module
+* Configuring a FIPS 140-2 certified environment
+* Securing flows with Spring security
+* Configuring TLS cryptographic protocol
+* Obtaining access to protected resource using Oath Authorization Grant Types
+* Configuring the Mule Secure Token Service
 
 
 == Secure Configuration Properties
-Encrypt configuration properties for your applications. The process involves creating a secure configuration properties file, defining the secure properties in the file and configuring the file in your project with the Mule Secure Configuration Properties Extension module. +
+Encrypting configuration properties for your applications involves creating a secure configuration properties file, defining the secure properties in the file, and configuring the file in your project with the Mule Secure Configuration Properties Extension module. +
 
 See details in xref:secure-configuration-properties.adoc[Secure Configuration Properties]
 
 == Cryptography Module
-The module provides cryptography capabilities to a Mule application. Main capabilities include:
+The Cryptography module provides the following main cryptography capabilities to a Mule application:
 
-* Symmetric encryption and decryption of messages.
-* Asymmetric encryption and decryption of messages.
-* Message signing and signature validation of signed messages. +
+* Symmetric and asymmetric encryption and decryption of messages
+* Message signing and signature validation of signed messages +
 
 This module supports three different strategies to encrypt and sign your messages:
 
 * xref:cryptography-pgp.adoc[PGP] +
- For signature/encryption.
+Provides basic signing and encryption.
 * xref:cryptography-xml.adoc[XML] +
- For signature/encryption of XML documents or elements.
+Provides signing and encryption of XML documents or elements.
 * xref:cryptography-jce.adoc[JCE] +
- For using a wider range of cryptography capabilities provided by the Java Cryptography Extension. +
+Provides the wide range of cryptography capabilities available through the Java Cryptography Extension. +
 
-See details in xref:cryptography.adoc[Cryptography Module]
+See details in xref:cryptography.adoc[Cryptography Module].
 
 == FIPS 140-2 Compliance Support
-Mule 4 can be configured to run in a FIPS 140-2 certified environment. There are two requirements:
+You can configure Mule 4 to run in a FIPS 140-2 certified environment if you meet the following two requirements:
 
-* Have a certified cryptography module installed in your Java environment
-* Adjust Mule settings to run in FIPS security mode
+* A certified cryptography module installed in your Java environment
+* Mule settings adjusted to run in FIPS security mode
 
 See details in xref:fips-140-2-compliance-support.adoc[FIPS 140-2 Compliance Support]
 
 == Spring Security
-Spring Security provides a number of authentication and authorization providers such as JAAS, LDAP, CAS (Yale Central Authentication service), and DAO. The following topics help get you started securing your flows using Spring Security:
+Spring Security provides authentication and authorization via JAAS, LDAP, CAS (Yale Central Authentication service), and DAO. The following topics help get you started securing your flows using Spring Security:
 
 * xref:setting-up-ldap-provider-for-spring-security.adoc[Configure LDAP Provider for Spring Security] +
 Perform component authorization, or use it as a Mule security provider.
@@ -58,11 +62,11 @@ TLS is a cryptographic protocol that provides communications security for your M
 See details in xref:tls-configuration.adoc[TLS Configuration]
 
 == OAuth Authorization Grant Types
-There are four types of authorization grants that an OAuth consumer (a client app) can use to obtain access to a protected resource from an OAuth service provider: Authorization Code, Implicit, Resource Owner Password Credentials and Client Credentials.
+There are four types of authorization grants that an OAuth consumer (a client app) can use to obtain access to a protected resource from an OAuth service provider: Authorization Code, Implicit, Resource Owner Password Credentials, and Client Credentials.
 
 See details in xref:authorization-grant-types.adoc[OAuth Authorization Grant Types]
 
 == Mule Secure Token Service
-Mule supports the OAuth 2.0 protocol. The way to configure OAuth 2.0 authorization differs, depending on the OAuth role and your objective.
+Mule supports the OAuth 2.0 protocol. How you configure OAuth 2.0 authorization depends on your OAuth role and objective.
 
 See details in xref:mule-secure-token-service.adoc[Mule Secure Token Service]

--- a/modules/ROOT/pages/securing.adoc
+++ b/modules/ROOT/pages/securing.adoc
@@ -7,9 +7,10 @@ endif::[]
 
 Security is an important aspect that you must take into account for your applications. +
 
-Businesses must ensure that the valuable information they store and make available through software applications and Web services is secure. Locked away and protected from unauthorized users and malicious attackers, protected resources — such as credit card information or Social Security numbers — must still be accessible to authorized legitimate users and systems in order to conduct business transactions. +
+Businesses must ensure that the valuable information they store and make available through software applications and Web services is secure. Locked away and protected from unauthorized users and malicious attackers, protected resources, such as credit card information or Social Security numbers, must still be accessible to authorized legitimate users and systems in order to conduct business transactions. +
 
-To provide secure access to information, applications and services can apply a variety of security measures. Mule Runtime engine provides several tools and methods that enable developers to protect applications according to security requirements, prevent security breaches and facilitate authorized access to data.
+To provide secure access to information, applications and services can apply a variety of security measures. Mule runtime engine provides several tools and methods that enable developers to protect applications according to security requirements, prevent security breaches and facilitate authorized access to data.
+Going from securing your application configuration properties to using cryptography capabilities, configuring FIPS 140-2 certified environment, securing flows with Spring Security, configuring TLS cryptographic protocol, obtaining access to protected resource using Oath Authorization Grant Types and configuring the Mule Secure Token Service. 
 
 
 == Secure Configuration Properties

--- a/modules/ROOT/pages/securing.adoc
+++ b/modules/ROOT/pages/securing.adoc
@@ -3,12 +3,65 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 :keywords: security, securing
-:page-aliases: mule-security.adoc
+:page-aliases: mule-security.adoc, configuring-security.adoc
 
-* xref:secure-configuration-properties.adoc[Secure Configuration Properties]
-* xref:cryptography.adoc[Cryptography Module]
- ** xref:cryptography-pgp.adoc[PGP]
- ** xref:cryptography-xml.adoc[XML]
- ** xref:cryptography-jce.adoc[JCE]
- ** xref:cryptography-reference.adoc[Crypto Module Documentation Reference]
-* xref:fips-140-2-compliance-support.adoc[FIPS 140-2 Compliance Support]
+Security is an important aspect that you must take into account for your applications. +
+
+Businesses must ensure that the valuable information they store and make available through software applications and Web services is secure. Locked away and protected from unauthorized users and malicious attackers, protected resources — such as credit card information or Social Security numbers — must still be accessible to authorized legitimate users and systems in order to conduct business transactions. +
+
+To provide secure access to information, applications and services can apply a variety of security measures. Mule Runtime engine provides several tools and methods that enable developers to protect applications according to security requirements, prevent security breaches and facilitate authorized access to data.
+
+
+== Secure Configuration Properties
+Encrypt configuration properties for your applications. The process involves creating a secure configuration properties file, defining the secure properties in the file and configuring the file in your project with the Mule Secure Configuration Properties Extension module. +
+
+See details in xref:secure-configuration-properties.adoc[Secure Configuration Properties]
+
+== Cryptography Module
+The module provides cryptography capabilities to a Mule application. Main capabilities include:
+
+* Symmetric encryption and decryption of messages.
+* Asymmetric encryption and decryption of messages.
+* Message signing and signature validation of signed messages. +
+
+This module supports three different strategies to encrypt and sign your messages:
+
+* xref:cryptography-pgp.adoc[PGP] +
+ For signature/encryption.
+* xref:cryptography-xml.adoc[XML] +
+ For signature/encryption of XML documents or elements.
+* xref:cryptography-jce.adoc[JCE] +
+ For using a wider range of cryptography capabilities provided by the Java Cryptography Extension. +
+
+See details in xref:cryptography.adoc[Cryptography Module]
+
+== FIPS 140-2 Compliance Support
+Mule 4 can be configured to run in a FIPS 140-2 certified environment. There are two requirements:
+
+* Have a certified cryptography module installed in your Java environment
+* Adjust Mule settings to run in FIPS security mode
+
+See details in xref:fips-140-2-compliance-support.adoc[FIPS 140-2 Compliance Support]
+
+== Spring Security
+Spring Security provides a number of authentication and authorization providers such as JAAS, LDAP, CAS (Yale Central Authentication service), and DAO. The following topics help get you started securing your flows using Spring Security:
+
+* xref:setting-up-ldap-provider-for-spring-security.adoc[Configure LDAP Provider for Spring Security] +
+Perform component authorization, or use it as a Mule security provider.
+* xref:component-authorization-using-spring-security.adoc[Component Authorization Using Spring Security] +
+Configure authorization over Mule components using Spring Security features, such as the Authentication Manager or configuring secure components in asynchronous systems.
+
+== TLS Configuration
+TLS is a cryptographic protocol that provides communications security for your Mule app. Mule 4.x supports Transport Layer Security (TLS) 1.1 and 1.2.
+
+See details in xref:tls-configuration.adoc[TLS Configuration]
+
+== OAuth Authorization Grant Types
+There are four types of authorization grants that an OAuth consumer (a client app) can use to obtain access to a protected resource from an OAuth service provider: Authorization Code, Implicit, Resource Owner Password Credentials and Client Credentials.
+
+See details in xref:authorization-grant-types.adoc[OAuth Authorization Grant Types]
+
+== Mule Secure Token Service
+Mule supports the OAuth 2.0 protocol. The way to configure OAuth 2.0 authorization differs, depending on the OAuth role and your objective.
+
+See details in xref:mule-secure-token-service.adoc[Mule Secure Token Service]


### PR DESCRIPTION
Creating Security landing page for Mule Runtime v 4.x
- Paragraph intro, doc structure, wording, styling.
- Merged 3.9 pages (_mule-security_ and _configuring-security_ into _securing_) to reduce number of pages and consolidate everything in one page since most of security features changed from 3.9 to 4.x versions.
- Added redirection page for mule-security and configuring-security
- Tested link checker and redirection.
