### PR TITLE
W-10852111: variableName can be calculated by using expression

### DIFF
--- a/modules/ROOT/pages/variable-transformer-reference.adoc
+++ b/modules/ROOT/pages/variable-transformer-reference.adoc
@@ -16,7 +16,7 @@ for complex scenarios.
 
 | Variable Name (`variableName`)
 | Required
-| Name of the variable. Names can only include numbers, characters, and underscores. For example, hyphens are not allowed in the name.
+| Name of the variable, which can be a string or a DataWeave expression. Resulting names can only include numbers, characters, and underscores. For example, hyphens are not allowed in the name.
 
 | Value (`value`)
 | Required

--- a/modules/ROOT/pages/variable-transformer-reference.adoc
+++ b/modules/ROOT/pages/variable-transformer-reference.adoc
@@ -16,7 +16,7 @@ for complex scenarios.
 
 | Variable Name (`variableName`)
 | Required
-| Name of the variable, which can be a string or a DataWeave expression. Variable names can only include numbers, characters, and underscores. For example, hyphens are not allowed in the name.
+| Name of the variable, which can be a string or a DataWeave expression. Variable names can include only numbers, characters, and underscores. For example, hyphens are not allowed in the name.
 
 | Value (`value`)
 | Required

--- a/modules/ROOT/pages/variable-transformer-reference.adoc
+++ b/modules/ROOT/pages/variable-transformer-reference.adoc
@@ -16,7 +16,7 @@ for complex scenarios.
 
 | Variable Name (`variableName`)
 | Required
-| Name of the variable, which can be a string or a DataWeave expression. Resulting names can only include numbers, characters, and underscores. For example, hyphens are not allowed in the name.
+| Name of the variable, which can be a string or a DataWeave expression. Variable names can only include numbers, characters, and underscores. For example, hyphens are not allowed in the name.
 
 | Value (`value`)
 | Required


### PR DESCRIPTION
With mule runtime 4.3.0 and 4.4.0 it is possible to use another flowVar for variablename.
e.g. via `variableName="#[vars.targetName]"`

The AttributeEvaluator is called when evaluating the variableName 

```
Thread [[MuleRuntime].uber.01: [20220224-expression-for-variablename].20220224-expression-for-variablenameFlow.CPU_LITE @157b0078] (Suspended)	
	DefaultExpressionManagerSession.evaluate(CompiledExpression, DataType) line: 113	
	ExpressionAttributeEvaluatorDelegate<T>.resolveExpressionWithSession(ExpressionManagerSession) line: 68	
	ExpressionAttributeEvaluatorDelegate<T>.resolve(CoreEvent, ExtendedExpressionManager) line: 50	
	AttributeEvaluator.resolveTypedValue(CoreEvent) line: 111	
	AttributeEvaluator.resolveValue(CoreEvent) line: 115	
	AddFlowVariableProcessor(AbstractAddVariablePropertyProcessor<T>).process(CoreEvent) line: 64	
	429995390.applyChecked(Object) line: not available
```	

Example:

```
<set-variable value="myVariable" doc:name="Set targetName" variableName="targetName"/>
<set-variable value="specialValue" doc:name="Set Variable #[vars.targetName]" variableName="#[vars.targetName]"/>
<logger level="INFO" doc:name="Log targetName" message='#["vars.targetName=" ++ vars.targetName]' category="log"/>
<logger level="INFO" doc:name="Log myVariable" message='#["vars.myVariable=" ++ vars.myVariable]' category="log" />
```

Result:

```
log: vars.targetName=myVariable
log: vars.myVariable=specialVal
```