### PR TITLE
duplicate paragraph

### DIFF
--- a/modules/ROOT/pages/execution-engine.adoc
+++ b/modules/ROOT/pages/execution-engine.adoc
@@ -233,10 +233,9 @@ Some connectors or components (expiration monitors, queue consumers, and so on) 
 Back pressure can occur when, under heavy load, Mule does not have resources available to process a specific event. This issue might occur because all threads are busy and cannot perform the handoff of the newly arrived event, or because the current flow’s `maxConcurrency` value has been exceeded already.
 
 If Mule cannot handle an event, it logs the condition with the message `Flow 'flowName' is unable to accept new events at this time`. Mule also notifies the flow source, to perform any required actions.
+
 The actions that Mule performs as a result of back-pressure are specific to each connector’s source. For example, `http:listener` might return a `503` error code, while a message-broker listener might provide the option to either wait for resources to be available or drop the message.
 In some cases, a source might disconnect from a remote system to avoid getting more data than it can process and then reconnect after the server state is normalized.
-
-The actions Mule performs on back-pressure are specific to each connector’s source. For instance, an `http:listener` might return a `503` error code, while a message broker listener might provide the option to either wait for resources to be available or drop the message. In some cases, a source might disconnect from a remote system to avoid getting more data than it can process and then reconnect once the server state is normalized.
 
 [[upgrading-from-4-x]]
 == Upgrading from Mule 4.2 or 4.1


### PR DESCRIPTION
Basically the same, but the first paragraph reads a little better (is more clear).