### PR TITLE
MULE-17590: Document Error handler supporting "when" and "type" simultaneously

### DIFF
--- a/modules/ROOT/pages/on-error-scope-concept.adoc
+++ b/modules/ROOT/pages/on-error-scope-concept.adoc
@@ -63,7 +63,7 @@ to fatal errors, which have error messages that contain the word "fatal":
   type="ANY"
   when='error.cause.message contains "fatal"'/>
 ----
-** In the example above, every error that matches the `when` expression will be handled by the `on-error-continue`. You can also put a restrictive type (e.g. `type="HTTP:CONNECTION"). In such case, only errors that matches type and condition will be handled by this error handler. 
+** In the example above, every error that matches the `when` expression will be handled by the `on-error-continue`. You can also put a restrictive type (e.g. `type="HTTP:CONNECTIVITY"). In such case, only errors that matches type and condition will be handled by this error handler. 
 
 Note that matching conditions are evaluated sequentially, in the order in
 which the On-Error components reside in the error handler. For example, if

--- a/modules/ROOT/pages/on-error-scope-concept.adoc
+++ b/modules/ROOT/pages/on-error-scope-concept.adoc
@@ -64,7 +64,7 @@ to fatal errors, which have error messages that contain the word "fatal":
   when='error.cause.message contains "fatal"'/>
 ----
 +
-In the example, every error that matches the `when` expression is handled by `on-error-continue`. You can also add a restrictive type such as `type="HTTP:CONNECTIVITY"` so that the error handler only handles the errors that match the specified type and condition. 
+In the example, every error that matches the `when` expression is handled by `on-error-continue`. You can also add a restrictive type such as `type="HTTP:CONNECTIVITY"` so that the error handler handles only the errors that match the specified type and condition. 
 
 Note that matching conditions are evaluated sequentially, in the order in
 which the On-Error components reside in the error handler. For example, if

--- a/modules/ROOT/pages/on-error-scope-concept.adoc
+++ b/modules/ROOT/pages/on-error-scope-concept.adoc
@@ -63,6 +63,7 @@ to fatal errors, which have error messages that contain the word "fatal":
   type="ANY"
   when='error.cause.message contains "fatal"'/>
 ----
+** In the example above, every error that matches the `when` expression will be handled by the `on-error-continue`. You can also put a restrictive type (e.g. `type="HTTP:CONNECTION"). In such case, only errors that matches type and condition will be handled by this error handler. 
 
 Note that matching conditions are evaluated sequentially, in the order in
 which the On-Error components reside in the error handler. For example, if

--- a/modules/ROOT/pages/on-error-scope-concept.adoc
+++ b/modules/ROOT/pages/on-error-scope-concept.adoc
@@ -63,7 +63,8 @@ to fatal errors, which have error messages that contain the word "fatal":
   type="ANY"
   when='error.cause.message contains "fatal"'/>
 ----
-** In the example above, every error that matches the `when` expression will be handled by the `on-error-continue`. You can also put a restrictive type (e.g. `type="HTTP:CONNECTIVITY"). In such case, only errors that matches type and condition will be handled by this error handler. 
++
+In the example, every error that matches the `when` expression is handled by `on-error-continue`. You can also add a restrictive type such as `type="HTTP:CONNECTIVITY"` so that the error handler only handles the errors that match the specified type and condition. 
 
 Note that matching conditions are evaluated sequentially, in the order in
 which the On-Error components reside in the error handler. For example, if


### PR DESCRIPTION
Since 4.3 both can be used at the same time to be more restrictive.