### PR TITLE
Type om 1st Paragraph

### DIFF
--- a/modules/ROOT/pages/transform-add-another-output-transform-studio-task.adoc
+++ b/modules/ROOT/pages/transform-add-another-output-transform-studio-task.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 
-A single Transform Message component can give shape to several different parts of the output Mule event (the payload, variables, and attributes). Each different output part must be defined in a separate target XML element inside the `<ee:transform>` XML element as anther block of DataWeave code. In Anypoint Studio 7, you do this by writing the DataWeave code in a separate tab of the Transform pane. For example, if one tab defines the payload, and another attributes, these are both parts of the same output Mule event.
+A single Transform Message component can give shape to several different parts of the output Mule event (the payload, variables, and attributes). Each different output part must be defined in a separate target XML element inside the `<ee:transform>` XML element as another block of DataWeave code. In Anypoint Studio 7, you do this by writing the DataWeave code in a separate tab of the Transform pane. For example, if one tab defines the payload, and another attributes, these are both parts of the same output Mule event.
 
 
 


### PR DESCRIPTION
Each different output part must be defined in a separate target XML element inside the <ee:transform> XML element as "anther"
Typo in 1st paragraph. It meant another than anther