### PR TITLE
</dependencies> open tag missing

### DIFF
--- a/modules/ROOT/pages/mmp-concept.adoc
+++ b/modules/ROOT/pages/mmp-concept.adoc
@@ -198,7 +198,7 @@ The following example configures Anypoint Connector for Database (Database Conne
   </plugins>
 </build>
 
-</dependencies>
+<dependencies>
   <!--Database Connector dependency -->
   <dependency>
     <groupId>org.mule.connectors</groupId>


### PR DESCRIPTION
Under 'Configure shared libraries' , <dependencies> start tag is missing