### PR TITLE
W-15713927: Updating example of custom properties provider.

### DIFF
--- a/modules/ROOT/pages/custom-configuration-properties-provider.adoc
+++ b/modules/ROOT/pages/custom-configuration-properties-provider.adoc
@@ -185,7 +185,7 @@ Follow these steps to customize the Mule SDK Module:
 . Open the `pom.xml` file:
 .. Define the GAV (`groupId`, `artifactId`, and `version`) of your module.
 .. Define the `name` of your module.
-.. Review the minimum Mule Version you want your properties provider to require. The example is compatible back to 4.1.1 to cover all possible scenarios. See xref:mule-sdk::choosing-version.adoc[Choosing the SDK Version].
+.. Review the minimum Mule version you want your properties provider to require. This example is compatible with Mule 4.1.1 and later to cover all possible scenarios. See xref:mule-sdk::choosing-version.adoc[Choosing the SDK Version].
 . Change the package name (`com.my.company.custom.provider.api`) of your code.
 . Open `resources/META-INF/services/org.mule.runtime.config.api.dsl.model.properties.ConfigurationPropertiesProviderFactory`, and change the content to match the package name you changed previously.
 . Open the `CustomConfigurationPropertiesExtension` class:
@@ -218,4 +218,4 @@ You can now configure your new component and start using properties with the pre
 
 == Using Custom Configuration Properties Provider versus a Connector
 
-For static properties, use the properties provider approach, because static properties do not change during runtime. If your properties might change during runtime, create a connector that can provide the value as one of its operations.
+For static properties, use the properties provider approach, because static properties don't change during runtime. If your properties might change during runtime, create a connector that can provide the value as one of its operations.

--- a/modules/ROOT/pages/custom-configuration-properties-provider.adoc
+++ b/modules/ROOT/pages/custom-configuration-properties-provider.adoc
@@ -185,20 +185,17 @@ Follow these steps to customize the Mule SDK Module:
 . Open the `pom.xml` file:
 .. Define the GAV (`groupId`, `artifactId`, and `version`) of your module.
 .. Define the `name` of your module.
+.. Review the minimum Mule Version you want your properties provider to require. The example is compatible back to 4.1.1 to cover all possible scenarios. See xref:mule-sdk::choosing-version.adoc[Choosing the SDK Version].
 . Change the package name (`com.my.company.custom.provider.api`) of your code.
-. Open `resources/META-INF/mule-artifact/mule-artifact.json`:
-.. Set the `type` field with value `com.my.company.custom.provider.api.CustomConfigurationPropertiesExtensionLoadingDelegate`, replacing `com.my.company.custom.provider.api` to match the package name you changed previously.
-.. Set the `name` field using the name you want to define for the module.
-.. Set the `exportedPackages` field to match the package name you changed previously.
-. Open `resources/META-INF/services/org.mule.runtime.properties.api.ConfigurationPropertiesProviderFactory`, and change the content to match the package name you changed previously.
-. Open the `CustomConfigurationPropertiesExtensionLoadingDelegate` class:
+. Open `resources/META-INF/services/org.mule.runtime.config.api.dsl.model.properties.ConfigurationPropertiesProviderFactory`, and change the content to match the package name you changed previously.
+. Open the `CustomConfigurationPropertiesExtension` class:
 .. Change the `EXTENSION_NAME` constant to the name of your module.
-.. Change the `fromVendor` method parameter to your company name.
+.. Change the `vendor` method parameter on the `@Extension` annotation to your company name.
 .. Customize the section at the end to define the parameters that can be configured in the `config` element of your module.
 . Open the `CustomConfigurationPropertiesProviderFactory` class:
 .. Change the `CUSTOM_PROPERTIES_PREFIX` value to a meaningful prefix for the configuration properties that your module must resolve.
 .. Change the class implementation to look up the properties from your custom source.
-. Update `CustomPropertiesProviderOperationsTestCase` with more test cases to cover your new module functionality.
+. Update the MUnit test cases in `test/munit` with more test cases to cover your new module functionality.
 
 Once your module is ready, you can install it locally using `mvn clean install` to make the module accessible from Studio.
 


### PR DESCRIPTION
Notice we are intentionally reverting the reference to `resources/META-INF/services/org.mule.runtime.config.api.dsl.model.properties.ConfigurationPropertiesProviderFactory` in order to reflect the actual name of the file in [the example code](https://github.com/mulesoft/mule-custom-properties-providers-module-example/blob/master/src/main/resources/META-INF/services/org.mule.runtime.config.api.dsl.model.properties.ConfigurationPropertiesProviderFactory).
It seem that was part of an [initiative](https://github.com/mulesoft/mule-custom-properties-providers-module-example/issues/6) to avoid using a deprecated package, however that never got merged, and doing that would require increasing the Min Mule Version of the example extension.

# Writer's Quality Checklist

Before merging your PR, did you:

- [ ] Run spell checker
- [ ] Run link checker to check for broken xrefs
- [ ] Check for orphan files
- [ ] Perform a local build and do a final visual check of your content, including checking for:
  - Broken images
  - Dead links
  - Correct rendering of partials if they are used in your content
  - Formatting issues, such as:
    - Misnumbered ordered lists (steps) or incorrectly nested unordered lists
    - Messed up tables
    - Proper indentation
    - Correct header levels
- [ ] Receive final review and signoff from:
  - Technical SME
  - Product Manager
  - Editor or peer reviewer
  - Reporter, if this content is in response to a reported issue (internal or external feedback)
- [ ] If applicable, verify that the software actually got released