### PR TITLE
W-15783514-Updated Scatter Gather output message format

### DIFF
--- a/modules/ROOT/pages/scatter-gather-concept.adoc
+++ b/modules/ROOT/pages/scatter-gather-concept.adoc
@@ -24,7 +24,7 @@ WARNING: Configure your Scatter-Gather component to have at least two routes; ot
 == Result
 
 After all routes complete, the component outputs the results in the following format:
-`{0: messageFromRoute0, 1: messageFromRoute1, ...}`
+`{0= messageFromRoute0, 1= messageFromRoute1, ...}`
 
 To extract all resulting payloads to an array, use a DataWeave script, such as the following:
 


### PR DESCRIPTION
In the previous version, it was mentioned the data format was `{0: messageFromRoute0, 1: messageFromRoute1, …​}`, However, the actual data format is `{0= messageFromRoute0, 1= messageFromRoute1, …​}`