### PR TITLE
DOCS-7547-4.2-DW-syntax-valueSet-kt

### DIFF
--- a/modules/ROOT/pages/dw-objects-functions-valueset.adoc
+++ b/modules/ROOT/pages/dw-objects-functions-valueset.adoc
@@ -28,7 +28,7 @@ This example returns the values from the input object.
 [source,DataWeave, linenums]
 ----
 %dw 2.0
-import dw::core::Objects
+import * from dw::core::Objects
 output application/json
 ---
 { "valueSet" : valueSet({a: true, b: 1}) }
@@ -40,4 +40,3 @@ output application/json
 ----
 { "valueSet" : [true,1] }
 ----
-


### PR DESCRIPTION
Added * missing for import * from dw::core::Objects valueSet
Bringing changes from https://github.com/mulesoft/data-weave/pull/492