### PR TITLE
DOCS-11987 (SE-22512) - DW EOI character troubleshooting

### DIFF
--- a/modules/ROOT/pages/dataweave-troubleshoot.adoc
+++ b/modules/ROOT/pages/dataweave-troubleshoot.adoc
@@ -132,6 +132,20 @@ Stack Overflow. Max stack is 256
 
 You can configure the maximum stack size by using the property `com.mulesoft.dw.stacksize`.
 
+== DataWeave Warnings
+
+=== End of input was reached
+
+DataWeave treats the Unicode non-character `U+FFFF` as a special character indicating
+end of input has been reached.
+One way to solve this problem is to replace the special character directly on the
+raw payload, and then proceed as usual.
+
+[source,weave, linenums]
+----
+read(payload.^raw replace "\uFFFF" with "NonChar")
+----
+
 == Output Mismatch When Undefined
 
 Unlike transformations, DataWeave expressions do not require you to define an output format because DataWeave can infer the output based on the expression and the variables you use. Occasionally, the inference process results in a mismatch between the inferred type and the expected type. To resolve this issue, you must make the output explicit. Common examples of this situation occur when:

--- a/modules/ROOT/pages/dataweave-troubleshoot.adoc
+++ b/modules/ROOT/pages/dataweave-troubleshoot.adoc
@@ -12,7 +12,6 @@ change unexpectedly. Therefore, it's important to capture the inputs going into 
 script debugging or using loggers. Often, the failures occur because the input
 coming from another component upstream is not valid. You can find here a listing of the most common DataWeave errors and how to overcome them.
 
-
 == Dump Input Context and the Script into a Folder
 
 In Mule 4.2.1, DataWeave introduced an experimental feature that enables you
@@ -36,7 +35,7 @@ The default directory is `/tmp`.
 
 == DataWeave Exceptions
 
-The tool can help you address a number of common DataWeave exceptions.
+The following are some common DataWeave exceptions that you can find in your dump file, along with some details to troubleshoot these errors.
 
 === Incorrect Arguments
 
@@ -134,12 +133,13 @@ You can configure the maximum stack size by using the property `com.mulesoft.dw.
 
 == DataWeave Warnings
 
-=== End of input was reached
+The following are some common DataWeave warnings that you can find in your dump file, along with some details to address these warnings.
 
-DataWeave treats the Unicode non-character `U+FFFF` as a special character indicating
-end of input has been reached.
-One way to solve this problem is to replace the special character directly on the
-raw payload, and then proceed as usual.
+=== End of Input Was Reached
+
+This warning shows because DataWeave treats the Unicode non-character `U+FFFF` as a special character that indicates the end of input.
+
+To avoid this warning, replace the special character in the raw payload and then proceed as usual.
 
 [source,weave, linenums]
 ----


### PR DESCRIPTION
Added a new troubleshooting section (`Dataweave Warnings`) and an entry with the \uFFFF character case