### PR TITLE
W-11098233: Links to the platform should not have 'www.'

### DIFF
--- a/modules/ROOT/pages/anypoint-connectors.adoc
+++ b/modules/ROOT/pages/anypoint-connectors.adoc
@@ -108,4 +108,4 @@ See also https://support.mulesoft.com[Contact MuleSoft Support].
 
 == See Also
 
-* https://www.anypoint.mulesoft.com/exchange/?type=connector[Anypoint Exchange].
+* https://anypoint.mulesoft.com/exchange/?type=connector[Anypoint Exchange].


### PR DESCRIPTION
[W-11098233](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00000wLRxMYAW/view): 
Based on the engineering feedback, we should update the links to the Anypoint platform to remove the `www.` section of the URL as it might not be fully supported.