### PR TITLE
DOCS-3208-4.1-reconnect-update-kt

### DIFF
--- a/modules/ROOT/pages/reconnection-strategy-reference.adoc
+++ b/modules/ROOT/pages/reconnection-strategy-reference.adoc
@@ -31,9 +31,13 @@ For example:
 
 [source,xml,linenums]
 ----
-<jms:activemq-connector name="AMQConnector">
-    <reconnect count="5" frequency="1000"/>
-</jms:activemq-connector>
+<jms:config name="JMS_Config" >
+ <jms:active-mq-connection >
+   <reconnection >
+   <reconnect frequency="1000" count="5" />
+   </reconnection>
+ </jms:active-mq-connection>
+</jms:config>
 ----
 
 == Reconnect Forever
@@ -48,39 +52,3 @@ A reconnection strategy that retries an infinite number of times at the specifie
 |`blocking` |boolean |no |true |If false, the reconnection strategy runs in a separate, non-blocking thread.
 |`frequency` |long |no |2000 |How often (in ms) to reconnect.
 |===
-
-== Reconnect Custom Strategy
-
-A user-defined reconnection strategy.
-
-=== Attributes of <reconnect-custom-strategy...>
-
-[%header%autowidth.spread]
-|===
-|Name |Type |Required |Default |Description |
-|`blocking` |boolean |no |true |If false, the reconnection strategy runs in a separate, non-blocking thread.
-|`class` |class name |yes |
-|===
-
-A class that implements the `RetryPolicyTemplate` interface.
-
-=== Child Elements of reconnect-custom-strategy
-
-[%header%autowidth.spread]
-|===
-|Name |Cardinality |Description
-|`abstract-reconnect-notifier` |0..1 |A placeholder for a reconnection notifier element. The RetryNotifier interface is a callback that allows actions to be performed after each reconnection attempt, for example, firing server notification events on success or failure.
-|`spring:property` |0..* |
-|===
-
-For example:
-
-[source,xml,linenums]
-----
-<jms:activemq-connector name="AMQConnector">
-    <reconnect-custom-strategy class="org.mule.retry.test.TestRetryPolicyTemplate">
-        <spring:property name="fooBar" value="true"/>
-        <spring:property name="revolutions" value="500"/>
-    </reconnect-custom-strategy>
-</jms:activemq-connector>
-----


### PR DESCRIPTION
- Removed Reconnect Custom Strategy from v4.1 since this feature is not supported. (Confirmed in https://docs.mulesoft.com/mule-runtime/4.1/migration-core `reconnect-custom-strategy`)
- Also updated JMS example to Mule 4 version, since it was showing the JMS parameters for Mule 3
`jms:activemq-connector` now is `jms:activemq-connection`
