### PR TITLE
JMSC-72: Improve docs on Thread pool optimizations

### DIFF
--- a/modules/ROOT/pages/execution-engine.adoc
+++ b/modules/ROOT/pages/execution-engine.adoc
@@ -29,6 +29,10 @@ For connectors created with the Mule SDK, the SDK determines the most
 appropriate processing type based on how the connector is implemented. For
 details on that mechanism, refer to the xref:1.1@mule-sdk::index.adoc[Mule SDK documentation].
 
+== Optimizations
+
+There are certain conditions on flow executions where the runtime may ignore the proposed Processing Type for event processor. This is due internal optimizations. Also xref:transaction-management.adoc[Transaction Management] may affect the Proccesing Type selection.
+
 [[threading]]
 == Threading
 

--- a/modules/ROOT/pages/execution-engine.adoc
+++ b/modules/ROOT/pages/execution-engine.adoc
@@ -31,7 +31,7 @@ details on that mechanism, refer to the xref:1.1@mule-sdk::index.adoc[Mule SDK d
 
 == Optimizations
 
-There are certain conditions on flow executions where the runtime may ignore the proposed Processing Type for event processor. This is due internal optimizations. Also xref:transaction-management.adoc[Transaction Management] may affect the Proccesing Type selection.
+There are certain conditions on flow executions where the runtime may ignore the proposed Processing Type for event processor. This is due internal optimizations.
 
 [[threading]]
 == Threading

--- a/modules/ROOT/pages/execution-engine.adoc
+++ b/modules/ROOT/pages/execution-engine.adoc
@@ -31,7 +31,7 @@ details on that mechanism, refer to the xref:1.1@mule-sdk::index.adoc[Mule SDK d
 
 == Optimizations
 
-There are certain conditions on flow executions where the runtime may ignore the proposed Processing Type for event processor. This is due internal optimizations.
+Due to internal optimizations, under certain conditions on flow executions Mule might ignore the proposed Processing Type for an event processor.
 
 [[threading]]
 == Threading

--- a/modules/ROOT/pages/transaction-management.adoc
+++ b/modules/ROOT/pages/transaction-management.adoc
@@ -129,7 +129,7 @@ include::{examplesdir}/transaction-management_1.xml[]
 ----
 
 [[tx_scopes_routers]]
-== How Transactions Affect Scopes, Routers and Execution Engine Selection
+== How Transactions Affect Scopes, Routers and Execution Type Selection
 
 When running in a transactional scope, the entire process must run in the same thread. This can change the way a scope executes, or how a transaction is handled. Below is detailed the behavior of the scopes and routers you must consider when running in a transactional scope:
 
@@ -147,9 +147,9 @@ When running in a transactional scope, the entire process must run in the same t
 
 Any other router or scope (for example, Foreach) continues with the transaction and its behavior is not modified.
 
-=== Execution Engine Selection
+=== Execution Engine Processing Type Selection
 
-Event processors provide hints to the runtime on which xref:execution-engine.adoc[Execution Engine] should be used to perform their task. As transaction scopes are set to run on the same thread, the Execution Engine hint will be ignored.
+Event processors provide hints to the runtime on which xref:execution-engine.adoc[Processing Type] should be used to perform their task. As transaction scopes are set to run on the same thread, the Processing Type hint will be ignored.
 
 == Error Handling
 

--- a/modules/ROOT/pages/transaction-management.adoc
+++ b/modules/ROOT/pages/transaction-management.adoc
@@ -129,7 +129,7 @@ include::{examplesdir}/transaction-management_1.xml[]
 ----
 
 [[tx_scopes_routers]]
-== How Transactions Affect Scopes and Routers
+== How Transactions Affect Scopes, Routers and Execution Engine Selection
 
 When running in a transactional scope, the entire process must run in the same thread. This can change the way a scope executes, or how a transaction is handled. Below is detailed the behavior of the scopes and routers you must consider when running in a transactional scope:
 
@@ -146,6 +146,10 @@ When running in a transactional scope, the entire process must run in the same t
 * xref:flowref-about.adoc[Flow Reference]: If the flow (or subflow) being executed is running within a transaction, the execution of the flow (or subflow) referenced by the Flow Reference component continues with the same transaction. If the referenced flow has a message source that begins a transaction (For example a `jms:listener` source with `transactionalAction="ALWAYS_BEGIN"`), the `transactionalAction` is ignored. The Flow Reference component executes the referenced flow components except for its message source.
 
 Any other router or scope (for example, Foreach) continues with the transaction and its behavior is not modified.
+
+=== Execution Engine Selection
+
+Event processors provide hints to the runtime on which xref:execution-engine.adoc[Execution Engine] should be used to perform their task. As transaction scopes are set to run on the same thread, the Execution Engine hint will be ignored.
 
 == Error Handling
 

--- a/modules/ROOT/pages/transaction-management.adoc
+++ b/modules/ROOT/pages/transaction-management.adoc
@@ -151,6 +151,8 @@ Any other router or scope (for example, Foreach) continues with the transaction 
 
 Event processors provide hints to the runtime on which xref:execution-engine.adoc[Processing Type] should be used to perform their task. As transaction scopes are set to run on the same thread, the Processing Type hint will be ignored.
 
+In other words, when processing a flow outside of a transaction, operations in the flow hints the runtime about the Execution Engine Processing Type Selection. When processing a flow inside a transaction, the operations hints are ignored at all and all the transaction is executed in the same Execution Engine Processing Type.
+
 == Error Handling
 
 When an error occurs during a transaction, your application must either handle the error and continue or perform a rollback.

--- a/modules/ROOT/pages/transaction-management.adoc
+++ b/modules/ROOT/pages/transaction-management.adoc
@@ -149,9 +149,14 @@ Any other router or scope (for example, Foreach) continues with the transaction 
 
 === Execution Engine Processing Type Selection
 
-Event processors provide hints to the runtime on which xref:execution-engine.adoc[Processing Type] should be used to perform their task. As transaction scopes are set to run on the same thread, the Processing Type hint will be ignored.
+Event processors provide information to Mule runtime engine about which xref:execution-engine.adoc[Processing Type] is best to execute the required task. Using this information, Mule executes the processor in the corresponding thread. However, this behavior changes when there's a transaction scope in a flow:
 
-In other words, when processing a flow outside of a transaction, operations in the flow hints the runtime about the Execution Engine Processing Type Selection. When processing a flow inside a transaction, the operations hints are ignored at all and all the transaction is executed in the same Execution Engine Processing Type.
+* Event processors outside of a transaction scope
++
+When Mule executes processors outside of a transaction scope, the Processing Type selection is honored.
+* Event processors inside of a transaction scope
++
+Because transaction scopes run on the same thread, Mule ignores information about the Processing Type when executing processors as part of a transaction.
 
 == Error Handling
 

--- a/modules/ROOT/pages/transaction-management.adoc
+++ b/modules/ROOT/pages/transaction-management.adoc
@@ -129,7 +129,7 @@ include::{examplesdir}/transaction-management_1.xml[]
 ----
 
 [[tx_scopes_routers]]
-== How Transactions Affect Scopes, Routers and Execution Type Selection
+== How Transactions Affect Scopes, Routers and Processing Type Selection
 
 When running in a transactional scope, the entire process must run in the same thread. This can change the way a scope executes, or how a transaction is handled. Below is detailed the behavior of the scopes and routers you must consider when running in a transactional scope:
 


### PR DESCRIPTION
Included a brief comment on when the runtime may optimize the thread pool selection for event processors.