### PR TITLE
AdoptOpenJDK is now Eclipse Temurin

### DIFF
--- a/modules/ROOT/pages/runtime-installation-task.adoc
+++ b/modules/ROOT/pages/runtime-installation-task.adoc
@@ -4,14 +4,14 @@ include::_attributes.adoc[]
 endif::[]
 
 Before downloading and installing Mule, verify that you have a supported JDK installed.
-This example uses AdoptOpenJDK 8, which is recommended for Mule 4.4.
+This example uses https://adoptium.net/temurin/releases/?version=8[Eclipse Temurin 8], which is recommended for Mule 4.4.
 
 [source,console,linenums]
 ----
 $ java -version
-openjdk version "1.8.0_282"
-OpenJDK Runtime Environment (AdoptOpenJDK)(build 1.8.0_282-b08)
-OpenJDK 64-Bit Server VM (AdoptOpenJDK)(build 25.282-b08, mixed mode)
+openjdk version "1.8.0_352"
+OpenJDK Runtime Environment (Temurin)(build 1.8.0_352-b08)
+OpenJDK 64-Bit Server VM (Temurin)(build 25.352-b08, mixed mode)
 ----
 
 == Download Mule


### PR DESCRIPTION
AdoptOpenJDK moved to Eclipse as Adoptium and the runtime is called Temurin.

# Writer's Quality Checklist

Before merging your PR, did you:

- [x] Run spell checker
- [x] Run link checker to check for broken xrefs
- [ ] Check for orphan files
- [ ] Perform a local build and do a final visual check of your content, including checking for:
  - Broken images
  - Dead links
  - Correct rendering of partials if they are used in your content
  - Formatting issues, such as:
    - Misnumbered ordered lists (steps) or incorrectly nested unordered lists
    - Messed up tables
    - Proper indentation
    - Correct header levels
- [ ] Receive final review and signoff from:
  - Technical SME
  - Product Manager
  - Editor or peer reviewer
  - Reporter, if this content is in response to a reported issue (internal or external feedback)
- [ ] If applicable, verify that the software actually got released