### PR TITLE
Added properties for dw memory pool configuration

### DIFF
--- a/modules/ROOT/pages/dataweave-memory-management.adoc
+++ b/modules/ROOT/pages/dataweave-memory-management.adoc
@@ -43,7 +43,7 @@ The default number of slots is 60.
 Introduced in Mule 4.3.0, this property determines the size in bytes of each slot in the pool of off-heap memory. The default slot size is 1572864 bytes (1.5 MB).
 
 * `com.mulesoft.dw.buffer.memory.monitoring` (experimental) +
-Introduced in Mule 4.3.0, when this property is enabled each time, a slot from the memory pool is taken or released and a message is logged.
+Introduced in Mule 4.3.0, when this property is enabled, a message is logged each time a slot from the memory pool is taken or released.
 Note that it may be removed or change its behavior in future versions.
 
 == See Also

--- a/modules/ROOT/pages/dataweave-memory-management.adoc
+++ b/modules/ROOT/pages/dataweave-memory-management.adoc
@@ -10,20 +10,41 @@ When processing large files through DataWeave in Mule runtime engine, there are 
 
 == RAM vs Disk Usage
 
-DataWeave uses disk data storage to avoid running out of memory. The files created are placed in a default temporary directory. If you want to store those files in a custom directory instead, you can specify the directory by using the `java.io.tmpdir` property.
+DataWeave keeps small files in memory, but after a configurable threshold uses disk space to avoid running out of memory. The created buffer files are placed in a default temporary directory. If you want to store those files in a custom directory instead, you can specify the directory by using the `java.io.tmpdir` property.
 
-Two types of DataWeave files are generated, both with names beginning with `dw-buffer-`: +
+Three types of DataWeave buffer files are generated: +
 
 * `dw-buffer-output-${count}.tmp` +
 Used to store the output of a transformation when the result is bigger than the threshold *1572864 bytes*.
-To change this threshold value, add the system property `com.mulesoft.dw.buffersize` and assign it the number of bytes you want as your new threshold. Because you can define system properties in several ways, see xref:configuring-properties.adoc#system-properties[system properties] for further details.
+To change this threshold value, add the system property `com.mulesoft.dw.buffersize` and assign it the number of bytes you want as your new threshold. 
 Mule runtime engine deletes the file when the value is no longer referenced, JVM GC collects it or when the Mule Event finishes executing.
+
+* `dw-buffer-input-${count}.tmp` +
+Used to store the input of a transformation when it is bigger than the in-memory buffer, which is *1572864 bytes* by default.
+This is analogous to the `dw-buffer-output-${count}.tmp` file, but for input data.
 
 * `dw-buffer-index-${count}.tmp` +
 Used to store index information of a value being read. This file helps DataWeave access data quickly. Mule runtime engine deletes the file when the execution of the transformation ends or, in a streaming use case like the foreach loop, when the stream ends (when foreach finishes its execution).
 
+System properties: +
+Because you can define system properties in several ways, see xref:configuring-properties.adoc#system-properties[system properties] for further details.
+
+* `com.mulesoft.dw.buffersize` +
+This system property determines the size in bytes of the in-memory input and output buffers used in DataWeave to keep the processed input and outputs. If a payload exceeds this size, it is stored in `dw-buffer-index-${count}.tmp` and `dw-buffer-output-${count}.tmp` temporary files. The default buffer size is 1572864 bytes (1.5 MB).
+
 * `com.mulesoft.dw.directbuffer.disable` +
 Introduced in Mule 4.2.2, this option controls whether DataWeave uses off-heap memory (the default) or heap memory. DataWeave uses off-heap memory for internal buffering. However, this setting can cause problems on machines that have only a small amount of memory.
+
+* `com.mulesoft.dw.memory_pool_size` +
+Since Mule 4.3.0 DataWeave buffers use off-heap memory from a pool up to a defined size and the rest is allocated using heap memory. This property determines the number of slots in the pool.
+The default number of slots is 60.
+
+* `com.mulesoft.dw.max_memory_allocation` +
+Introduced in Mule 4.3.0, this option determines the size in bytes of each slot in the pool of off-heap memory. The default slot size is 1572864 bytes (1.5 MB).
+
+* `com.mulesoft.dw.buffer.memory.monitoring` (experimental) +
+Introduced in Mule 4.3.0, when this is enabled each time a slot from the memory pool is taken or released a message is logged.
+Note that it may be removed or change its behaviour in future versions.
 
 == See Also
 

--- a/modules/ROOT/pages/dataweave-memory-management.adoc
+++ b/modules/ROOT/pages/dataweave-memory-management.adoc
@@ -16,7 +16,7 @@ Three types of DataWeave buffer files are generated: +
 
 * `dw-buffer-output-${count}.tmp` +
 Used to store the output of a transformation when the result is bigger than the threshold *1572864 bytes*.
-To change this threshold value, add the system property `com.mulesoft.dw.buffersize` and assign it the number of bytes you want as your new threshold. 
+To change this threshold value, add the system property `com.mulesoft.dw.buffersize` and assign it the number of bytes you want as your new threshold.
 Mule runtime engine deletes the file when the value is no longer referenced, JVM GC collects it or when the Mule Event finishes executing.
 
 * `dw-buffer-input-${count}.tmp` +
@@ -36,15 +36,15 @@ This system property determines the size in bytes of the in-memory input and out
 Introduced in Mule 4.2.2, this option controls whether DataWeave uses off-heap memory (the default) or heap memory. DataWeave uses off-heap memory for internal buffering. However, this setting can cause problems on machines that have only a small amount of memory.
 
 * `com.mulesoft.dw.memory_pool_size` +
-Since Mule 4.3.0 DataWeave buffers use off-heap memory from a pool up to a defined size and the rest is allocated using heap memory. This property determines the number of slots in the pool.
+Since Mule 4.3.0, DataWeave buffers use off-heap memory from a pool up to a defined size and allocates the rest using heap memory. This property determines the number of slots in the pool.
 The default number of slots is 60.
 
 * `com.mulesoft.dw.max_memory_allocation` +
-Introduced in Mule 4.3.0, this option determines the size in bytes of each slot in the pool of off-heap memory. The default slot size is 1572864 bytes (1.5 MB).
+Introduced in Mule 4.3.0, this property determines the size in bytes of each slot in the pool of off-heap memory. The default slot size is 1572864 bytes (1.5 MB).
 
 * `com.mulesoft.dw.buffer.memory.monitoring` (experimental) +
-Introduced in Mule 4.3.0, when this is enabled each time a slot from the memory pool is taken or released a message is logged.
-Note that it may be removed or change its behaviour in future versions.
+Introduced in Mule 4.3.0, when this property is enabled each time, a slot from the memory pool is taken or released and a message is logged.
+Note that it may be removed or change its behavior in future versions.
 
 == See Also
 


### PR DESCRIPTION
Clarified first paragraph a little and separated com.mulesoft.dw.buffersize into available system properties section.