### PR TITLE
DOCS-8851: TCP/UDP specification in required cluster ports

### DIFF
--- a/modules/ROOT/pages/mule-high-availability-ha-clusters.adoc
+++ b/modules/ROOT/pages/mule-high-availability-ha-clusters.adoc
@@ -70,7 +70,7 @@ If multiple instances of the same application are deployed, they will fail becau
 
 * You must have at least two Mule runtime engines in a cluster, each one running on different machines.
 * Mule high availability (HA) requires a reliable network connection between servers to maintain synchronization between the nodes in the cluster.
-* You must keep the following ports open to set up a Mule cluster: port `5701` TCP and port `54327` UDP (only for Multicast).
+* You must keep the following ports open to set up a Mule cluster: TCP port `5701` and UDP port `54327` (only for Multicast).
 * If you configure your cluster to use multicast, you need to enable the multicast IP address: `224.2.2.3`. Multicast is used to discover new cluster members.
 
 == High Availability

--- a/modules/ROOT/pages/mule-high-availability-ha-clusters.adoc
+++ b/modules/ROOT/pages/mule-high-availability-ha-clusters.adoc
@@ -70,7 +70,7 @@ If multiple instances of the same application are deployed, they will fail becau
 
 * You must have at least two Mule runtime engines in a cluster, each one running on different machines.
 * Mule high availability (HA) requires a reliable network connection between servers to maintain synchronization between the nodes in the cluster.
-* You must keep the following ports open to set up a Mule cluster: port `5701` and port `54327`.
+* You must keep the following ports open to set up a Mule cluster: port `5701` TCP and port `54327` UDP (only for Multicast).
 * If you configure your cluster to use multicast, you need to enable the multicast IP address: `224.2.2.3`. Multicast is used to discover new cluster members.
 
 == High Availability


### PR DESCRIPTION
Specified that port 5701 TCP and 54327 UDP (only for Multicast) are required to set up a cluster. Right now the documentation only specifies the port numbers but not if they are TCP/UDP