### PR TITLE
DOCS-6357-batch-v4.3-cv

### DIFF
--- a/modules/ROOT/pages/batch-processing-concept.adoc
+++ b/modules/ROOT/pages/batch-processing-concept.adoc
@@ -50,20 +50,20 @@ The Batch XML structure was modified on Mule 4.0. The example below shows abbrev
 [source,xml,linenums]
 ----
 <flow name="flowOne">
-	<batch:job jobName="batchJob">
-		<batch:process-records>
+  <batch:job jobName="batchJob">
+    <batch:process-records>
 
-			<batch:step name="batchStep1">
-				<event processor/>
-				<event processor/>
-			</batch:step>
+      <batch:step name="batchStep1">
+        <event processor/>
+        <event processor/>
+      </batch:step>
 
-			<batch:step name="batchStep2">
-				<event processor/>
-				<event processor/>
-			</batch:step>
-		</batch:process-records>
-	</batch:job>
+      <batch:step name="batchStep2">
+        <event processor/>
+        <event processor/>
+      </batch:step>
+    </batch:process-records>
+  </batch:job>
 </flow>
 ----
 
@@ -151,25 +151,19 @@ During this phase, you can optionally configure the runtime to create a report o
 [source,xml,linenums]
 ----
 <batch:job name="Batch3">
-        <batch:input>
-            <poll doc:name="Poll">
-                <sfdc:authorize/>
-            </poll>
-            <set-variable/>
-        </batch:input>
-        <batch:process-records>
-            <batch:step name="Step1">
-                <batch:record-variable-transformer/>
-                <data-mapper:transform/>
-            </batch:step>
-            <batch:step name="Step2">
-                <logger/>
-                <http:request/>
-            </batch:step>
-        </batch:process-records>
-        <batch:on-complete>
-            <logger/>
-        </batch:on-complete>
+  <batch:process-records>
+    <batch:step name="Step1">
+      <batch:record-variable-transformer/>
+      <ee:transform/>
+    </batch:step>
+    <batch:step name="Step2">
+      <logger/>
+      <http:request/>
+    </batch:step>
+  </batch:process-records>
+  <batch:on-complete>
+    <logger/>
+  </batch:on-complete>
 </batch:job>
 ----
 


### PR DESCRIPTION
Removed outdated element: _<batch:input>_. Fixed indentation in examples.