### PR TITLE
[W-14989277] Prevent unresolved partials in JP handback

### DIFF
--- a/modules/ROOT/pages/_partials/mmp-deploy-to-cloudhub-2.adoc
+++ b/modules/ROOT/pages/_partials/mmp-deploy-to-cloudhub-2.adoc
@@ -1,7 +1,7 @@
 //= Deploy Applications to CH 2.0 Using the Mule Maven Plugin
 // tag::intro[]
 
-include::mule-runtime::partial$mmp-concept.adoc[tag=deprecatedVersionsWarning]
+include::partial$mmp-concept.adoc[tag=deprecatedVersionsWarning]
 
 include::reuse::partial$non-inclusive-banner.adoc[]
 
@@ -49,7 +49,7 @@ Inside the `plugin` element, add a configuration for your CloudHub 2.0 deploymen
 [source,xml,linenums]
 ----
 <plugin>
-include::mule-runtime::example$mmp-concept-config.xml[]
+include::example$mmp-concept-config.xml[]
   <configuration>
     <cloudhub2Deployment>
       <uri>https://anypoint.mulesoft.com</uri>
@@ -112,9 +112,9 @@ CloudHub 2.0 rewrites the application you had deployed.
 // tag::authenticationMethods[]
 == Authentication Methods
 
-include::mule-runtime::partial$mmp-concept.adoc[tag=authenticationMethodsIntro]
+include::partial$mmp-concept.adoc[tag=authenticationMethodsIntro]
 
-include::mule-runtime::partial$mmp-concept.adoc[tags=authenticationCH2]
+include::partial$mmp-concept.adoc[tags=authenticationCH2]
 
 For a detailed description of the configuration parameters, see the <<cloudhub2-deploy-reference, CloudHub 2.0 Deployment Parameters Reference>>.
 // end::authenticationMethods[]
@@ -179,10 +179,10 @@ See xref:cloudhub-2::ch2-architecture.adoc#cloudhub-2-replicas[CloudHub 2.0 Repl
 This parameter cannot be used if you configure `instanceType`.
 
 | No
-include::mule-runtime::partial$mmp-concept.adoc[tag=businessGroupParameterDescription]
-include::mule-runtime::partial$mmp-concept.adoc[tag=businessGroupIdParameterDescription]
-include::mule-runtime::partial$mmp-concept.adoc[tag=deploymentTimeoutParameterDescription]
-include::mule-runtime::partial$mmp-concept.adoc[tag=serverParameterDescription]
+include::partial$mmp-concept.adoc[tag=businessGroupParameterDescription]
+include::partial$mmp-concept.adoc[tag=businessGroupIdParameterDescription]
+include::partial$mmp-concept.adoc[tag=deploymentTimeoutParameterDescription]
+include::partial$mmp-concept.adoc[tag=serverParameterDescription]
 | `properties` | Top-Level element +
 If you need to set properties for the Mule application you are deploying, you can use the `<properties>` top-level element:
 [source,xml,linenums]
@@ -201,11 +201,11 @@ For example:
 ----
 If you must redeploy the application and there aren't properties configured in the deployment POM file, the existing properties in your CloudHub 2.0 environment are kept. Note that if properties are defined in the POM file, the app is deployed using those properties and overrides any properties set in the UI.
 | No
-include::mule-runtime::partial$mmp-concept.adoc[tag=securePropertiesCH2ParameterDescription]
-include::mule-runtime::partial$mmp-concept.adoc[tag=skipParameterDescription]
-include::mule-runtime::partial$mmp-concept.adoc[tag=skipDeploymentVerification]
-include::mule-runtime::partial$mmp-concept.adoc[tag=authTokenParameterDescription]
-include::mule-runtime::partial$mmp-concept.adoc[tag=connectedAppsParameterDescription]
+include::partial$mmp-concept.adoc[tag=securePropertiesCH2ParameterDescription]
+include::partial$mmp-concept.adoc[tag=skipParameterDescription]
+include::partial$mmp-concept.adoc[tag=skipDeploymentVerification]
+include::partial$mmp-concept.adoc[tag=authTokenParameterDescription]
+include::partial$mmp-concept.adoc[tag=connectedAppsParameterDescription]
 | `deploymentSettings` | Any of the parameters documented in <<deployment-settings, deploymentSettings Reference>>.
 | No
 
@@ -337,7 +337,7 @@ Configuration example:
 // tag::EncryptCredentials[]
 == Encrypt Credentials
 
-include::mule-runtime::partial$mmp-concept.adoc[tag=encryptCredentials]
+include::partial$mmp-concept.adoc[tag=encryptCredentials]
 +
 [source,xml,linenums]
 ----

--- a/modules/ROOT/pages/_partials/mmp-deploy-to-rtf.adoc
+++ b/modules/ROOT/pages/_partials/mmp-deploy-to-rtf.adoc
@@ -1,7 +1,7 @@
 //= Deploy Applications to Runtime Fabric Using the Mule Maven Plugin
 // tag::intro[]
 
-include::mule-runtime::partial$mmp-concept.adoc[tag=deprecatedVersionsWarning]
+include::partial$mmp-concept.adoc[tag=deprecatedVersionsWarning]
 
 include::reuse::partial$non-inclusive-banner.adoc[]
 
@@ -62,7 +62,7 @@ Inside the `plugin` element, add a configuration for your Runtime Fabric deploym
 [source,xml,linenums]
 ----
 <plugin>
-include::mule-runtime::example$mmp-concept-config.xml[]
+include::example$mmp-concept-config.xml[]
   <configuration>
     <runtimeFabricDeployment>
       <uri>https://anypoint.mulesoft.com</uri>
@@ -138,9 +138,9 @@ Runtime Fabric rewrites the application you had deployed.
 // tag::authenticationMethods[]
 == Authentication Methods
 
-include::mule-runtime::partial$mmp-concept.adoc[tag=authenticationMethodsIntro]
+include::partial$mmp-concept.adoc[tag=authenticationMethodsIntro]
 
-include::mule-runtime::partial$mmp-concept.adoc[tags=authenticationOptionsList;!authenticationMethodsIntro;!authenticationCloudHub;!authenticationOnPrem]
+include::partial$mmp-concept.adoc[tags=authenticationOptionsList;!authenticationMethodsIntro;!authenticationCloudHub;!authenticationOnPrem]
 
 For a detailed description of the configuration parameters, see the <<rtf-deploy-reference, Runtime Fabric Deployment Parameters Reference>>.
 // end::authenticationMethods[]
@@ -173,16 +173,16 @@ This value must match an environment configured in your Anypoint Platform accoun
 ----
 | Yes
 | `replicas` | Specifies the number of replicas, or instances, of the Mule application to deploy. The maximum number of replicas per application is 16. | Yes
-include::mule-runtime::partial$mmp-concept.adoc[tag=businessGroupParameterDescription]
-include::mule-runtime::partial$mmp-concept.adoc[tag=businessGroupIdParameterDescription]
-include::mule-runtime::partial$mmp-concept.adoc[tag=deploymentTimeoutParameterDescription]
-include::mule-runtime::partial$mmp-concept.adoc[tag=serverParameterDescription]
-include::mule-runtime::partial$mmp-concept.adoc[tag=propertiesParameterDescription]
-include::mule-runtime::partial$mmp-concept.adoc[tag=securePropertiesRTFParameterDescription]
-include::mule-runtime::partial$mmp-concept.adoc[tag=skipParameterDescription]
-include::mule-runtime::partial$mmp-concept.adoc[tag=skipDeploymentVerification]
-include::mule-runtime::partial$mmp-concept.adoc[tag=authTokenParameterDescription]
-include::mule-runtime::partial$mmp-concept.adoc[tag=connectedAppsParameterDescription]
+include::partial$mmp-concept.adoc[tag=businessGroupParameterDescription]
+include::partial$mmp-concept.adoc[tag=businessGroupIdParameterDescription]
+include::partial$mmp-concept.adoc[tag=deploymentTimeoutParameterDescription]
+include::partial$mmp-concept.adoc[tag=serverParameterDescription]
+include::partial$mmp-concept.adoc[tag=propertiesParameterDescription]
+include::partial$mmp-concept.adoc[tag=securePropertiesRTFParameterDescription]
+include::partial$mmp-concept.adoc[tag=skipParameterDescription]
+include::partial$mmp-concept.adoc[tag=skipDeploymentVerification]
+include::partial$mmp-concept.adoc[tag=authTokenParameterDescription]
+include::partial$mmp-concept.adoc[tag=connectedAppsParameterDescription]
 | `deploymentSettings` | Any of the parameters documented in <<deployment-settings, deploymentSettings Reference>>
 | No
 |===
@@ -352,7 +352,7 @@ Configuration example:
 // tag::rtfEncryptCredentials[]
 == Encrypt Credentials
 
-include::mule-runtime::partial$mmp-concept.adoc[tag=encryptCredentials]
+include::partial$mmp-concept.adoc[tag=encryptCredentials]
 +
 [source,xml,linenums]
 ----

--- a/modules/ROOT/pages/dataweave.adoc
+++ b/modules/ROOT/pages/dataweave.adoc
@@ -6,7 +6,7 @@ endif::[]
 
 // :page-aliases: 4.3@mule-runtime::dataweave.adoc
 
-include::mule-runtime::partial$dataweave-intro.adoc[]
+include::partial$dataweave-intro.adoc[]
 
 * To get started with DataWeave 2.4.0 for Mule runtime engine (Mule) version 4.4 and later, visit
 xref:dataweave::dataweave-quickstart.adoc[the quickstart].

--- a/modules/ROOT/pages/deploy-on-premises.adoc
+++ b/modules/ROOT/pages/deploy-on-premises.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 
-include::mule-runtime::partial$mmp-concept.adoc[tag=deprecatedVersionsWarning]
+include::partial$mmp-concept.adoc[tag=deprecatedVersionsWarning]
 
 include::reuse::partial$non-inclusive-banner.adoc[]
 
@@ -44,7 +44,7 @@ Inside the `plugin` element, add a configuration for your standalone deployment,
 [source,xml,linenums]
 ----
 <plugin>
-include::mule-runtime::example$mmp-concept-config.xml[]
+include::example$mmp-concept-config.xml[]
   <configuration>
     <standaloneDeployment>
       <muleHome>${mule.home.test}</muleHome>
@@ -68,14 +68,14 @@ mvn clean deploy -DmuleDeploy
 |===
 |Parameter | Description | Required
 |`standaloneDeployment` | Top-Level Element. | Yes
-include::mule-runtime::partial$mmp-concept.adoc[tag=applicationNameParameterDescription]
+include::partial$mmp-concept.adoc[tag=applicationNameParameterDescription]
 | `muleVersion` | The Mule version running in your local machine instance. +
 If this value does not match the Mule version running in your deployment target, the plugin raises an exception.
 
 The Mule Maven Plugin does not download a Mule runtime engine if these values don't match. | Yes
 | `muleHome` | The location of the Mule instance in your local machine. | Yes
-include::mule-runtime::partial$mmp-concept.adoc[tag=deploymentTimeoutParameterDescription]
-include::mule-runtime::partial$mmp-concept.adoc[tag=skipParameterDescription]
+include::partial$mmp-concept.adoc[tag=deploymentTimeoutParameterDescription]
+include::partial$mmp-concept.adoc[tag=skipParameterDescription]
 
 |===
 
@@ -98,7 +98,7 @@ Inside the `plugin` element, add a configuration for your Runtime Manager deploy
 [source,xml,linenums]
 ----
 <plugin>
-include::mule-runtime::example$mmp-concept-config.xml[]
+include::example$mmp-concept-config.xml[]
   <configuration>
     <armDeployment>
       <muleVersion>${app.runtime}</muleVersion>
@@ -125,9 +125,9 @@ mvn clean deploy -DmuleDeploy
 
 === Authentication Methods
 
-include::mule-runtime::partial$mmp-concept.adoc[tag=authenticationMethodsIntro]
+include::partial$mmp-concept.adoc[tag=authenticationMethodsIntro]
 
-include::mule-runtime::partial$mmp-concept.adoc[tags=authenticationOptionsList;!authenticationCloudHub;!authenticationRTF]
+include::partial$mmp-concept.adoc[tags=authenticationOptionsList;!authenticationCloudHub;!authenticationRTF]
 
 For a detailed description of the configuration parameters, see the <<arm-deploy-reference, Runtime Manager REST API Deployment Parameters Reference>>.
 
@@ -138,7 +138,7 @@ For a detailed description of the configuration parameters, see the <<arm-deploy
 |===
 |Parameter | Description | Required
 |`armDeployment` | Top-Level Element. | Yes
-include::mule-runtime::partial$mmp-concept.adoc[tag=applicationNameParameterDescription]
+include::partial$mmp-concept.adoc[tag=applicationNameParameterDescription]
 | `muleVersion` | The Mule version required for your application to run in your deployment target. +
 If this value does not match the Mule version running in your deployment target, the plugin raises an exception.
 
@@ -163,20 +163,20 @@ For Example:
 <environment>Sandbox</environment>
 ----
 | Yes
-include::mule-runtime::partial$mmp-concept.adoc[tag=businessGroupParameterDescription]
-include::mule-runtime::partial$mmp-concept.adoc[tag=businessGroupIdParameterDescription]
-include::mule-runtime::partial$mmp-concept.adoc[tag=deploymentTimeoutParameterDescription]
-include::mule-runtime::partial$mmp-concept.adoc[tag=serverParameterDescription]
-include::mule-runtime::partial$mmp-concept.adoc[tag=propertiesParameterDescription]
-include::mule-runtime::partial$mmp-concept.adoc[tag=skipParameterDescription]
-include::mule-runtime::partial$mmp-concept.adoc[tag=skipDeploymentVerification]
-include::mule-runtime::partial$mmp-concept.adoc[tag=authTokenParameterDescription]
-include::mule-runtime::partial$mmp-concept.adoc[tag=connectedAppsParameterDescription]
+include::partial$mmp-concept.adoc[tag=businessGroupParameterDescription]
+include::partial$mmp-concept.adoc[tag=businessGroupIdParameterDescription]
+include::partial$mmp-concept.adoc[tag=deploymentTimeoutParameterDescription]
+include::partial$mmp-concept.adoc[tag=serverParameterDescription]
+include::partial$mmp-concept.adoc[tag=propertiesParameterDescription]
+include::partial$mmp-concept.adoc[tag=skipParameterDescription]
+include::partial$mmp-concept.adoc[tag=skipDeploymentVerification]
+include::partial$mmp-concept.adoc[tag=authTokenParameterDescription]
+include::partial$mmp-concept.adoc[tag=connectedAppsParameterDescription]
 |===
 
 === Encrypt Credentials
 
-include::mule-runtime::partial$mmp-concept.adoc[tag=encryptCredentials]
+include::partial$mmp-concept.adoc[tag=encryptCredentials]
 +
 [source,xml,linenums]
 ----
@@ -209,7 +209,7 @@ See the configuration example below:
 [source,xml,linenums]
 ----
 <plugin>
-include::mule-runtime::example$mmp-concept-config.xml[]
+include::example$mmp-concept-config.xml[]
   <configuration>
     <armDeployment>
         <target>${target}</target>
@@ -231,7 +231,7 @@ Inside the `plugin` element, add a configuration for your Runtime Manager agent 
 [source,xml,linenums]
 ----
 <plugin>
-include::mule-runtime::example$mmp-concept-config.xml[]
+include::example$mmp-concept-config.xml[]
   <configuration>
     <agentDeployment>
       <uri>http://localhost:9999/</uri>
@@ -254,14 +254,14 @@ mvn clean deploy -DmuleDeploy
 |===
 |Parameter | Description | Required
 |`agentDeployment` | Top-Level Element. | Yes
-include::mule-runtime::partial$mmp-concept.adoc[tag=applicationNameParameterDescription]
+include::partial$mmp-concept.adoc[tag=applicationNameParameterDescription]
 | `muleVersion` | The Mule version required for your application to run in your deployment target. +
 If this value does not match the Mule version running in your deployment target, the plugin raises an exception.
 
 The Mule Maven Plugin does not download a Mule runtime engine if these values don't match. | Yes
 | `uri` | The server URI where your Mule instances are installed. | Yes
-include::mule-runtime::partial$mmp-concept.adoc[tag=deploymentTimeoutParameterDescription]
-include::mule-runtime::partial$mmp-concept.adoc[tag=skipParameterDescription]
+include::partial$mmp-concept.adoc[tag=deploymentTimeoutParameterDescription]
+include::partial$mmp-concept.adoc[tag=skipParameterDescription]
 
 |===
 
@@ -277,7 +277,7 @@ To deploy a domain, use the same configuration and deployment steps you use when
 [source,xml,linenums]
 ----
 <plugin>
-include::mule-runtime::example$mmp-concept-config.xml[]
+include::example$mmp-concept-config.xml[]
   <configuration>
     <standaloneDeployment>
       <muleHome>${mule.home.test}</muleHome>

--- a/modules/ROOT/pages/deploy-to-cloudhub-2.adoc
+++ b/modules/ROOT/pages/deploy-to-cloudhub-2.adoc
@@ -1,20 +1,20 @@
 = Deploy Applications to CloudHub 2.0 Using the Mule Maven Plugin
 
-include::mule-runtime::partial$mmp-deploy-to-cloudhub-2.adoc[tag=intro]
+include::partial$mmp-deploy-to-cloudhub-2.adoc[tag=intro]
 
-include::mule-runtime::partial$mmp-deploy-to-cloudhub-2.adoc[tag=prerequisites]
+include::partial$mmp-deploy-to-cloudhub-2.adoc[tag=prerequisites]
 
-include::mule-runtime::partial$mmp-deploy-to-cloudhub-2.adoc[tag=DeploymentConfig]
+include::partial$mmp-deploy-to-cloudhub-2.adoc[tag=DeploymentConfig]
 
-include::mule-runtime::partial$mmp-deploy-to-cloudhub-2.adoc[tag=DeploymentCommands]
+include::partial$mmp-deploy-to-cloudhub-2.adoc[tag=DeploymentCommands]
 
-include::mule-runtime::partial$mmp-deploy-to-cloudhub-2.adoc[tag=authenticationMethods]
+include::partial$mmp-deploy-to-cloudhub-2.adoc[tag=authenticationMethods]
 
-include::mule-runtime::partial$mmp-deploy-to-cloudhub-2.adoc[tag=DeploymentReference]
+include::partial$mmp-deploy-to-cloudhub-2.adoc[tag=DeploymentReference]
 
-include::mule-runtime::partial$mmp-deploy-to-cloudhub-2.adoc[tag=DeploymentSettingsReference]
+include::partial$mmp-deploy-to-cloudhub-2.adoc[tag=DeploymentSettingsReference]
 
-include::mule-runtime::partial$mmp-deploy-to-cloudhub-2.adoc[tag=EncryptCredentials]
+include::partial$mmp-deploy-to-cloudhub-2.adoc[tag=EncryptCredentials]
 
 == See Also
 

--- a/modules/ROOT/pages/deploy-to-cloudhub.adoc
+++ b/modules/ROOT/pages/deploy-to-cloudhub.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 
-include::mule-runtime::partial$mmp-concept.adoc[tag=deprecatedVersionsWarning]
+include::partial$mmp-concept.adoc[tag=deprecatedVersionsWarning]
 
 include::reuse::partial$non-inclusive-banner.adoc[]
 
@@ -34,7 +34,7 @@ Inside the `plugin` element in your project's `pom.xml` file, configure your Clo
 [source,xml,linenums]
 ----
 <plugin>
-include::mule-runtime::example$mmp-concept-config.xml[]
+include::example$mmp-concept-config.xml[]
   <configuration>
     <cloudHubDeployment>
       <uri>https://anypoint.mulesoft.com</uri>
@@ -79,9 +79,9 @@ The undeploy command also deletes the app in Mule Maven plugin 3.3.0 and later v
 
 == Authentication Methods
 
-include::mule-runtime::partial$mmp-concept.adoc[tag=authenticationMethodsIntro]
+include::partial$mmp-concept.adoc[tag=authenticationMethodsIntro]
 
-include::mule-runtime::partial$mmp-concept.adoc[tags=authenticationOptionsList;!authenticationRTF;!authenticationOnPrem]
+include::partial$mmp-concept.adoc[tags=authenticationOptionsList;!authenticationRTF;!authenticationOnPrem]
 
 For a detailed description of the configuration parameters, see the <<cloudhub-deploy-reference, CloudHub Deployment Reference>>.
 
@@ -117,7 +117,7 @@ This value must match any environment configured in your CloudHub account. +
 <environment>Sandbox</environment>
 ----
 | Yes
-include::mule-runtime::partial$mmp-concept.adoc[tag=propertiesParameterDescription]
+include::partial$mmp-concept.adoc[tag=propertiesParameterDescription]
 | `workers` | The number of workers +
 By default, this value is 1. | No
 | `workerType` | Size of each worker; one of the following values:
@@ -150,14 +150,14 @@ By default, this value is 1. | No
 By default, this value is set to `true` to match the Runtime Manager configuration of OSv2. | No
 | `persistentQueues` | Enables persistent queues +
 By default, it is set to `false`. | No
-include::mule-runtime::partial$mmp-concept.adoc[tag=businessGroupParameterDescription]
-include::mule-runtime::partial$mmp-concept.adoc[tag=businessGroupIdParameterDescription]
-include::mule-runtime::partial$mmp-concept.adoc[tag=deploymentTimeoutParameterDescription]
-include::mule-runtime::partial$mmp-concept.adoc[tag=serverParameterDescription]
-include::mule-runtime::partial$mmp-concept.adoc[tag=skipParameterDescription]
-include::mule-runtime::partial$mmp-concept.adoc[tag=skipDeploymentVerification]
-include::mule-runtime::partial$mmp-concept.adoc[tag=authTokenParameterDescription]
-include::mule-runtime::partial$mmp-concept.adoc[tag=connectedAppsParameterDescription]
+include::partial$mmp-concept.adoc[tag=businessGroupParameterDescription]
+include::partial$mmp-concept.adoc[tag=businessGroupIdParameterDescription]
+include::partial$mmp-concept.adoc[tag=deploymentTimeoutParameterDescription]
+include::partial$mmp-concept.adoc[tag=serverParameterDescription]
+include::partial$mmp-concept.adoc[tag=skipParameterDescription]
+include::partial$mmp-concept.adoc[tag=skipDeploymentVerification]
+include::partial$mmp-concept.adoc[tag=authTokenParameterDescription]
+include::partial$mmp-concept.adoc[tag=connectedAppsParameterDescription]
 | `applyLatestRuntimePatch` | When set to `true`, the plugin instructs CloudHub to update the worker to the latest available patch for the Mule runtime engine version specified in the deployment configuration, and then deploys the application. +
 By default, it is set to `false`. | No
 | `disableCloudHubLogs` | When set to `true`, the plugin instructs CloudHub to disable CloudHub logging and instead use the application configured in the `log4j2.xml` file. +
@@ -166,7 +166,7 @@ By default, it is set to `false`. | No
 
 == Encrypt Credentials
 
-include::mule-runtime::partial$mmp-concept.adoc[tag=encryptCredentials]
+include::partial$mmp-concept.adoc[tag=encryptCredentials]
 +
 [source,xml,linenums]
 ----

--- a/modules/ROOT/pages/deploy-to-rtf.adoc
+++ b/modules/ROOT/pages/deploy-to-rtf.adoc
@@ -1,20 +1,20 @@
 = Deploy Applications to Runtime Fabric Using the Mule Maven Plugin
 
-include::mule-runtime::partial$mmp-deploy-to-rtf.adoc[tag=intro]
+include::partial$mmp-deploy-to-rtf.adoc[tag=intro]
 
-include::mule-runtime::partial$mmp-deploy-to-rtf.adoc[tag=prerequisites]
+include::partial$mmp-deploy-to-rtf.adoc[tag=prerequisites]
 
-include::mule-runtime::partial$mmp-deploy-to-rtf.adoc[tag=rtfDeploymentConfig]
+include::partial$mmp-deploy-to-rtf.adoc[tag=rtfDeploymentConfig]
 
-include::mule-runtime::partial$mmp-deploy-to-rtf.adoc[tag=rtfDeploymentCommands]
+include::partial$mmp-deploy-to-rtf.adoc[tag=rtfDeploymentCommands]
 
-include::mule-runtime::partial$mmp-deploy-to-rtf.adoc[tag=authenticationMethods]
+include::partial$mmp-deploy-to-rtf.adoc[tag=authenticationMethods]
 
-include::mule-runtime::partial$mmp-deploy-to-rtf.adoc[tag=rtfDeploymentReference]
+include::partial$mmp-deploy-to-rtf.adoc[tag=rtfDeploymentReference]
 
-include::mule-runtime::partial$mmp-deploy-to-rtf.adoc[tag=rtfDeploymentSettingsReference]
+include::partial$mmp-deploy-to-rtf.adoc[tag=rtfDeploymentSettingsReference]
 
-include::mule-runtime::partial$mmp-deploy-to-rtf.adoc[tag=rtfEncryptCredentials]
+include::partial$mmp-deploy-to-rtf.adoc[tag=rtfEncryptCredentials]
 
 == See Also
 

--- a/modules/ROOT/pages/maven-reference.adoc
+++ b/modules/ROOT/pages/maven-reference.adoc
@@ -4,7 +4,7 @@ include::_attributes.adoc[]
 endif::[]
 :keywords: studio, maven, version control, dependencies, libraries
 
-include::mule-runtime::partial$mmp-concept.adoc[tag=deprecatedVersionsWarning]
+include::partial$mmp-concept.adoc[tag=deprecatedVersionsWarning]
 
 This page summarizes reference information that helps you work when using Maven with Mule. Refer to xref:using-maven-with-mule.adoc[Maven Support in Mule] for an introduction and overview.
 

--- a/modules/ROOT/pages/mmp-concept.adoc
+++ b/modules/ROOT/pages/mmp-concept.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 
-include::mule-runtime::partial$mmp-concept.adoc[tag=deprecatedVersionsWarning]
+include::partial$mmp-concept.adoc[tag=deprecatedVersionsWarning]
 
 The Mule Maven plugin enables you to integrate the packaging and deployment of your Mule applications with your Maven lifecycle. +
 See xref:package-a-mule-application.adoc[Package a Mule Application] for packaging instructions.
@@ -120,7 +120,7 @@ The undeploy goal also deletes the app in Mule Maven plugin 3.3.0 and later vers
 
 Before you can perform any operations, you must add the Mule Maven plugin to your project.
 
-include::mule-runtime::partial$mmp-concept.adoc[tag=addMuleMavenPluginToAProject]
+include::partial$mmp-concept.adoc[tag=addMuleMavenPluginToAProject]
 
 == Skip Plugin Execution
 
@@ -129,7 +129,7 @@ You can skip the plugin execution by setting the `skip` parameter to true inside
 [source,xml,linenums]
 ----
 <plugin>
-include::mule-runtime::example$mmp-concept-config.xml[]
+include::example$mmp-concept-config.xml[]
   <configuration>
     <standaloneDeployment>
       <muleHome>${mule.home.test}</muleHome>
@@ -146,7 +146,7 @@ You can skip the status verification of your deployed app by setting the `skipDe
 [source,xml,linenums]
 ----
 <plugin>
-include::mule-runtime::example$mmp-concept-config.xml[]
+include::example$mmp-concept-config.xml[]
   <configuration>
     <runtimeFabricDeployment>
       ...

--- a/modules/ROOT/pages/package-a-mule-application.adoc
+++ b/modules/ROOT/pages/package-a-mule-application.adoc
@@ -1,6 +1,6 @@
 = Package a Mule Application
 
-include::mule-runtime::partial$mmp-concept.adoc[tag=deprecatedVersionsWarning]
+include::partial$mmp-concept.adoc[tag=deprecatedVersionsWarning]
 
 You can package your Mule applications using Mule Maven Plugin(command line) or Anypoint Studio. See xref:studio::import-export-packages.adoc#export-project-studio[Exporting Projects from Studio] for details about this procedure.
 

--- a/modules/ROOT/pages/runtime-installation-task.adoc
+++ b/modules/ROOT/pages/runtime-installation-task.adoc
@@ -136,7 +136,7 @@ You can xref:monitoring::am-installing.adoc[install Anypoint Monitoring] for clo
 
 == Update, Upgrade, or Migrate Mule Versions
 
-include::mule-runtime::partial$upgrade-update-migrate-mule.adoc[]
+include::partial$upgrade-update-migrate-mule.adoc[]
 
 == See Also
 

--- a/modules/ROOT/pages/using-maven-with-mule.adoc
+++ b/modules/ROOT/pages/using-maven-with-mule.adoc
@@ -4,7 +4,7 @@ include::_attributes.adoc[]
 endif::[]
 :keywords: studio, maven, version control, dependencies, libraries, runtime
 
-include::mule-runtime::partial$mmp-concept.adoc[tag=deprecatedVersionsWarning]
+include::partial$mmp-concept.adoc[tag=deprecatedVersionsWarning]
 
 Maven is a project management utility that Mule implements to enhance project development. Mule provides built-in Maven functionality, including the following features:
 


### PR DESCRIPTION
Making a change to the format for some includes to prevent unresolved partial errors. More information in the fix for JP here:
https://github.com/mulesoft/docs-mule-runtime-jp/pull/81

(The fix has been applied in previous versions for JP. For English, I'm only making the change in 4.9 so that it's fixed in our next handoff.)

# Writer's Quality Checklist

Before merging your PR, did you:

- [ ] Run spell checker
- [ ] Run link checker to check for broken xrefs
- [ ] Check for orphan files
- [ ] Perform a local build and do a final visual check of your content, including checking for:
  - Broken images
  - Dead links
  - Correct rendering of partials if they are used in your content
  - Formatting issues, such as:
    - Misnumbered ordered lists (steps) or incorrectly nested unordered lists
    - Messed up tables
    - Proper indentation
    - Correct header levels
- [ ] Receive final review and signoff from:
  - Technical SME
  - Product Manager
  - Editor or peer reviewer
  - Reporter, if this content is in response to a reported issue (internal or external feedback)
- [ ] If applicable, verify that the software actually got released