### PR TITLE
DOCS-7379-properties-v4.3-cv

### DIFF
--- a/modules/ROOT/pages/configuring-properties.adoc
+++ b/modules/ROOT/pages/configuring-properties.adoc
@@ -242,7 +242,7 @@ See xref:runtime-manager::managing-applications-on-cloudhub.adoc[Managing Applic
 [[properties-hierarchy]]
 == Properties Hierarchy
 
-Configuration properties can be overwritten. The Mule runtime engine uses the following hierarchy to determine which properties take precedence if they have the same name. In this hierarchy, system properties are at the top, so they take precedence over the other types of properties.
+Configuration properties can be overwritten. The Mule runtime engine uses the following hierarchy to determine which properties take precedence if they have the same name. In this hierarchy, deployment properties are at the top, so they take precedence over the other types of properties.
 
 . Deployment properties
 . System properties


### PR DESCRIPTION
Fixed inconsistent text in hierarchy's description.