### PR TITLE
 W-15256317-Add note about cron expressions

### DIFF
--- a/modules/ROOT/pages/scheduler-concept.adoc
+++ b/modules/ROOT/pages/scheduler-concept.adoc
@@ -238,6 +238,9 @@ The Scheduler component also supports Quartz Scheduler special characters:
 
 //source info: +http://www.quartz-scheduler.org/documentation/quartz-2.x/tutorials/crontrigger.html+
 
+Note that it is not possible to specify a day of month and a day of the week at the same time, one of the two values has be set to '?'.
+//source info: +https://github.com/quartz-scheduler/quartz/blob/a5c4d27e963f51097f9b2777489d310a88897ca4/quartz/src/main/java/org/quartz/CronExpression.java#L189+
+
 This example logs the message "hello" every second:
 
 [source,XML,linenums]


### PR DESCRIPTION
I stumbled upon the issue that my cron expression was not accepted and I could not find out why until I looked it up in the source code. It is mandatory to use the '?' value for one of the two day fields.

# Writer's Quality Checklist

Before merging your PR, did you:

- [ ] Run spell checker
- [ ] Run link checker to check for broken xrefs
- [ ] Check for orphan files
- [ ] Perform a local build and do a final visual check of your content, including checking for:
  - Broken images
  - Dead links
  - Correct rendering of partials if they are used in your content
  - Formatting issues, such as:
    - Misnumbered ordered lists (steps) or incorrectly nested unordered lists
    - Messed up tables
    - Proper indentation
    - Correct header levels
- [ ] Receive final review and signoff from:
  - Technical SME
  - Product Manager
  - Editor or peer reviewer
  - Reporter, if this content is in response to a reported issue (internal or external feedback)
- [ ] If applicable, verify that the software actually got released