### PR TITLE
DOCS-12677: Fixed condition that would trigger a retry

### DIFF
--- a/modules/ROOT/pages/until-successful-scope.adoc
+++ b/modules/ROOT/pages/until-successful-scope.adoc
@@ -7,7 +7,7 @@ endif::[]
 The Until Successful scope processes the components within it, in order, until they
 succeed or exhaust the maximum number of retries. Like all Core components
 other than Async, Until Successful runs synchronously. If a component
-within the scope fails to connect or produce a successful result,
+within the scope fails to connect or produce an unsuccessful result,
 Until Successful retries the failed task until all configured retries
 are exhausted. If a retry succeeds, the scope proceeds to the next
 component. If the final retry does not succeed, Until Successful produces an error.


### PR DESCRIPTION
A successful result will not trigger a retry. Using antonymous instead.