### PR TITLE
Change Time Zone ID Page Reference

### DIFF
--- a/modules/ROOT/pages/dataweave-types.adoc
+++ b/modules/ROOT/pages/dataweave-types.adoc
@@ -384,7 +384,7 @@ For examples, see xref:dataweave-cookbook-format-dates.adoc[Format Dates and Tim
 
 In addition to accepting time zone values, such as `-07:00`, DataWeave also accepts IDs such as `America/Buenos_Aires`, `America/Los_Angeles`, `Asia/Tokyo`, and `GMT`.
 
-For examples and a list of supported IDs, see xref:dataweave-cookbook-format-dates.adoc#ex03[Format Dates and Times].
+For examples and a list of supported IDs, see xref:dataweave-cookbook-change-time-zone.adoc#timezone-ids[Change a Time Zone].
 
 [[dw_type_enum]]
 == Enum (dw::Core Type)


### PR DESCRIPTION
I changed the section on Time Zone ID to point to the right page with the right title.