### PR TITLE
DOCS-10219: Fix example with property to skip null values

### DIFF
--- a/modules/ROOT/pages/dataweave-formats.adoc
+++ b/modules/ROOT/pages/dataweave-formats.adoc
@@ -170,12 +170,12 @@ output application/csv separator=";", header=false
 payload
 ----
 
-Writer properties depend on the format. The following example uses the JSON writer property, `skipOnNull`:
+Writer properties depend on the format. The following example uses the JSON writer property, `skipNullOn`:
 
 [source,json,linenums]
 ----
 %dw 2.0
-output application/json skipOnNull=everywhere
+output application/json skipNullOn="everywhere"
 ---
 payload
 ----


### PR DESCRIPTION
property name was wrong and quotes are required for value