### PR TITLE
DOCS-7714-4.3-mime-types-batch-aggregator-kt

### DIFF
--- a/modules/ROOT/pages/batch-filters-and-batch-aggregator.adoc
+++ b/modules/ROOT/pages/batch-filters-and-batch-aggregator.adoc
@@ -297,6 +297,101 @@ To make sure that the connector you are using supports record-level errors, chec
 Such a transaction must start and end within the step's boundaries.
 * You cannot share a transaction between a batch step and a batch aggregator that exists within the step. Any transaction that the batch step starts, ends before the batch aggregator begins processing. In other words, a transaction cannot cross the barrier between a batch step and the batch aggregator scope it contains.
 
+== Preserving the MIME types of the Aggregated Records
+
+_Supported by Mule 4.3_
+
+Aggregated records are passed into the aggregator as an array containing each record’s payload. However, the MIME types associated with those payloads are not preserved by default. You can preserve record’s MIME types by specifying the `preserveMimeTypes` attribute in a batch aggregator.
+
+As an example, consider the following JSON document:
+
+[source,json,linenums]
+----
+[
+	{
+		"name": "Tony Stark",
+		"alias": "Iron Man",
+		"status": "DEAD"
+	},
+	{
+		"name": "Steve Rodgers",
+		"alias": "Captain America",
+		"status": "RETIRED"
+	},
+	{
+		"name": "Peter Parker",
+		"alias": "SpiderMan",
+		"status": "FUGITIVE"
+	}
+]
+----
+
+Suppose you fed this document into the following job:
+
+[source,xml,linenums]
+----
+<batch:job name="avengersLogger">
+	<batch:process-records>
+		<batch:step name="log">
+			<batch:aggregator size="10">
+				<foreach>
+					<logger message="Agent #[payload.alias] is #[payload.status]" />
+				</foreach>
+			</batch:aggregator>
+		</batch:step>
+	</batch:process-records>
+</batch:name>
+----
+
+The batch engine splits the input JSON array into individual records, which means that the aggregator block receives an array with three elements. The first one of them is:
+
+[source,json,linenums]
+----
+{
+ "name": "Tony Stark",
+ "alias": "Iron Man",
+ "status": "DEAD"
+}
+----
+
+However, when the logger element attempts to evaluate the `#[payload.alias]` expression, it results in an error similar to the following:
+
+[source,text,linenums]
+----
+********************************************************************************
+Message               : "You called the function 'Value Selector' with these arguments:
+  1: Binary ("ewogICJmaXJzdE5hbWUiOiAiUmFtIiwKICAibGFzdE5hbWUiOiAiUmFtMSIsCiAgImFkZHJlc3Mi...)
+  2: Name ("alias")
+
+But it expects one of these combinations:
+  (Array, Name)
+  (Array, String)
+  (Date, Name)
+  (DateTime, Name)
+  (LocalDateTime, Name)
+  (LocalTime, Name)
+  (Object, Name)
+  (Object, String)
+  (Period, Name)
+  (Time, Name)
+
+5|                                         name: payload.alias,
+                                                 ^^^^^^^^^^^^^
+----
+
+The previous error occurs because MIME types are not preserved by default, and therefore Mule doesn’t know that this record is actually a JSON. You can fix this by specifying the `preserveMimeTypes` attribute in the batch aggregator:
+
+[source,xml,linenums]
+----
+<batch:aggregator size="10" preserveMimeTypes="true">
+	<foreach>
+	   <logger message="Agent #[payload.alias] is #[payload.status]" />
+	</foreach>
+</batch:aggregator>
+----
+
+By setting this attribute, Mule automatically maintains each record's media type and knows that the payload actually represents a JSON document.
+
 == See Also
 
 * xref:batch-processing-concept.adoc[Batch Processing]


### PR DESCRIPTION
Adding new section `Preserving the MIME types of the Aggregated Records` into https://docs.mulesoft.com/mule-runtime/4.2/batch-filters-and-batch-aggregator 

Link-checker ran successfully. 

Original Google Doc work
https://docs.google.com/document/d/1xTvtY8KfZ3m1dqIs_8w-cX3clLVGCtPDzh_aBCNTGPI/edit#heading=h.141dii63gcu0