### PR TITLE
Update dataweave-formats-json.adoc

### DIFF
--- a/modules/ROOT/pages/dataweave-formats-json.adoc
+++ b/modules/ROOT/pages/dataweave-formats-json.adoc
@@ -214,7 +214,7 @@ returnedElement : element.zipcode
 </flow>
 ----
 
-* The streaming example configures the HTTP listener to stream the JSON input
+* The streaming example configures the File Read operation to stream the JSON input
 by setting `outputMimeType="application/json; streaming=true"`.
 In the Studio UI, you can set the *MIME Type* on the listener to `application/json`
 and the *Parameters* for the MIME Type to *Key* `streaming` and *Value* `true`.


### PR DESCRIPTION
Fixed explanatory note for JSON streaming example. This streaming configuration is for a File Read, not an HTTP Listener.