### PR TITLE
Update scheduler-xml-reference.adoc

### DIFF
--- a/modules/ROOT/pages/scheduler-xml-reference.adoc
+++ b/modules/ROOT/pages/scheduler-xml-reference.adoc
@@ -13,8 +13,8 @@ A XML for the Scheduler has these elements:
 [%header,cols="34,33,33"]
 |===
 |Attribute |Description |Example
-|`disallowedConcurrentExecution`
-|Skips the next scheduled flow execution if the last one has not ended. Next attempt to execute will be after another frequency period. Default value is `true`.
+|`disallowConcurrentExecution`
+|Skips the next scheduled flow execution if the last one has not ended. Next attempt to execute will be after another frequency period. Default value is `false`.
 |`disallowConcurrentExecution="true"`
 |===
 


### PR DESCRIPTION
- corrected default value of "disallowConcurrentExecution" attribute, set to "false"
- corrected spelling of "disallowConcurrentExecution" attribute

rationale:
After seeing some unexpected behavior in our applications and running some tests, if the "disallowConcurrentExecution" attribute is not added then concurrent executions of the flow occurs with a scheduler endpoint.  So the default is "false" and not "true".
Tested by adding a transform with a "wait(10000)" to a flow with a scheduler endpoint set to run on fixed frequency of 1000ms.  So scheduler executes every 1 second, and the transform within it waits 10 seconds.  
Without setting  "disallowConcurrentExecution", the runtime executes the flow every 1 second, resulting in 10 concurrent executions.
Setting  "disallowConcurrentExecution" to "true", the runtime executes the flow every 10 seconds, resulting in 0 concurrent executions.