### PR TITLE
blocking in Mule 4 is called failsDeployment

### DIFF
--- a/modules/ROOT/pages/reconnection-strategy-reference.adoc
+++ b/modules/ROOT/pages/reconnection-strategy-reference.adoc
@@ -14,7 +14,7 @@ A reconnection strategy that allows the user to configure how many times a recon
 [%header%autowidth.spread]
 |===
 |Name |Type |Required |Default |Description
-|`blocking` |boolean |no |true |If false, the reconnection strategy runs in a separate, non-blocking thread
+|`failsDeployment` |boolean |no |true |If false, the reconnection strategy runs in a separate, non-blocking thread
 |`frequency` |long |no |2000 |How often (in ms) to reconnect
 |`count` |integer |no |2 |How many reconnection attempts to make
 |===
@@ -45,7 +45,7 @@ A reconnection strategy that retries an infinite number of times at the specifie
 [%header%autowidth.spread]
 |===
 |Name |Type |Required |Default |Description
-|`blocking` |boolean |no |true |If false, the reconnection strategy runs in a separate, non-blocking thread.
+|`failsDeployment` |boolean |no |true |If false, the reconnection strategy runs in a separate, non-blocking thread.
 |`frequency` |long |no |2000 |How often (in ms) to reconnect.
 |===
 


### PR DESCRIPTION
This should be fixed in all 4.x documentation references (not only 4.2)
In the sample in https://docs.mulesoft.com/mule-runtime/4.2/reconnection-strategy-about you can see failsDeployment being used (instead of mule 3's blocking)