### PR TITLE
DOCS-11581: Update dataweave-flat-file-schemas.adoc

### DIFF
--- a/modules/ROOT/pages/dataweave-flat-file-schemas.adoc
+++ b/modules/ROOT/pages/dataweave-flat-file-schemas.adoc
@@ -10,7 +10,7 @@ include::partial$dataweave1-links.adoc[tag=dataweave1LandingPage]
 
 DataWeave uses a YAML format called FFD (for Flat File Definition) to represent flat file schemas. The FFD format is flexible enough to support a range of use cases, but is based around the concepts of elements, composites, segments, groups, and structures.
 
-Schemas must be written in Flat File Schema Language, and by convention use a `.ffs` extension. This language is very similar to EDI Schema Language (ESL), which is also accepted by Anypoint Studio.
+Schemas must be written in Flat File Schema Language, and by convention use a `.ffd` extension. This language is very similar to EDI Schema Language (ESL), which is also accepted by Anypoint Studio.
 
 In DataWeave, you can bind your input or output to a flat file schema through a property.
 


### PR DESCRIPTION
Mule only accepts .ffd files as the Flat File Schema files, not .ffs.