### PR TITLE
Update mule-error-concept.adoc

### DIFF
--- a/modules/ROOT/pages/mule-error-concept.adoc
+++ b/modules/ROOT/pages/mule-error-concept.adoc
@@ -41,7 +41,7 @@ number of the error fields.
 
 |Description
 |A description of the problem.
-|`#[error.description]` and
+|`#[error.description]`
 
 |Detailed Description
 |A description of the problem, which can be the same or more extensive than the description.


### PR DESCRIPTION
There was a random "and" after the selector expression for error.description