### PR TITLE
W-16124485: Addding clarification about custom configuration properties providers not being capable of using ConnectionProviders, hence not supporting connectivity testing.

### DIFF
--- a/modules/ROOT/pages/custom-configuration-properties-provider.adoc
+++ b/modules/ROOT/pages/custom-configuration-properties-provider.adoc
@@ -218,11 +218,7 @@ You can now configure your new component and start using properties with the pre
 
 == Using Custom Configuration Properties Provider versus a Connector
 
-<<<<<<< W-16124485
-For static properties, use the properties provider approach, because static properties do not change during runtime. If your properties might change during runtime, create a connector that can provide the value as one of its operations.
+For static properties, use the properties provider approach, because static properties don't change during runtime. If your properties might change during runtime, create a connector that can provide the value as one of its operations.
 
 [NOTE]
 Although the xref:mule-sdk::getting-started.adoc[Mule SDK for Java] is used to implement a custom configuration properties provider, you can't use xref:mule-sdk::connections.adoc[ConnectionProviders] to connect to external sources. This is because `ConnectionProviders` are managed by Mule runtime and are initialized at a later stage, after the static properties are resolved. Consequently, connectivity testing isn't supported for custom properties providers.
-=======
-For static properties, use the properties provider approach, because static properties don't change during runtime. If your properties might change during runtime, create a connector that can provide the value as one of its operations.
->>>>>>> v4.7

--- a/modules/ROOT/pages/custom-configuration-properties-provider.adoc
+++ b/modules/ROOT/pages/custom-configuration-properties-provider.adoc
@@ -223,4 +223,5 @@ You can now configure your new component and start using properties with the pre
 
 For static properties, use the properties provider approach, because static properties do not change during runtime. If your properties might change during runtime, create a connector that can provide the value as one of its operations.
 
-NOTE: Even though the xref:mule-sdk::getting-started.adoc[Mule Java SDK] is used to implement a custom configuration properties provider, you can't use xref:mule-sdk::connections.adoc[ConnectionProviders] to connect to external sources. This is because `ConnectionProviders` are meant to be managed by the Mule Runtime, and they get initialized at a later stage than when the static properties need to be resolved. This also means connectivity testing is also not supported for custom properties providers.
+[NOTE]
+Although the xref:mule-sdk::getting-started.adoc[Mule SDK for Java] is used to implement a custom configuration properties provider, you can't use xref:mule-sdk::connections.adoc[ConnectionProviders] to connect to external sources. This is because `ConnectionProviders` are managed by Mule runtime and are initialized at a later stage, after the static properties are resolved. Consequently, connectivity testing isn't supported for custom properties providers.

--- a/modules/ROOT/pages/custom-configuration-properties-provider.adoc
+++ b/modules/ROOT/pages/custom-configuration-properties-provider.adoc
@@ -222,3 +222,5 @@ You can now configure your new component and start using properties with the pre
 == Using Custom Configuration Properties Provider versus a Connector
 
 For static properties, use the properties provider approach, because static properties do not change during runtime. If your properties might change during runtime, create a connector that can provide the value as one of its operations.
+
+NOTE: Even though the xref:mule-sdk::getting-started.adoc[Mule Java SDK] is used to implement a custom configuration properties provider, you can't use xref:mule-sdk::connections.adoc[ConnectionProviders] to connect to external sources. This is because `ConnectionProviders` are meant to be managed by the Mule Runtime, and they get initialized at a later stage than when the static properties need to be resolved. This also means connectivity testing is also not supported for custom properties providers.


### PR DESCRIPTION
# Writer's Quality Checklist

Before merging your PR, did you:

- [ ] Run spell checker
- [ ] Run link checker to check for broken xrefs
- [ ] Check for orphan files
- [ ] Perform a local build and do a final visual check of your content, including checking for:
  - Broken images
  - Dead links
  - Correct rendering of partials if they are used in your content
  - Formatting issues, such as:
    - Misnumbered ordered lists (steps) or incorrectly nested unordered lists
    - Messed up tables
    - Proper indentation
    - Correct header levels
- [ ] Receive final review and signoff from:
  - Technical SME
  - Product Manager
  - Editor or peer reviewer
  - Reporter, if this content is in response to a reported issue (internal or external feedback)
- [ ] If applicable, verify that the software actually got released