### PR TITLE
DW-145: Document coercions in Relational Operators for v4.1

### DIFF
--- a/modules/ROOT/pages/dw-operators.adoc
+++ b/modules/ROOT/pages/dw-operators.adoc
@@ -87,7 +87,7 @@ output application/json
 .Output
 [source,json,linenums]
 ----
-"relational": [
+{ "relational": [
     { "(1 < 1)": false },
     { "(1 > 2)": false },
     { "(1 <= 1)": true },
@@ -95,6 +95,13 @@ output application/json
   ]
 }
 ----
+
+NOTE: If the sides of the relational operator are of different types,
+DataWeave is going to coerce the right side to the type of the left side.
+For example: In the expression `"123" > 12` DataWeave is going to coerce the Number `12`
+to the String `"12"` and do the comparison between Strings (that compares two Strings lexicographically).
+In the expression `123 > "12"` DW is going to coerce the String `"12"` to the Number `12`
+and do the comparison between Numbers.
 
 These examples use equality operators:
 

--- a/modules/ROOT/pages/dw-operators.adoc
+++ b/modules/ROOT/pages/dw-operators.adoc
@@ -96,12 +96,12 @@ output application/json
 }
 ----
 
-NOTE: If the sides of the relational operator are of different types,
-DataWeave is going to coerce the right side to the type of the left side.
-For example: In the expression `"123" > 12` DataWeave is going to coerce the Number `12`
-to the String `"12"` and do the comparison between Strings (that compares two Strings lexicographically).
-In the expression `123 > "12"` DW is going to coerce the String `"12"` to the Number `12`
-and do the comparison between Numbers.
+Note that if the operands of the relational operator belong to different types,
+DataWeave coerces the right-side operand to the type of the left-side operand.
+For example, in the expression `"123" > 12` DataWeave coerces `12` (a Number type)
+to `"12"` (a String type) and performs the compares each each String value lexicographically.
+In the expression `123 > "12"`, DataWeave coerces the String value `"12"` to the Number value `12`
+and compares the numbers.
 
 These examples use equality operators:
 

--- a/modules/ROOT/pages/dw-operators.adoc
+++ b/modules/ROOT/pages/dw-operators.adoc
@@ -14,7 +14,6 @@ DataWeave 2.0 supports the most common mathematical operators:
 |===
 | Operator | Description
 | `+` | For addition
-| `-` | For subtraction
 | `*` | For multiplication.
 | `/`  | For division.
 |===
@@ -99,7 +98,7 @@ output application/json
 Note that if the operands of the relational operator belong to different types,
 DataWeave coerces the right-side operand to the type of the left-side operand.
 For example, in the expression `"123" > 12` DataWeave coerces `12` (a Number type)
-to `"12"` (a String type) and performs the compares each each String value lexicographically.
+to `"12"` (a String type) and compares each String value lexicographically.
 In the expression `123 > "12"`, DataWeave coerces the String value `"12"` to the Number value `12`
 and compares the numbers.
 


### PR DESCRIPTION
The coercion in relational operators (>, <, >=, <=) changed between 4.1 and 4.2.
In 4.1 if the sides of the relational operator are of different types, DW will coerce the right side to the type of the left side.