### PR TITLE
W-23162902: Regenerate feature-flagging.adoc for 4.12.1-rc1

### DIFF
--- a/modules/ROOT/pages/feature-flagging.adoc
+++ b/modules/ROOT/pages/feature-flagging.adoc
@@ -137,8 +137,6 @@ The following table shows the available feature flags, a description of their fu
 
 *Enabled by Default Since*
 
-* Not enabled by default in any Mule version.
-
 *Issue ID*
 
 * MULE-19588
@@ -166,8 +164,6 @@ The following table shows the available feature flags, a description of their fu
 * 4.4.0-20220221
 
 *Enabled by Default Since*
-
-* Not enabled by default in any Mule version
 
 *Issue ID*
 
@@ -316,26 +312,11 @@ Suppressed errors are treated as underlying causes that can also be matched by O
 
 *Enabled by Default Since*
 
-* 4.4.0-20220922
-
-
-*Issue ID*
-
-* W-11778765
-<.^|`mule.errorTypes.lax`
-|When enabled, error types validations are enforced even for error handlers/components that aren't referenced.
-
-*Available Since*
-
-* 4.5.0
-
-*Enabled by Default Since*
-
-* 4.5.0
+* Enabled by default in every Mule version
 
 *Issue ID*
 
-* MULE-19879
+* W-11308645
 <.^|`mule.support.native.library.dependencies`
 |When enabled, if an application accesses a native library, the rest of its declared native libraries are also loaded. This prevents errors like `UnsatisfiedLinkError` when the accessed native library depends on another native library. Libraries must be declared at the `sharedLibraries` configuration following the dependency order, meaning that if library A depends on library B, then A must be declared first. Declaring the native libraries at a domain is also supported.
 
@@ -394,8 +375,8 @@ This feature isn't configurable by system property.
 
 *Issue ID*
 
-* W-10619787
-<.^|`disable.attribute.parameter.whitespace.trimming`
+* MULE-19879
+<.^|`mule.disable.attribute.parameter.whitespace.trimming`
 |When enabled, Mule trims whitespaces from parameter values defined at the attribute level in the DSL.
 
 *Available Since*
@@ -409,7 +390,7 @@ This feature isn't configurable by system property.
 *Issue ID*
 
 * MULE-19803
-<.^|`disable.pojo.text.parameter.whitespace.trimming`
+<.^|`mule.disable.pojo.text.parameter.whitespace.trimming`
 |When enabled, Mule trims whitespaces from CDATA text parameter of pojos in the DSL.
 
 *Available Since*
@@ -423,7 +404,7 @@ This feature isn't configurable by system property.
 *Issue ID*
 
 * MULE-20048
-<.^|`enforce.expression.validation`
+<.^|`mule.enforce.expression.validation`
 |When enabled, expression validations are enforced for `targetValue`, not allowing a literal value.
 
 *Available Since*
@@ -437,28 +418,12 @@ This feature isn't configurable by system property.
 *Issue ID*
 
 * MULE-19987
-<.^|`enforce.dw.expression.validation`
+<.^|`mule.enforce.dw.expression.validation`
 |When enabled, expression validations are enforced for all DataWeave expressions.
 
 *Available Since*
 
 * 4.5.0
-
-*Enabled by Default Since*
-
-* 4.5.0
-
-*Issue ID*
-
-* MULE-19967
-<.^|`force.runtime.profiling.consumers.enablement`
-|When enabled, profiling consumers implemented by Mule are enabled by default.
-
-*Available Since*
-
-* 4.5.0
-
-* 4.4.0-202202
 
 *Enabled by Default Since*
 
@@ -480,7 +445,7 @@ This feature isn't configurable by system property.
 
 *Deprecated Since*
 
-* 4.9.0
+* since 4.9.0, `optional` attribute in entries are no longer supported
 
 *Issue ID*
 
@@ -519,11 +484,12 @@ This feature isn't configurable by system property.
 *Available Since*
 
 * 4.5.0
+
 * 4.4.0-202210
 
 *Enabled by Default Since*
 
-* Enabled by default in any Mule version
+* Enabled by default in every Mule version
 
 *Issue ID*
 
@@ -565,12 +531,11 @@ This feature isn't configurable by system property.
 
 *Enabled by Default Since*
 
-* Enabled by default in any Mule version
+* Enabled by default in every Mule version
 
 *Issue ID*
 
 * W-12128703
-
 <.^|`mule.enable.policy.context.parallel.scopes`
 |When enabled, a new (Source) Policy Context is created for the execution of parallel scopes: ParallelForeach, ScatterGather, and Async.
 
@@ -739,7 +704,9 @@ This feature isn't configurable by system property.
 *Available Since*
 
 * 4.9.0
+
 * 4.8.4
+
 * 4.6.12
 
 *Enabled by Default Since*
@@ -755,8 +722,11 @@ This feature isn't configurable by system property.
 *Available Since*
 
 * 4.10.0
+
 * 4.9.2
+
 * 4.6.14
+
 * 4.4.0-20250217
 
 *Enabled by Default Since*
@@ -772,13 +742,20 @@ This feature isn't configurable by system property.
 *Available Since*
 
 * 4.10.0
+
 * 4.9.7
+
 * 4.6.20
+
 * 4.4.1
 
 *Enabled by Default Since*
 
 * Not enabled by default in any Mule version
+
+*Deprecated Since*
+
+* since 4.12, this is configurable on streaming configuration. Use the
 
 *Issue ID*
 
@@ -803,7 +780,9 @@ This feature isn't configurable by system property.
 *Available Since*
 
 * 4.11.0
+
 * 4.10.1
+
 * 4.9.11
 
 *Enabled by Default Since*
@@ -819,8 +798,11 @@ This feature isn't configurable by system property.
 *Available Since*
 
 * 4.11.0
+
 * 4.10.1
+
 * 4.9.11
+
 * 4.6.24
 
 *Enabled by Default Since*
@@ -836,8 +818,11 @@ This feature isn't configurable by system property.
 *Available Since*
 
 * 4.11.0
+
 * 4.10.1
+
 * 4.9.11
+
 * 4.6.24
 
 *Enabled by Default Since*
@@ -853,13 +838,16 @@ This feature isn't configurable by system property.
 *Available Since*
 
 * 4.11.0
+
 * 4.10.2
+
 * 4.9.12
+
 * 4.6.25
 
 *Enabled by Default Since*
 
-* Not enabled by default in any Mule version
+* 4.12.0
 
 *Issue ID*
 
@@ -873,7 +861,7 @@ This feature isn't configurable by system property.
 
 *Enabled by Default Since*
 
-* 4.11.0
+* 4.12.0
 
 *Issue ID*
 
@@ -884,13 +872,16 @@ This feature isn't configurable by system property.
 *Available Since*
 
 * 4.11.1
+
 * 4.10.3
+
 * 4.9.13
+
 * 4.6.26
 
 *Enabled by Default Since*
 
-* Not enabled by default in any Mule version
+* 4.12.0
 
 *Issue ID*
 
@@ -901,12 +892,14 @@ This feature isn't configurable by system property.
 *Available Since*
 
 * 4.11.3
+
 * 4.9.16
+
 * 4.6.29
 
 *Enabled by Default Since*
 
-* Not enabled by default in any Mule version
+* 4.13.0
 
 *Issue ID*
 
@@ -917,13 +910,16 @@ This feature isn't configurable by system property.
 *Available Since*
 
 * 4.12.0
+
 * 4.11.1
+
 * 4.9.14
+
 * 4.6.27
 
 *Enabled by Default Since*
 
-* Not enabled by default in any Mule version
+* 4.12.0
 
 *Issue ID*
 
@@ -938,12 +934,73 @@ After this feature flag is enabled, it can't be disabled because the format of p
 
 *Enabled by Default Since*
 
-* Not enabled by default in any Mule version
+* 4.12.0
 
 *Issue ID*
 
 * W-21549211
+<.^|`mule.enable.byteBuddy.objectCreation`
+|When enabled, the Objects factories will be created with Byte Buddy instead of CGLIB.
 
+*Available Since*
+
+* 4.4.0-202203
+
+* 4.3.0-202203
+
+*Enabled by Default Since*
+
+* 4.4.0
+
+*Deprecated Since*
+
+* since 4.5.0, ByteBuddy is always used
+
+*Issue ID*
+
+* W-10672687
+<.^|`ENFORCE_BATCH_AGGREGATOR_VALIDATION`
+|When enabled, batch:aggregator validations will be enforced.
+
+*Available Since*
+
+* 4.12.0
+
+*Enabled by Default Since*
+
+* 4.12.0
+
+*Issue ID*
+
+* W-21549351
+<.^|`ENFORCE_POLICY_PROXY_VALIDATION`
+|When enabled, http-policy:proxy completeness validations will be enforced.
+
+*Available Since*
+
+* 4.12.0
+
+*Enabled by Default Since*
+
+* 4.12.0
+
+*Issue ID*
+
+* W-21549351
+<.^|`mule.enable.cluster.in.memory.object.store`
+|When enabled, non-persistent object store partitions use the cluster's in-memory store (e.g. Hazelcast). This ensures transient object store entries are consistent across cluster nodes when OSv2 and Hazelcast clustering are both active.
+
+*Available Since*
+
+* 4.13.0
+
+*Enabled by Default Since*
+
+* 4.13.0
+
+*Issue ID*
+
+* W-17714668
 |===
 
 == See Also


### PR DESCRIPTION
Regenerates `modules/ROOT/pages/feature-flagging.adoc` from `MuleRuntimeFeature.java` for runtime version(s) 4.12.1-rc1 (mule-api `1.12.1-rc1`).

Tracked under [W-23162902](https://gus.my.salesforce.com/lightning/r/ADM_Work__c/W-23162902).

Generated by `utils/scripts/update-feature-flags-docs/update_feature_flags_docs.py`.
