### PR TITLE
DOCS-11043 fix quotes

### DIFF
--- a/modules/ROOT/pages/dataweave-language-introduction.adoc
+++ b/modules/ROOT/pages/dataweave-language-introduction.adoc
@@ -61,7 +61,7 @@ fun toUser(obj) = {
   firstName: obj.field1,
   lastName: obj.field2
 }
-type Currency = String { format: “##“}
+type Currency = String { format: "##"}
 ns ns0 http://www.abc.com
 output application/xml
 ---


### PR DESCRIPTION
I tried to copy and use the following line:

`type Currency = String { format: “##“}`

and it didn't work as Dataweave does not recognize this quotation.

Fixed it here.