### PR TITLE
Update dataweave-create-module.adoc

### DIFF
--- a/modules/ROOT/pages/dataweave-create-module.adoc
+++ b/modules/ROOT/pages/dataweave-create-module.adoc
@@ -155,7 +155,7 @@ When you import the custom module into a DataWeave script, you can create aliase
 [source,dataweave,linenums]
 ----
 %dw 2.0
-import myFunc as appendDash, myVar as weaveName from modules::MyModule
+import myFunc as appendDash, name as weaveName from modules::MyModule
 var myVar = "Mapping"
 output application/json
 ---


### PR DESCRIPTION
MyModule.dwl file in the example doesn't have "myVar" variable. It should be "name".