### PR TITLE
DOCS-13075: Removed the synchronized="false"

### DIFF
--- a/modules/ROOT/pages/cache-scope-strategy.adoc
+++ b/modules/ROOT/pages/cache-scope-strategy.adoc
@@ -72,7 +72,7 @@ The following XML snippet shows the configuration of a caching strategy that syn
 [source, xml, linenums]
 ----
 <!-- Caching strategy definition -->
-<ee:object-store-caching-strategy name="Caching_Strategy" doc:name="Caching Strategy" synchronized="false" >
+<ee:object-store-caching-strategy name="Caching_Strategy" doc:name="Caching Strategy">
   <!-- Object Store defined for the caching strategy-->
   <os:private-object-store
     alias="CachingStrategy_ObjectStore"


### PR DESCRIPTION
Removed the synchronized="false" in the line number 75 as per the line 63 this setting is for disabling the cache synchronization and line 70 says XML snippet is for the configuration of a caching strategy that synchronizes access to the cache. But with the setting synchronized="false" I believe we are actually disabling synchronization and that is not the intent as per line 70.