### PR TITLE
[W-11825726] callout typo fix gc v3.9

### DIFF
--- a/modules/ROOT/pages/mule-credentials-vault.adoc
+++ b/modules/ROOT/pages/mule-credentials-vault.adoc
@@ -166,7 +166,7 @@ image::global-secure.png[global_secure]
 |*Name* |x |A unique name for your global secure property placeholder.
 |*Key* |x |the word or phrase to unlock the Credentials Vault according to the system property you define in this field. For example, `${production.myproperty}` instructs Mule to demand the key at runtime.
 |*Location* |  |The name of the properties file that the key unlocks.
-|*Encryption Algorithm* |  |The type of algorithm you used to encrypt the content of the Credentials Vault. +
+|*Encryption Algorithm* |  |The type of algorithm you used to encrypt the content of the Credentials Vault.
 [TIP]
 --
 The algorithms supported are:
@@ -191,7 +191,7 @@ The algorithms supported are:
 * Twofish
 * XT
 --
-|*Encryption Mode* |  |The procedure that allows Mule to repeatedly use a block cipher with a single key. +
+|*Encryption Mode* |  |The procedure that allows Mule to repeatedly use a block cipher with a single key.
 [TIP]
 --
 The modes supported are:
@@ -220,31 +220,7 @@ The modes supported are:
 |*name* |x |A unique name for your global secure property placeholder.
 |*key* |x |the word or phrase to unlock the Credentials Vault according to the system property you define in this field. For example, `${production.myproperty}` instructs Mule to demand the key at runtime.
 |*location* |  |The name of the properties file that the key unlocks.
-|*encryptionAlgorithm* |  |The type of algorithm you used to encrypt the content of the Credentials Vault. +
-[TIP]
---
-The algorithms supported are:
-
-* AES
-* Blowfish
-* Camelia
-* CAST5
-* CAST6
-* DES
-* DESede
-* Noekeon
-* RC3
-* RC5
-* RC6
-* Rijndael
-* RSA
-* SEED
-* Serpent
-* Skipjack
-* TEA
-* Twofish
-* XT
--- +
+|*encryptionAlgorithm* |  |The type of algorithm you used to encrypt the content of the Credentials Vault.
 [TIP]
 --
 The algorithms supported are:
@@ -269,8 +245,32 @@ The algorithms supported are:
 * Twofish
 * XT
 --
+[TIP]
+--
+The algorithms supported are:
 
-|*encryptionMode* |  |The procedure that allows Mule to repeatedly use a block cipher with a single key. +
+* AES
+* Blowfish
+* Camelia
+* CAST5
+* CAST6
+* DES
+* DESede
+* Noekeon
+* RC3
+* RC5
+* RC6
+* Rijndael
+* RSA
+* SEED
+* Serpent
+* Skipjack
+* TEA
+* Twofish
+* XT
+--
+
+|*encryptionMode* |  |The procedure that allows Mule to repeatedly use a block cipher with a single key.
 [TIP]
 --
 The modes supported are:
@@ -279,7 +279,7 @@ The modes supported are:
 * CFB
 * ECB
 * OFB
--- +
+--
 [TIP]
 --
 The modes supported are:

--- a/modules/ROOT/pages/mule-credentials-vault.adoc
+++ b/modules/ROOT/pages/mule-credentials-vault.adoc
@@ -245,41 +245,8 @@ The algorithms supported are:
 * Twofish
 * XT
 --
-[TIP]
---
-The algorithms supported are:
-
-* AES
-* Blowfish
-* Camelia
-* CAST5
-* CAST6
-* DES
-* DESede
-* Noekeon
-* RC3
-* RC5
-* RC6
-* Rijndael
-* RSA
-* SEED
-* Serpent
-* Skipjack
-* TEA
-* Twofish
-* XT
---
 
 |*encryptionMode* |  |The procedure that allows Mule to repeatedly use a block cipher with a single key.
-[TIP]
---
-The modes supported are:
-
-* CBC
-* CFB
-* ECB
-* OFB
---
 [TIP]
 --
 The modes supported are:


### PR DESCRIPTION
ref: W-11825726

- removed the unnecessary +'s that are causing build warnings
- removed duplicate TIPs blocks

validated via local build, screenshot below showing TIP blocks looking good:
![Screen Shot 2022-10-06 at 9 52 56 AM](https://user-images.githubusercontent.com/10934908/194372794-f680a6a9-3c33-4d1d-818a-91375b4f2d85.png)

# Writer's Quality Checklist

Before merging your PR, did you:

- [ ] Run spell checker
- [ ] Run link checker to check for broken xrefs
- [ ] Check for orphan files
- [ ] Perform a local build and do a final visual check of your content, including checking for:
  - Broken images
  - Dead links
  - Correct rendering of partials if they are used in your content
  - Formatting issues, such as:
    - Misnumbered ordered lists (steps) or incorrectly nested unordered lists
    - Messed up tables
    - Proper indentation
    - Correct header levels
- [ ] Receive final review and signoff from:
  - Technical SME
  - Product Manager
  - Editor or peer reviewer
  - Reporter, if this content is in response to a reported issue (internal or external feedback)
- [ ] If applicable, verify that the software actually got released