### PR TITLE
Repeated entries

### DIFF
--- a/modules/ROOT/pages/tuning-monitoring.adoc
+++ b/modules/ROOT/pages/tuning-monitoring.adoc
@@ -21,7 +21,6 @@ image::mruntime-tuning-monitoring-top.png[Top command CPU stats]
 The main metrics to pay attention to are:
 
 ** `%sys`, which shows how much CPU is used at system level (kernel)
-** `%sys`, which shows how much CPU is used at system level (kernel)
 ** `%idle`, which shows the percentage of time that the CPU was idle
 
 .Sar command CPU stats


### PR DESCRIPTION
 `%sys`, which shows how much CPU is used at system level (kernel) line is repeated twice under 'CPU Resource' Heading