### PR TITLE
W-10984718: Error Mapping section update

### DIFF
--- a/modules/ROOT/pages/intro-error-handlers.adoc
+++ b/modules/ROOT/pages/intro-error-handlers.adoc
@@ -89,7 +89,7 @@ The error handler behaves as we have explained earlier. In the example above, an
 == Error Mapping
 Mule 4 now also allows for mapping default errors to custom ones. The Try scope is useful, but if you have several equal components and want to distinguish the errors of each one, using a Try on them can clutter your app. Instead, you can add error mappings to each component, meaning that all or certain kind of errors streaming from the component are mapped to another error of your choosing. If, for example, you are aggregating results from 2 APIs using an HTTP request component for each, you might want to distinguish between the errors of API 1 and API 2, since by default, their errors are the same.
 
-By mapping errors from the first request to a custom `API_1` error and errors in the second request to `API_2`, you can route those errors to different handlers. The next example maps `HTTP:INTERNAL_SERVER_ERROR`  so that different handling policies can be applied if the APIs go down (propagating the error in the first API and handling it in the second API).
+By mapping errors from the first request to a custom `API_1:API_1` error and errors in the second request to `API_2:API_2`, you can route those errors to different handlers. The next example maps `HTTP:INTERNAL_SERVER_ERROR`  so that different handling policies can be applied if the APIs go down (propagating the error in the first API and handling it in the second API).
 
 image::error-handling-mappings.png[Error Handling Mappings]
 


### PR DESCRIPTION
There are two errors when creating the flow for the two requests using AnyPoint Studio Version: 7.11.1: 
MuleRuntimeException: Could not find ErrorType for the given identifier: 'API_1'
MuleRuntimeException: Could not find ErrorType for the given identifier: 'API_2'

Updating the Error Type in the Error Continue and in Error Propagate to API_2:API_2 and API_1:API_1 respectively will fix the issue. Currently the screenshot https://docs.mulesoft.com/mule-runtime/4.4/_images/error-handling-mappings.png also misleads that the error type is API_1 or API_2 instead of API_1:API_1 and API_2:API_2. It is also good to update both Requests display name to API 1 and API 2. I have an updated screenshot as well, https://i.ibb.co/3SyGbv7/error-mappings.png.