### PR TITLE
W-10840238: Path doesn't have ++ : Point 11

### DIFF
--- a/modules/ROOT/pages/dynamic-evaluate-component-reference.adoc
+++ b/modules/ROOT/pages/dynamic-evaluate-component-reference.adoc
@@ -99,6 +99,7 @@ The source initiates the flow by listening for incoming HTTP requests.
 +
 . Click *OK*.
 . In the *File path* field, set the path `#["dw_" ++ attributes.queryParams.locale ++ ".dwl"]`. 
++
 The connector reads the locally stored DataWeave script file names that start with `dw_` and contains the `locale` query parameter (`attributes.queryParams.locale`) received in the HTTP request.
 +
 . In the *Advanced* tab, set the *Target Variable* field to `dwScript`. +

--- a/modules/ROOT/pages/dynamic-evaluate-component-reference.adoc
+++ b/modules/ROOT/pages/dynamic-evaluate-component-reference.adoc
@@ -98,7 +98,7 @@ The source initiates the flow by listening for incoming HTTP requests.
 `/Users/username/AnypointStudio/studio-workspace/dynamicevaluate/src/main/resources`
 +
 . Click *OK*.
-. In the *File path* field, set the path `#["dw_" ++ attributes.queryParams.locale ++ ".dwl"]`. +
+. In the *File path* field, set the path `#["dw_" ++ attributes.queryParams.locale ++ ".dwl"]`. 
 The connector reads the locally stored DataWeave script file names that start with `dw_` and contains the `locale` query parameter (`attributes.queryParams.locale`) received in the HTTP request.
 +
 . In the *Advanced* tab, set the *Target Variable* field to `dwScript`. +


### PR DESCRIPTION
Point 11 under 'Create the Mule Application', File path doesnt have concatenation . It should be 
#["dw_" ++  attributes.queryParams.locale " ++ .dwl"] instead of
#["dw_" attributes.queryParams.locale ".dwl"]