### PR TITLE
DW-145: Document coercions in Relational Operators for v4.2

### DIFF
--- a/modules/ROOT/pages/dw-operators.adoc
+++ b/modules/ROOT/pages/dw-operators.adoc
@@ -100,12 +100,12 @@ output application/json
 }
 ----
 
-NOTE: If one side of the relational operator is of type `String` and not the other,
-DataWeave is going to coerce the `String` to the type of the other side. For example: In the expression
-`"123" > 12` DataWeave is going to coerce the String `"123"` to the Number `123`
-and do the comparison between numbers (the same happens if the right side is
-the one that is a String `12 > "123"`).
-If the `String` cannot be coerced to the type of the other side, that will end up in an exception.
+Note that if the operands of the relational operator belong to different types,
+DataWeave coerces the right-side operand to the type of the left-side operand.
+For example, in the expression `"123" > 12` DataWeave coerces `12` (a Number type)
+to `"12"` (a String type) and compares each String value lexicographically.
+In the expression `123 > "12"`, DataWeave coerces the String value `"12"` to the Number value `12`
+and compares the numbers.
 
 These examples use equality operators:
 

--- a/modules/ROOT/pages/dw-operators.adoc
+++ b/modules/ROOT/pages/dw-operators.adoc
@@ -91,7 +91,7 @@ output application/json
 .Output
 [source,json,linenums]
 ----
-"relational": [
+{ "relational": [
     { "(1 < 1)": false },
     { "(1 > 2)": false },
     { "(1 <= 1)": true },
@@ -99,6 +99,13 @@ output application/json
   ]
 }
 ----
+
+NOTE: If one side of the relational operator is of type `String` and not the other,
+DataWeave is going to coerce the `String` to the type of the other side. For example: In the expression
+`"123" > 12` DataWeave is going to coerce the String `"123"` to the Number `123`
+and do the comparison between numbers (the same happens if the right side is
+the one that is a String `12 > "123"`).
+If the `String` cannot be coerced to the type of the other side, that will end up in an exception.
 
 These examples use equality operators:
 


### PR DESCRIPTION
The coercion in relational operators (>, <, >=, <=) changes between 4.1 and 4.2.
We should add this to the documentation.
In 4.2 if one side of the relational operator is of type String and not the other, it will coerce the String to the type of the other side.