### PR TITLE
W-13067925-target field values for shared space updated

### DIFF
--- a/modules/ROOT/pages/_partials/mmp-deploy-to-cloudhub-2.adoc
+++ b/modules/ROOT/pages/_partials/mmp-deploy-to-cloudhub-2.adoc
@@ -145,7 +145,22 @@ Configuration example:
 ----
 | No
 | `target` | The CloudHub 2.0 target name to deploy the app to. +
-Specify either a shared space or a private space available in your Deployment Target values in CloudHub 2.0. See xref:cloudhub-2::ch2-features.adoc[Features of CloudHub 2.0] for a detailed description on shared and private spaces. | Yes
+Specify either a shared space or a private space available in your Deployment Target values in CloudHub 2.0. Below are target values for shared space:
+
+* `Cloudhub-US-East-1` (US East, N. Virginia)
+* `Cloudhub-US-East-2` (default; US East, Ohio)
+* `Cloudhub-US-West-1` (US West, N. California)
+* `Cloudhub-US-West-2` (US West, Oregon)
+* `Cloudhub-CA-Central-1` (Canada, Central)
+* `Cloudhub-SA-East-1` (South America, São Paulo)
+* `Cloudhub-EU-West-1` (EU, Ireland)
+* `Cloudhub-EU-Central-1` (EU, Frankfurt)
+* `Cloudhub-EU-West-2` (EU, London)
+* `Cloudhub-AP-SouthEast-1` (Asia Pacific, Singapore)
+* `Cloudhub-AP-SouthEast-2` (Asia Pacific, Sydney)
+* `Cloudhub-AP-NorthEast-1` (Asia Pacific, Tokyo)
+While target value for private space will be name provided to private space
+| Yes
 | `provider` | Set to `MC`, for CloudHub 2.0. | Yes
 | `environment` | Target Anypoint Platform environment. +
 This value must match an environment configured in your Anypoint Platform account, as shown here: +


### PR DESCRIPTION
Target field values are not provided anywhere on documentation as well comment -"See Features of CloudHub 2.0 for a detailed description on shared and private spaces." doesn't provide any information which can used properly for this field

# Writer's Quality Checklist

Before merging your PR, did you:

- [x] Run spell checker
- [x] Run link checker to check for broken xrefs
- [x] Check for orphan files
- [x] Perform a local build and do a final visual check of your content, including checking for:
  - Broken images
  - Dead links
  - Correct rendering of partials if they are used in your content
  - Formatting issues, such as:
    - Misnumbered ordered lists (steps) or incorrectly nested unordered lists
    - Messed up tables
    - Proper indentation
    - Correct header levels
- [ ] Receive final review and signoff from:
  - Technical SME
  - Product Manager
  - Editor or peer reviewer
  - Reporter, if this content is in response to a reported issue (internal or external feedback)
- [ ] If applicable, verify that the software actually got released