### PR TITLE
Update correct location of forwardSslSession and lastMileSecurity con…

### DIFF
--- a/modules/ROOT/pages/_partials/mmp-deploy-to-cloudhub-2.adoc
+++ b/modules/ROOT/pages/_partials/mmp-deploy-to-cloudhub-2.adoc
@@ -48,10 +48,10 @@ include::mule-runtime::example$mmp-concept-config.xml[]
         <http>
           <inbound>
             <publicUrl>${publicURL}</publicUrl>
+            <forwardSslSession>true</forwardSslSession>
+            <lastMileSecurity>true</lastMileSecurity>
           </inbound>
         </http>
-        <lastMileSecurity>true</lastMileSecurity>
-        <forwardSslSession>true</forwardSslSession>
       </deploymentSettings>
     </cloudhub2Deployment>
   </configuration>
@@ -213,15 +213,7 @@ Configuration example:
   <updateStrategy>recreate</updateStrategy>
 </deploymentSettings>
 ----
-| `forwardSslSession` | Enables SSL forwarding during a session. The default value is `false`.
 
-Configuration example:
-[source,xml,linenums]
-----
-<deploymentSettings>
-  <forwardSslSession>true</forwardSslSession>
-</deploymentSettings>
-----
 | `clustered` | Enables clustering across two or more replicas of the application. The default value is `false`. +
 
 Configuration example:
@@ -231,23 +223,16 @@ Configuration example:
     <clustered>true</clustered>
 </deploymentSettings>
 ----
-| `lastMileSecurity` | Enable Last-Mile security to forward HTTPS connections to be decrypted by this application +
-This requires an SSL certificate to be included in the Mule application, and also requires more CPU resources. The default value is `false`. +
-Configuration example:
-[source,xml,linenums]
-----
-<deploymentSettings>
-    <lastMileSecurity>true</lastMileSecurity>
-</deploymentSettings>
-----
 
 | `http` |
 
 [cols=".^1,.^1,.^3"]
 !===
-.2+! `inbound`
+.3+! `inbound`
 //  ! `pathRewrite` ! TBC.
   ! `publicURL` ! URL of the deployed application.
+  ! `lastMileSecurity` ! Enable Last-Mile security to forward HTTPS connections to be decrypted by this application. This requires an SSL certificate to be included in the Mule application, and also requires more CPU resources. The default value is `false`.
+  ! `forwardSslSession` ! Enables SSL forwarding during a session. The default value is `false`.
 !===
 Configuration example:
 [source,xml,linenums]
@@ -256,6 +241,8 @@ Configuration example:
   <http>
     <inbound>
       <publicUrl>myapp.anypoint.com</publicUrl>
+      <lastMileSecurity>true</lastMileSecurity>
+      <forwardSslSession>true</forwardSslSession>
     </inbound>
   </http>
 </deploymentSettings>


### PR DESCRIPTION
…fig elements

Update correct location of forwardSslSession and lastMileSecurity config elements. They have moved location from deploymentSettings to deploymentSettings/http/inbound. See source here: https://github.com/mulesoft/mule-maven-plugin/blob/34f7932feed0da4471f7666efa47c768ffa2dbf3/mule-deployer/src/main/java/org/mule/tools/model/anypoint/Inbound.java

# Writer's Quality Checklist

Before merging your PR, did you:

- [x] Run spell checker
- [x] Run link checker to check for broken xrefs
- [x] Check for orphan files
- [x] Perform a local build and do a final visual check of your content, including checking for:
  - Broken images
  - Dead links
  - Correct rendering of partials if they are used in your content
  - Formatting issues, such as:
    - Misnumbered ordered lists (steps) or incorrectly nested unordered lists
    - Messed up tables
    - Proper indentation
    - Correct header levels
- [x] Receive final review and signoff from:
  - Technical SME
  - Product Manager
  - Editor or peer reviewer
  - Reporter, if this content is in response to a reported issue (internal or external feedback)
- [x] If applicable, verify that the software actually got released