### PR TITLE
Camelcase for No for Better Look n Feel

### DIFF
--- a/modules/ROOT/pages/streaming-strategies-reference.adoc
+++ b/modules/ROOT/pages/streaming-strategies-reference.adoc
@@ -38,8 +38,8 @@ buffer is full.
 a STREAM_MAXIMUM_SIZE_EXCEEDED error is raised. A value lower or equal to zero means no limit. Defaults to 1024
 
 | `bufferUnit`
-| NO
-| NO
+| No
+| No
 | KB
 | The unit in which all these attributes are expressed. Possible values: BYTE, KB, MB, GB.
 |===


### PR DESCRIPTION
bufferUnit Parameter name 
- is required & Expressions - value can be made Camelcase for better look and feel in line with previous Parameter names
- No from NO