### PR TITLE
DOCS-6709-3.9-build-https-service-kt

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -311,6 +311,7 @@
   *** xref:publishing-a-soap-api.adoc[Publishing a SOAP API]
    **** xref:securing-a-soap-api.adoc[Securing a SOAP API]
    **** xref:extra-cxf-component-configurations.adoc[Extra CXF Component Configurations]
+ ** xref:build-an-https-service.adoc[Build an HTTPS Service]
  ** xref:understanding-mule-configuration.adoc[Understanding Mule Configuration]
   *** xref:about-the-xml-configuration-file.adoc[About the Mule Application XML Configuration File]
   *** xref:configuring-properties.adoc[Configuring Properties]

--- a/modules/ROOT/pages/build-an-https-service.adoc
+++ b/modules/ROOT/pages/build-an-https-service.adoc
@@ -38,9 +38,9 @@ keytool -genkeypair -keystore keystore.jks   -dname "CN=localhost, OU=Unknown, O
 [source,xml,linenums]
 ----
 ...
-<http:listener-config name="HTTPS_Listener_Configuration" protocol="HTTPS" host="0.0.0.0" port="${https.port}" doc:name="HTTP Listener Configuration">
+<http:listener-config name="HTTPS_Listener_Configuration" protocol="HTTPS" host="0.0.0.0" port="${https.port}">
      <tls:context>
-         <tls:key-store path="keystore.jks" keyPassword="${keystore.password}" password="password"/>
+         <tls:key-store path="keystore.jks" keyPassword="${keystore.password}" password="${password}"/>
      </tls:context>
  </http:listener-config>
 ...
@@ -52,7 +52,7 @@ keytool -genkeypair -keystore keystore.jks   -dname "CN=localhost, OU=Unknown, O
 [source,xml,linenums]
 ----
 <flow name="httpsserviceFlow">
-    <http:listener config-ref="HTTPS_Listener_Configuration" path="hello" doc:name="HTTPS_Listener_Configuration"/>
+    <http:listener config-ref="HTTPS_Listener_Configuration" path="hello"/>
 </flow>
 ----
 
@@ -62,9 +62,9 @@ keytool -genkeypair -keystore keystore.jks   -dname "CN=localhost, OU=Unknown, O
 [source,xml,linenums]
 ----
 ...
-<http:request-config name="HTTP_Request_Configuration" protocol="HTTPS" host="0.0.0.0" port="${https.port}" doc:name="HTTP Request Configuration">
+<http:request-config name="HTTP_Request_Configuration" protocol="HTTPS" host="0.0.0.0" port="${https.port}" >
      <tls:context>
-         <tls:key-store path="keystore.jks" password="password" keyPassword="${keystore.password}" />
+         <tls:key-store path="keystore.jks" password="${password}" keyPassword="${keystore.password}" />
      </tls:context>
 </http:request-config>
 ...
@@ -76,7 +76,7 @@ keytool -genkeypair -keystore keystore.jks   -dname "CN=localhost, OU=Unknown, O
 [source,xml,linenums]
 ----
 <flow name="httpsserviceFlow">
-  <http:request config-ref="HTTP_Request_Configuration" path="some-path" method="GET" doc:name="HTTPS_Request_Configuration" host="0.0.0.0" port="${https.port}"/>
+  <http:request config-ref="HTTP_Request_Configuration" path="some-path" method="GET" host="0.0.0.0" port="${https.port}"/>
 </flow>
 ----
 
@@ -99,7 +99,7 @@ The parser detects an error because the flow references an HTTPS Connector that 
 [source,xml,linenums]
 ----
 <tls:context name="tls-context-config">
-    <tls:key-store path="keystore.jks" password="password"
+    <tls:key-store path="keystore.jks" password="${password}"
        keyPassword="${keystore.password}"/>
 </tls:context>
 ----
@@ -131,7 +131,7 @@ http://www.mulesoft.org/schema/mule/tls http://www.mulesoft.org/schema/mule/tls/
 
     <http:listener-config name="https-lc-0.0.0.0-8082" host="0.0.0.0" port="![p['proxy.port']]" protocol="HTTPS">
         <tls:context name="tls-context-config">
-            <tls:key-store path="keystore.jks" password="password"
+            <tls:key-store path="keystore.jks" password="${password}"
                            keyPassword="${keystore.password}"/>
         </tls:context>
      </http:listener-config>

--- a/modules/ROOT/pages/build-an-https-service.adoc
+++ b/modules/ROOT/pages/build-an-https-service.adoc
@@ -1,0 +1,145 @@
+= Configure an HTTPS Service
+ifndef::env-site,env-github[]
+include::_attributes.adoc[]
+endif::[]
+:keywords: mule runtime, arm, https, cloudhub
+
+To help you ensure your data confidentiality, you can deploy your Mule app using an HTTPS based service. Learn how to configure:
+
+* An HTTPS service to deploy your application to CloudHub
+* HTTPS services using API Manager Proxies
+
+If you need to deploy your app locally, see xref:tls-configuration.adoc[TLS Configuration].
+
+== Prerequisites
+
+Before you begin, build a service (such as a simple "Hello World" service) and deploy it.
+
+== Configure HTTPS Service
+
+Modify your service to HTTPS to deploy your app to CloudHub:
+
+. Generate a `keystore.jks` file using the JDK `keytool` utility on the command line. You must also specify the hostname on the command line to generate a self-signed certificate. +
+
++
+For example, the following command with hostname `SAN=DNS:localhost,IP:127.0.0.1` creates a `keystore.jks` file:
++
+[source,text,linenums]
+----
+keytool -genkeypair -keystore keystore.jks   -dname "CN=localhost, OU=Unknown, O=Unknown, L=Unknown, ST=Unknown, C=Unknown"  -keypass password  -storepass password  -keyalg RSA  -sigalg SHA1withRSA  -keysize 2048  -alias mule  -ext SAN=DNS:localhost,IP:127.0.0.1 -validity 9999
+----
+
+. Add the generated `keystore.jks` file to your Anypoint Studio Mule app folder in `src/main/resources`.
+. Configure the HTTP Listener in your Mule app, specifying:
+
+* Any host IP addresses you want to use with the HTTPS scheme for the value of `host`
+* The `${https.port} variable for the value of `port`
+
+[source,xml,linenums]
+----
+...
+<http:listener-config name="HTTPS_Listener_Configuration" protocol="HTTPS" host="0.0.0.0" port="${https.port}" doc:name="HTTP Listener Configuration">
+     <tls:context>
+         <tls:key-store path="keystore.jks" keyPassword="${keystore.password}" password="password"/>
+     </tls:context>
+ </http:listener-config>
+...
+----
+
+[start=4]
+. Include a `config-ref` reference to the HTTPS global listener configuration.
+
+[source,xml,linenums]
+----
+<flow name="httpsserviceFlow">
+    <http:listener config-ref="HTTPS_Listener_Configuration" path="hello" doc:name="HTTPS_Listener_Configuration"/>
+</flow>
+----
+
+[start=5]
+. Configure the HTTP Requester using your required TLS configuration to enable HTTPS requests to external addresses:
++
+[source,xml,linenums]
+----
+...
+<http:request-config name="HTTP_Request_Configuration" protocol="HTTPS" host="0.0.0.0" port="${https.port}" doc:name="HTTP Request Configuration">
+     <tls:context>
+         <tls:key-store path="keystore.jks" password="password" keyPassword="${keystore.password}" />
+     </tls:context>
+</http:request-config>
+...
+----
+
+[start=6]
+. Include a `config-ref` reference to the HTTPS global request configuration:
++
+[source,xml,linenums]
+----
+<flow name="httpsserviceFlow">
+  <http:request config-ref="HTTP_Request_Configuration" path="some-path" method="GET" doc:name="HTTPS_Request_Configuration" host="0.0.0.0" port="${https.port}"/>
+</flow>
+----
+
+[start=7]
+. Your application is now ready to be deployed on CloudHub. You can access your endpoint using the HTTPS address: for example, `+https://yourdomain.cloudhub.io+`
+
+== Configure Services under API Manager Proxies
+
+If you are prompted to download a proxy from API Manager and need to configure it for HTTPS, follow the steps in the HTTP Connector configuration for the HTTP Requester. The HTTP Listener configuration is provided as a template.
+
+To complete the configuration:
+
+. Import the proxy project into Anypoint Studio.
+. Select the *Configuration XML* tab for your proxy flow.
++
+The parser detects an error because the flow references an HTTPS Connector that is commented out.
+. Uncomment the `http:listener-config` block.
+. Add the `keystore` values: `path`, `password`, and `keyPassword`:
++
+[source,xml,linenums]
+----
+<tls:context name="tls-context-config">
+    <tls:key-store path="keystore.jks" password="password"
+       keyPassword="${keystore.password}"/>
+</tls:context>
+----
++
+* You can use external properties.
+* The value of `path` cannot include `src/main/resources`.
++
+Your configuration should look similar to the following:
++
+[source,xml,linenums]
+----
+<?xml version="1.0" encoding="UTF-8"?>
+
+<mule xmlns:api-platform-gw="http://www.mulesoft.org/schema/mule/api-platform-gw"
+	xmlns:tls="http://www.mulesoft.org/schema/mule/tls" xmlns:http="http://www.mulesoft.org/schema/mule/http" xmlns="http://www.mulesoft.org/schema/mule/core" xmlns:doc="http://www.mulesoft.org/schema/mule/documentation"
+	xmlns:spring="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="
+http://www.mulesoft.org/schema/mule/api-platform-gw http://www.mulesoft.org/schema/mule/api-platform-gw/current/mule-api-platform-gw.xsd http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-current.xsd
+http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd
+http://www.mulesoft.org/schema/mule/tls http://www.mulesoft.org/schema/mule/tls/current/mule-tls.xsd">
+      <configuration defaultProcessingStrategy="non-blocking" />
+
+    <expression-language:property-placeholder location="config.properties" />
+
+    <api-platform-gw:api apiName="![p['api.name']]" version="![p['api.version']]" flowRef="proxy">
+    </api-platform-gw:api>
+
+    <http:listener-config name="https-lc-0.0.0.0-8082" host="0.0.0.0" port="![p['proxy.port']]" protocol="HTTPS">
+        <tls:context name="tls-context-config">
+            <tls:key-store path="keystore.jks" password="password"
+                           keyPassword="${keystore.password}"/>
+        </tls:context>
+     </http:listener-config>
+...
+----
+
+== See Also
+
+* xref:api-manager::building-https-proxy.adoc[Building an HTTPS API Proxy] in Mule 4
+* xref:3.9@mule-runtime::http-connector.adoc[HTTP Connector for Mule 3]
+* xref:3.9@mule-runtime::tls-configuration.adoc[TLS Configuration]

--- a/modules/ROOT/pages/build-an-https-service.adoc
+++ b/modules/ROOT/pages/build-an-https-service.adoc
@@ -13,7 +13,8 @@ If you need to deploy your app locally, see xref:tls-configuration.adoc[TLS Conf
 
 == Prerequisites
 
-Before you begin, build a service (such as a simple "Hello World" service) and deploy it.
+Before you begin, build a service (such as a simple "Hello World" service) and deploy it. +
+Learn how to design and develop an API using our xref:general::api-led-overview.adoc[Build an API from Start to Finish] tutorial.
 
 == Configure HTTPS Service
 

--- a/modules/ROOT/pages/build-an-https-service.adoc
+++ b/modules/ROOT/pages/build-an-https-service.adoc
@@ -1,13 +1,13 @@
-= Configure an HTTPS Service
+= Build an HTTPS Service
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 :keywords: mule runtime, arm, https, cloudhub
 
-To help you ensure your data confidentiality, you can deploy your Mule app using an HTTPS based service. Learn how to configure:
+To help you ensure data confidentiality, you can deploy your Mule app using an HTTPS-based service. Learn how to build:
 
 * An HTTPS service to deploy your application to CloudHub
-* HTTPS services using API Manager Proxies
+* HTTPS services using API Manager proxies
 
 If you need to deploy your app locally, see xref:tls-configuration.adoc[TLS Configuration].
 
@@ -16,7 +16,7 @@ If you need to deploy your app locally, see xref:tls-configuration.adoc[TLS Conf
 Before you begin, build a service (such as a simple "Hello World" service) and deploy it. +
 Learn how to design and develop an API using our xref:general::api-led-overview.adoc[Build an API from Start to Finish] tutorial.
 
-== Configure HTTPS Service
+== Build an HTTPS Service
 
 Modify your service to HTTPS to deploy your app to CloudHub:
 
@@ -34,7 +34,7 @@ keytool -genkeypair -keystore keystore.jks   -dname "CN=localhost, OU=Unknown, O
 . Configure the HTTP Listener in your Mule app, specifying:
 
 * Any host IP addresses you want to use with the HTTPS scheme for the value of `host`
-* The `${https.port} variable for the value of `port`
+* A value for `${https.port} variable for the value of `port`
 
 [source,xml,linenums]
 ----
@@ -58,7 +58,7 @@ keytool -genkeypair -keystore keystore.jks   -dname "CN=localhost, OU=Unknown, O
 ----
 
 [start=5]
-. Configure the HTTP Requester using your required TLS configuration to enable HTTPS requests to external addresses:
+. Configure the HTTP Requester using the TLS configuration required to enable HTTPS requests to external addresses:
 +
 [source,xml,linenums]
 ----
@@ -81,12 +81,12 @@ keytool -genkeypair -keystore keystore.jks   -dname "CN=localhost, OU=Unknown, O
 </flow>
 ----
 
-[start=7]
-. Your application is now ready to be deployed on CloudHub. You can access your endpoint using the HTTPS address: for example, `+https://yourdomain.cloudhub.io+`
++
+Your application is now ready to be deployed on CloudHub. You can access your endpoint using the HTTPS address: for example, `+https://yourdomain.cloudhub.io+`
 
-== Configure Services under API Manager Proxies
+== Configure Services Under API Manager Proxies
 
-If you are prompted to download a proxy from API Manager and need to configure it for HTTPS, follow the steps in the HTTP Connector configuration for the HTTP Requester. The HTTP Listener configuration is provided as a template.
+If you are prompted to download a proxy from API Manager and need to configure it for HTTPS, follow the same steps that you used in Anypoint Connector for HTTP to configure the HTTP Requester. The HTTP Listener configuration is provided as a template.
 
 To complete the configuration:
 


### PR DESCRIPTION
Moved `Build an HTTPS Service` documentation from Runtime Manager to Mule Runtime.
- Re-structure
- Wording, styling

Original PR where dev wanted to have this document transfered from RM to MR https://github.com/mulesoft/docs-runtime-manager/pull/238