### PR TITLE
W-11406774: updated doc concerning try scope

### DIFF
--- a/modules/ROOT/pages/intro-error-handlers.adoc
+++ b/modules/ROOT/pages/intro-error-handlers.adoc
@@ -84,7 +84,7 @@ For the most part, Mule 3 only allows error handling at the flow level, forcing 
 
 image::error-handling-try.png[Try Scope]
 
-The error handler behaves as we have explained earlier. In the example above, any database connection errors are propagated, causing the `try` to fail and the flow’s error handler to execute. In this case, any other errors are handled, and the Try scope is considered successful which, in turn, means that the next processor in the flow, an HTTP request, continues its execution.
+The error handler behaves as we have explained earlier. In the example above, any database connection errors are propagated, causing the `try` to fail and the flow’s error handler to execute. As the `try` is failed, the Write processor is not executed. Moreover, the errors are passed back to the try-example flow which causes execution of that flow to stop and propagate the error. Therefore, the HTTP request is never executed.
 
 == Error Mapping
 Mule 4 now also allows for mapping default errors to custom ones. The Try scope is useful, but if you have several equal components and want to distinguish the errors of each one, using a Try on them can clutter your app. Instead, you can add error mappings to each component, meaning that all or certain kind of errors streaming from the component are mapped to another error of your choosing. If, for example, you are aggregating results from 2 APIs using an HTTP request component for each, you might want to distinguish between the errors of API 1 and API 2, since by default, their errors are the same.


### PR DESCRIPTION
Two ways this doc can be updated:
1. The try scope example is not specific. Per the diagram, it should say that the http request is never executed as the error is re-thrown to the try-example flow. (I have updated the doc).
2. Or two diagrams should be included to elaborate both On-Error components with respect to the Try scope
    2.1 the on-error-continue (placing it on top of the try scope error handler)
    2.2 the on-error-propagate (placing it on top of the try scope error handler - the way it is now in the diagram)

* also with the new version of AnyPoint Studio (7.12.1), when I was testing it, the top on-error component needed 'Any' type.

# Writer's Quality Checklist

Before merging your PR, did you:

- [ ] Run spell checker
- [ ] Run link checker to check for broken xrefs
- [ ] Check for orphan files
- [ ] Perform a local build and do a final visual check of your content, including checking for:
  - Broken images
  - Dead links
  - Correct rendering of partials if they are used in your content
  - Formatting issues, such as:
    - Misnumbered ordered lists (steps) or incorrectly nested unordered lists
    - Messed up tables
    - Proper indentation
    - Correct header levels
- [ ] Receive final review and signoff from:
  - Technical SME
  - Product Manager
  - Editor or peer reviewer
  - Reporter, if this content is in response to a reported issue (internal or external feedback)
- [ ] If applicable, verify that the software actually got released