### PR TITLE
DOCS-11491-DW-csv-invisible-character-example-kt

### DIFF
--- a/modules/ROOT/pages/dataweave-formats.adoc
+++ b/modules/ROOT/pages/dataweave-formats.adoc
@@ -181,6 +181,42 @@ output application/json skipNullOn="everywhere"
 payload
 ----
 
+The following example shows a DataWeave script that uses an invisible ASCII character as a separator for the CSV output. The separator property value is `\u001E` where `\u` is the escape sequence representation and `001E` is the hexadecimal representation of the record separator (RS) ASCII character.
+
+[source,DataWeave,linenums]
+----
+%dw 2.0
+output application/csv separator = "\u001E"
+---
+[
+	{
+		"Name" : "Tom",
+		"UID" : 2569,
+		"ShipOrderID" : "ui-288188"
+	},
+	{
+		"Name" : "Alan",
+		"UID" : 7756,
+		"ShipOrderID" : "xj-232142"
+	},
+	{
+		"Name" : "Dan",
+		"UID" : 7821,
+		"ShipOrderID" : "uk-259459"
+	}
+]
+----
+
+The CSV example produces the following output:
+
+[source,csv,linenums]
+----
+NameUIDShipOrderID
+Tom2569ui-288188
+Alan7756xj-232142
+Dan7821uk-259459
+----
+
 Scripts that use the `read` or `readUrl` methods can also specify reader properties through the `readerProperties` parameter. See examples in xref:dw-core-functions-read.adoc[read]. However, note that use of reader properties is more common in message sources, such as the HTTP listener, as shown in the <<example_csv_reader, CSV reader example>>.
 
 It is also possible to use a Mule variable as a value of a configuration property. For more complete examples, see xref:dataweave-cookbook-set-reader-writer-props.adoc[Set Reader and Writer Configuration Properties].

--- a/modules/ROOT/pages/dataweave-formats.adoc
+++ b/modules/ROOT/pages/dataweave-formats.adoc
@@ -181,7 +181,7 @@ output application/json skipNullOn="everywhere"
 payload
 ----
 
-The following example shows a DataWeave script that uses an invisible ASCII character as a separator for the CSV output. The separator property value is `\u001E` where `\u` is the escape sequence representation and `001E` is the hexadecimal representation of the record separator (RS) ASCII character.
+The following example shows a DataWeave script that uses an invisible ASCII character as a separator for the CSV output. The separator property value is `\u001E`. `\u` is the escape sequence representation and `001E` is the hexadecimal representation of the record separator (RS) ASCII character.
 
 [source,DataWeave,linenums]
 ----


### PR DESCRIPTION
Migrating KB to our docs https://help.mulesoft.com/s/article/How-to-use-invisible-character-as-delimiter-in-csv-Mule-4
Adding new example for CSV Writer property