### PR TITLE
DOCS-7246

### DIFF
--- a/modules/ROOT/pages/execution-engine.adoc
+++ b/modules/ROOT/pages/execution-engine.adoc
@@ -140,6 +140,9 @@ Applying pool configurations at the application level causes Mule to create a co
 
 Because MuleSoft recommends running Mule using the default settings, if you decide to customize thread pool configurations, be sure to perform load and stress testing with all applications, using real-life scenarios, and consult with MuleSoft Support before moving to production using customized settings.
 
+[NOTE]
+If you define pool configurations at the application level for Mule apps deployed to CloudHub, be mindful about worker sizes because fractional vCores have less memory. See xref:runtime-manager::cloudhub-architecture.adoc#cloudhub-workers[CloudHub Workers] for more details.
+
 [[backpressure]]
 == Back-Pressure Management
 

--- a/modules/ROOT/pages/execution-engine.adoc
+++ b/modules/ROOT/pages/execution-engine.adoc
@@ -111,7 +111,9 @@ Due to latency optimizations, thread switches are omitted when an I/O or `CPU_IN
 
 == Configuration
 
-Mule runtime engine automatically configures thread pools for the entire Mule instance at startup, applying formulas that consider available resources such as CPU and memory. Although you can modify these global formulas by editing the `MULE_HOME/conf/schedulers-pools.conf` file, MuleSoft doesn’t recommend it.
+Mule runtime engine automatically configures thread pools for the entire Mule instance at startup, applying formulas that consider available resources such as CPU and memory.
+
+If you run Mule runtime engine on premises, you can modify these global formulas by editing the `MULE_HOME/conf/schedulers-pools.conf` file in your local Mule instance. However, MuleSoft doesn’t recommend editing this file's configuration.
 
 === Configuration at the Application Level
 
@@ -136,7 +138,7 @@ Besides the global configuration, you can define the configuration of each pool 
 
 Applying pool configurations at the application level causes Mule to create a completely new set of thread pools for the Mule app. This configuration does not change the default settings configured in the `scheduler-conf.properties` file, which is particularly important for on-premises deployments in which many Mule apps can be deployed to the same Mule instance.
 
-Because Mulesoft recommends running Mule using the default settings, if you decide to customize thread pool configurations, be sure to perform load and stress testing with all applications, using real-life scenarios, and consult with MuleSoft Support before moving to production using customized settings.
+Because MuleSoft recommends running Mule using the default settings, if you decide to customize thread pool configurations, be sure to perform load and stress testing with all applications, using real-life scenarios, and consult with MuleSoft Support before moving to production using customized settings.
 
 [[backpressure]]
 == Back-Pressure Management


### PR DESCRIPTION
Clarified that schedulers-pools.conf can only be edited in on-premises 
Mule instances.