### PR TITLE
DOCS-3940: logger example can produce error given some input types

### DIFF
--- a/modules/ROOT/pages/error-handling.adoc
+++ b/modules/ROOT/pages/error-handling.adoc
@@ -48,7 +48,7 @@ a reference:
 [source,xml,linenums]
 ----
 <on-error-continue name="loggingErrorHandler">
-    <logger message="#['Error: ' ++ error.description ++ ']"/>
+    <logger message="#['Error: ' ++ error.description]"/>
 </on-error-continue>
 
 <flow name="withSharedHandler">

--- a/modules/ROOT/pages/error-handling.adoc
+++ b/modules/ROOT/pages/error-handling.adoc
@@ -48,7 +48,7 @@ a reference:
 [source,xml,linenums]
 ----
 <on-error-continue name="loggingErrorHandler">
-    <logger message="#['Error: ' ++ error.description ++ ', Payload: ' ++ payload]"/>
+    <logger message="#['Error: ' ++ error.description ++ ']"/>
 </on-error-continue>
 
 <flow name="withSharedHandler">


### PR DESCRIPTION
revise to avoid unnecessary error 