### PR TITLE
Default value for disallowedConcurrentExecution

### DIFF
--- a/modules/ROOT/pages/scheduler-xml-reference.adoc
+++ b/modules/ROOT/pages/scheduler-xml-reference.adoc
@@ -14,7 +14,7 @@ A XML for the Scheduler has these elements:
 |===
 |Attribute |Description |Example
 |`disallowedConcurrentExecution`
-|Skips the next scheduled flow execution if the last one has not ended. Next attempt to execute will be after another frequency period. Default value is `true`.
+|Skips the next scheduled flow execution if the last one has not ended. Next attempt to execute will be after another frequency period. Default value is `false`.
 |`disallowConcurrentExecution="true"`
 |===
 


### PR DESCRIPTION
The default value for disallowedConcurrentExecution is false in the mule-core-common.xsd file actually. Not only in the schema documentation but in the behavior also. If disallowedConcurrentExecution=true is not present, it will allow concurrent executions.