### PR TITLE
DOCS-11107: fix "on error continue" section text

### DIFF
--- a/modules/ROOT/pages/on-error-scope-concept.adoc
+++ b/modules/ROOT/pages/on-error-scope-concept.adoc
@@ -35,7 +35,7 @@ image::mruntime-on-error-propagate.png[]
 Executes and uses the result of the execution as the result of its owner,
 as if the owner completed the execution successfully. Any transaction the
 owner handles is committed. However, note that the transaction is not committed
-if another component (one that does not own On Error Propagate) created the
+if another component (one that does not own On Error Continue) created the
 transaction.
 
 == Error Matching


### PR DESCRIPTION
it is referencing "on error propagate", but it should be "on error continue"