### PR TITLE
Update migration-connectors-database.adoc

### DIFF
--- a/modules/ROOT/pages/migration-connectors-database.adoc
+++ b/modules/ROOT/pages/migration-connectors-database.adoc
@@ -34,7 +34,7 @@ The XML for these connection configurations has changed in Mule 4:
 
 * Mule 3: Database elements such as `<db:derby-config />` are the top-level elements.
 * Mule 4: `<db:config />` is the top-level element for all database connection configurations in Mule 4, and specific database configurations are nested under separate `<db:config />` elements:
-** Derby: `<db:data-source-connection />`
+** Derby: `<db:derby-connection />`
 ** Microsoft SQL Server: `<db:mssql-connection />`
 ** MySQL: `<db:my-sql-connection />`
 ** Oracle: `<db:oracle-connection />`


### PR DESCRIPTION
Corrected the connection definition for Derby (changed it from "db:data-source-connection" to "db:derby-connection").