### PR TITLE
DOCS-6709-3.9 page alias build http service-kt

### DIFF
--- a/modules/ROOT/pages/build-an-https-service.adoc
+++ b/modules/ROOT/pages/build-an-https-service.adoc
@@ -3,6 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 :keywords: mule runtime, arm, https, cloudhub
+:page-aliases: runtime-manager::building-an-https-service.adoc
 
 To help you ensure data confidentiality, you can deploy your Mule app using an HTTPS-based service. Learn how to build:
 


### PR DESCRIPTION
Adding page aliases for Building an HTTP Service from Runtime Manager to Mule Runtime

`:page-aliases: runtime-manager::building-an-https-service.adoc`

Content PR https://github.com/mulesoft/docs-mule-runtime/pull/1258
Transfer this PR to 4.3 once version is in production.