### PR TITLE
 W-15953447-'EXTENSION' is not a valid value of union type 'notificationTypes'

### DIFF
--- a/modules/ROOT/pages/notifications-configuration-reference.adoc
+++ b/modules/ROOT/pages/notifications-configuration-reference.adoc
@@ -104,7 +104,6 @@ You can specify the following types of notifications using the `event` attribute
 * CUSTOM
 * EXCEPTION
 * EXCEPTION-STRATEGY
-* EXTENSION
 * MANAGEMENT
 * MESSAGE-PROCESSOR
 * PIPELINE-MESSAGE


### PR DESCRIPTION
'EXTENSION' is not a valid value of union type 'notificationTypes'

see /mule-4/runtime-extension-model/src/main/resources/META-INF/mule-core-common.xsd

# Writer's Quality Checklist

Before merging your PR, did you:

- [ ] Run spell checker
- [ ] Run link checker to check for broken xrefs
- [ ] Check for orphan files
- [ ] Perform a local build and do a final visual check of your content, including checking for:
  - Broken images
  - Dead links
  - Correct rendering of partials if they are used in your content
  - Formatting issues, such as:
    - Misnumbered ordered lists (steps) or incorrectly nested unordered lists
    - Messed up tables
    - Proper indentation
    - Correct header levels
- [ ] Receive final review and signoff from:
  - Technical SME
  - Product Manager
  - Editor or peer reviewer
  - Reporter, if this content is in response to a reported issue (internal or external feedback)
- [ ] If applicable, verify that the software actually got released