### PR TITLE
W-21948253: Correct AES key length and JCE policy in secure properties

### DIFF
--- a/modules/ROOT/pages/secure-configuration-properties.adoc
+++ b/modules/ROOT/pages/secure-configuration-properties.adoc
@@ -286,7 +286,7 @@ See <<supported_modes>> for a full list.
 ====
 * If you use the `$` character in your key, you must precede it with `\`.
 For example, to use key `myKey#$%123`, you must specify the `<key>` parameter as `myKey#\$%123`. +
-* Beginning with Java Cryptography Extension (JCE) version 1.8.0_161, the AES key size must be of at least 32 characters (256 bits).
+* Beginning with Java 8 Update 161 (JRE 1.8.0_161), the Unlimited Strength Jurisdiction Policy is enabled by default. This allows the use of AES-256 (32-byte keys) without additional JVM configuration. Ensure your key length (16, 24, or 32 bytes which typically equates to the same number of standard text characters) exactly matches the requirements of your chosen encryption algorithm (AES-128, AES-192, or AES-256 respectively).
 ====
 |`<value>`
 |Specifies the string value that is encrypted or decrypted during the `string` operation.


### PR DESCRIPTION
Replace inaccurate JCE/AES key-length note under the <key> parameter with wording aligned to Java 8u161 unlimited strength defaults and AES-128/192/256.

# Writer's Quality Checklist

Before merging your PR, did you:

- [ ] Run spell checker
- [ ] Run link checker to check for broken xrefs
- [ ] Check for orphan files
- [ ] Perform a local build and do a final visual check of your content, including checking for:
  - Broken images
  - Dead links
  - Correct rendering of partials if they are used in your content
  - Formatting issues, such as:
    - Misnumbered ordered lists (steps) or incorrectly nested unordered lists
    - Messed up tables
    - Proper indentation
    - Correct header levels
- [ ] Receive final review and signoff from:
  - Technical SME
  - Product Manager
  - Editor or peer reviewer
  - Reporter, if this content is in response to a reported issue (internal or external feedback)
- [ ] If applicable, verify that the software actually got released