### PR TITLE
DOCS-11115-dw-read-example-kt

### DIFF
--- a/modules/ROOT/pages/dw-core-functions-read.adoc
+++ b/modules/ROOT/pages/dw-core-functions-read.adoc
@@ -107,7 +107,7 @@ output application/xml
 
 === Example
 
-This example reads if the specified input string is XML or JSON format.
+This example reads if the specified input string is in XML or JSON format.
 
 ==== Source
 

--- a/modules/ROOT/pages/dw-core-functions-read.adoc
+++ b/modules/ROOT/pages/dw-core-functions-read.adoc
@@ -105,3 +105,33 @@ output application/xml
 </XML>
 ----
 
+=== Example
+
+This example reads if the specified input string is XML or JSON format.
+
+==== Source
+
+[source,DataWeave,linenums]
+----
+%dw 2.0
+output application/dw
+var xml = "<test>XML</test>"
+var json = '{"test":1, "test2": 2}'
+var test = xml
+---
+// Reads if the input string is in JSON format
+dw::Runtime::try(() -> read(test,"application/json"))
+// Reads if the input string is in XML format
+dw::Runtime::orElseTry(() -> read(test,"application/xml"))
+// The input string is not either in XML or JSON format
+dw::Runtime::orElse("Not XML or JSON")
+----
+
+==== Output
+
+[source,dataweave,linenums]
+----
+{
+  test: "XML"
+}
+----

--- a/modules/ROOT/pages/dw-core-functions-read.adoc
+++ b/modules/ROOT/pages/dw-core-functions-read.adoc
@@ -114,17 +114,18 @@ This example reads if the specified input string is XML or JSON format.
 [source,DataWeave,linenums]
 ----
 %dw 2.0
+import * from dw::Runtime
 output application/dw
 var xml = "<test>XML</test>"
 var json = '{"test":1, "test2": 2}'
 var test = xml
 ---
 // Reads if the input string is in JSON format
-dw::Runtime::try(() -> read(test,"application/json"))
+try(() -> read(test,"application/json"))
 // Reads if the input string is in XML format
-dw::Runtime::orElseTry(() -> read(test,"application/xml"))
+orElseTry(() -> read(test,"application/xml"))
 // The input string is not either in XML or JSON format
-dw::Runtime::orElse("Not XML or JSON")
+orElse("Not XML or JSON")
 ----
 
 ==== Output

--- a/modules/ROOT/pages/dw-core-functions-read.adoc
+++ b/modules/ROOT/pages/dw-core-functions-read.adoc
@@ -107,7 +107,8 @@ output application/xml
 
 === Example
 
-This example reads if the specified input string is in XML or JSON format.
+This example returns the input parameter if it is in XML or JSON format, otherwise, it returns the message `Not XML or JSON`.
+The example uses the `read` function to verify if the specified input string is in XML or JSON.
 
 ==== Source
 
@@ -116,16 +117,23 @@ This example reads if the specified input string is in XML or JSON format.
 %dw 2.0
 import * from dw::Runtime
 output application/dw
-var xml = "<test>XML</test>"
-var json = '{"test":1, "test2": 2}'
-var test = xml
+var xmlInput = "<Input><name>Max the Mule</name><ID>123</ID><Type>XML</Type></Input>"
+var jsonInput = '{"Input": {"name": "Max the Mule", "ID": 123, "Type": "JSON"}}'
+var stringInput = "name: Max the Mule, ID: 123, Type: String"
+//This function returns the input parameter if it is in XML or JSON format, otherwise, it returns a static message
+fun testType(inputMessage) =
+    // Reads the input only if the data is in JSON format
+    try(() -> read(inputMessage,"application/json"))
+    // Reads the input only if the data is in XML format
+    orElseTry(() -> read(inputMessage,"application/xml"))
+    // Return this message if the input data is not either in XML or JSON format
+    orElse("Not XML or JSON")
 ---
-// Reads if the input string is in JSON format
-try(() -> read(test,"application/json"))
-// Reads if the input string is in XML format
-orElseTry(() -> read(test,"application/xml"))
-// The input string is not either in XML or JSON format
-orElse("Not XML or JSON")
+{
+    "Test 'xmlInput' ": testType(xmlInput),
+    "Test 'jsonInput' ": testType(jsonInput),
+    "Test 'stringInput' ": testType(stringInput),
+}
 ----
 
 ==== Output
@@ -133,6 +141,20 @@ orElse("Not XML or JSON")
 [source,dataweave,linenums]
 ----
 {
-  test: "XML"
+  "Test 'xmlInput' ": {
+    Input: {
+      name: "Max the Mule",
+      ID: "123",
+      Type: "XML"
+    }
+  },
+  "Test 'jsonInput' ": {
+    Input: {
+      name: "Max the Mule",
+      ID: 123,
+      Type: "JSON"
+    }
+  },
+  "Test 'stringInput' ": "Not XML or JSON"
 }
 ----


### PR DESCRIPTION
Migrating read StackOverflow sample into our Docs site https://stackoverflow.com/questions/58508146/in-mulesoft-dataweave-2-0-is-there-a-way-to-test-if-an-input-string-is-xml-or-js