### PR TITLE
W-23162902: Regenerate feature-flagging.adoc for 4.6.32-rc1

### DIFF
--- a/modules/ROOT/pages/feature-flagging.adoc
+++ b/modules/ROOT/pages/feature-flagging.adoc
@@ -123,7 +123,7 @@ The following table shows the available feature flags, a description of their fu
 
 *Deprecated Since*
 
-* since 4.5.0, ByteBuddy is always used
+* 4.5.0, ByteBuddy is mandatory
 
 *Issue ID*
 
@@ -667,7 +667,7 @@ This feature isn't configurable by system property.
 
 * W-20038933
 <.^|`mule.put.trace.id.and.span.id.in.mdc`
-|When enabled, the trace id and span id will be added to the MDC when available.
+|When enabled, the trace ID and span ID are added to the MDC when available.
 
 *Available Since*
 
@@ -681,7 +681,7 @@ This feature isn't configurable by system property.
 
 * W-12979787
 <.^|`mule.enable.mule.specific.tracing.information`
-|When enabled the ancestor-mule-span-id value will be added in the trace state when a span is propagated.
+|When enabled, the `ancestor-mule-span-id` value is added in the trace state when a span is propagated.
 
 *Available Since*
 
@@ -693,7 +693,7 @@ This feature isn't configurable by system property.
 
 * W-13215870
 <.^|`mule.tx.error.when.timeout`
-|When enabled, when a (local or xa) transaction reached timeout, an error will be thrown that can be handled using error handling
+|When enabled, an error is thrown when a local or XA transaction reach timeout. This error can be handled using error handling.
 
 *Available Since*
 
@@ -707,7 +707,7 @@ This feature isn't configurable by system property.
 
 * W-14608096
 <.^|`mule.enable.xml.sdk.mdc.reset`
-|When enabled, the MDC context will reset after XML SDK Operation has been executed.
+|When enabled, the MDC context resets after XML SDK operation is executed.
 
 *Available Since*
 
@@ -727,11 +727,11 @@ This feature isn't configurable by system property.
 
 * W-15206528
 <.^|`mule.honour.persisted.flow.state`
-|When enabled, flows will honour the state configured in flows.deployment.properties when restarting the app, regardless of the initial state.
+|When enabled, flows honor the state configured in `flows.deployment.properties` when restarting the app, regardless of the initial state.
 
 *Available Since*
 
-* 4.8
+* 4.8.0
 
 *Enabled by Default Since*
 
@@ -741,11 +741,11 @@ This feature isn't configurable by system property.
 
 * W-15750334
 <.^|`mule.disable.optimised.notification.handler.dynamic.resolution.update.based.on.delegate`
-|When disabled, dynamic resolution of notification handling will not happen after the mule artifact is initialized. This can result in race conditions that can affect monitoring metrics.
+|When disabled, dynamic resolution of notification handling doesn't occur after the Mule artifact is initialized. This can cause race conditions that affect monitoring metrics.
 
 *Available Since*
 
-* 4.8
+* 4.8.0
 
 *Enabled by Default Since*
 
@@ -753,11 +753,11 @@ This feature isn't configurable by system property.
 
 * W-16828516
 <.^|`mule.ntlm.avoid.send.payload.on.type1`
-|When enabled, body contents will not be sent on NTLM type 1 requests. This saves resources by not sending a payload that will never be consumed (the server will reject it until the dance is completed).
+|When enabled, body contents aren't sent on NTLM type 1 requests. This saves resources by not sending a payload that is never consumed (the server rejects the payload until the dance is completed).
 
 *Available Since*
 
-* 4.8
+* 4.8.0
 
 *Enabled by Default Since*
 
@@ -767,7 +767,7 @@ This feature isn't configurable by system property.
 
 * W-17107281
 <.^|`mule.repeatableStreaming.bytes.eagerRead`
-|When enabled, cursors from repeatable streams 'read' methods will return immediately after readily available data has been read. If disabled, 'read' methods will not return until the requested 'len' has been read. Setting this to 'true' is useful, for instance, so that SSE events sent over HTTP can be processed as they arrive instead of being buffered by repeatable streaming.
+|When enabled, the `read` methods of bytes repeatable streams return immediately with any available data. If disabled, they don't return until the requested `len` is fully read. Set this property to `true` to process SSE events over HTTP as they arrive instead of buffering them.
 
 *Available Since*
 
@@ -787,7 +787,7 @@ This feature isn't configurable by system property.
 
 * W-18716253
 <.^|`mule.redeliveryPolicy.encode.secureHash`
-|When set to true, the result of the encryption of the payload will be encoded to Hexadecimal. This only affects the case when there is no ExpressionID set by the user.
+|When enabled, the encrypted payload is encoded in hexadecimal format when no Expression ID is specified.
 
 *Available Since*
 
@@ -805,7 +805,7 @@ This feature isn't configurable by system property.
 
 * W-18584560
 <.^|`mule.untilSuccessful.retryOnCriticalError.disallow`
-|When set to true, if a 'MULE:CRITICAL' error is raised within an 'until-successful' the event will NOT be retried.
+|When enabled, events aren't retried if a `MULE:CRITICAL` error occurs within an until-successful scope.
 
 *Available Since*
 
@@ -825,7 +825,7 @@ This feature isn't configurable by system property.
 
 * W-19648397
 <.^|`mule.flowStop.parallel.enable`
-|When set to true, when a mule application is stopped all of its flows will be stopped at the same time in parallel rather than sequentially.
+|When enabled, all Mule flows are stopped in parallel rather than sequentially when a Mule application is stopped. This prevents delays caused by in-flight events in one flow from delaying the shutdown of other flows.
 
 *Available Since*
 
@@ -844,20 +844,7 @@ This feature isn't configurable by system property.
 *Issue ID*
 
 * W-21228085
-<.^|`mule.enable.cluster.in.memory.object.store`
-|When enabled, non-persistent object store partitions use the cluster's in-memory store (e.g. Hazelcast). This ensures transient object store entries are consistent across cluster nodes when OSv2 and Hazelcast clustering are both active.
 
-*Available Since*
-
-* 4.13.0
-
-*Enabled by Default Since*
-
-* 4.13.0
-
-*Issue ID*
-
-* W-17714668
 |===
 
 == See Also

--- a/modules/ROOT/pages/feature-flagging.adoc
+++ b/modules/ROOT/pages/feature-flagging.adoc
@@ -57,8 +57,6 @@ The following table shows the available feature flags, a description of their fu
 
 *Enabled by Default Since*
 
-* Not enabled by default in any Mule version
-
 *Issue ID*
 
 * MULE-19218
@@ -91,7 +89,7 @@ The following table shows the available feature flags, a description of their fu
 
 *Enabled by Default Since*
 
-* 4.5.0
+* 4.5.0, 4.4.1, 4.3.1
 
 *Issue ID*
 
@@ -123,6 +121,10 @@ The following table shows the available feature flags, a description of their fu
 
 * 4.4.0
 
+*Deprecated Since*
+
+* since 4.5.0, ByteBuddy is always used
+
 *Issue ID*
 
 * W-10672687
@@ -151,8 +153,6 @@ The following table shows the available feature flags, a description of their fu
 
 *Enabled by Default Since*
 
-* Not enabled by default in any Mule version.
-
 *Issue ID*
 
 * MULE-19588
@@ -178,8 +178,6 @@ The following table shows the available feature flags, a description of their fu
 * 4.4.0-20220221
 
 *Enabled by Default Since*
-
-* Not enabled by default in any Mule version
 
 *Issue ID*
 
@@ -209,9 +207,7 @@ The following table shows the available feature flags, a description of their fu
 
 *Enabled by Default Since*
 
-* 4.4.0
-
-* 4.3.0
+* 4.4.0, 4.3.0
 
 *Issue ID*
 
@@ -330,26 +326,11 @@ Suppressed errors are treated as underlying causes that can also be matched by O
 
 *Enabled by Default Since*
 
-* 4.4.0-20220922
-
-
-*Issue ID*
-
-* W-11778765
-<.^|`mule.errorTypes.lax`
-|When enabled, error types validations are enforced even for error handlers/components that aren't referenced.
-
-*Available Since*
-
-* 4.4.0-20211227
-
-*Enabled by Default Since*
-
-* Not enabled by default in any Mule version.
+* 4.5.0, 4.4.0-202210, 4.3.0-202210
 
 *Issue ID*
 
-* MULE-19879
+* W-11308645
 <.^|`mule.support.native.library.dependencies`
 |When enabled, if an application accesses a native library, the rest of its declared native libraries are also loaded. This prevents errors like `UnsatisfiedLinkError` when the accessed native library depends on another native library. Libraries must be declared at the `sharedLibraries` configuration following the dependency order, meaning that if library A depends on library B, then A must be declared first. Declaring the native libraries at a domain is also supported.
 
@@ -408,8 +389,8 @@ This feature isn't configurable by system property.
 
 *Issue ID*
 
-* W-10619787
-<.^|`disable.attribute.parameter.whitespace.trimming`
+* MULE-19879
+<.^|`mule.disable.attribute.parameter.whitespace.trimming`
 |When enabled, Mule trims whitespaces from parameter values defined at the attribute level in the DSL.
 
 *Available Since*
@@ -423,7 +404,7 @@ This feature isn't configurable by system property.
 *Issue ID*
 
 * MULE-19803
-<.^|`disable.pojo.text.parameter.whitespace.trimming`
+<.^|`mule.disable.pojo.text.parameter.whitespace.trimming`
 |When enabled, Mule trims whitespaces from CDATA text parameter of pojos in the DSL.
 
 *Available Since*
@@ -437,7 +418,7 @@ This feature isn't configurable by system property.
 *Issue ID*
 
 * MULE-20048
-<.^|`enforce.expression.validation`
+<.^|`mule.enforce.expression.validation`
 |When enabled, expression validations are enforced for `targetValue`, not allowing a literal value.
 
 *Available Since*
@@ -451,28 +432,12 @@ This feature isn't configurable by system property.
 *Issue ID*
 
 * MULE-19987
-<.^|`enforce.dw.expression.validation`
+<.^|`mule.enforce.dw.expression.validation`
 |When enabled, expression validations are enforced for all DataWeave expressions.
 
 *Available Since*
 
 * 4.5.0
-
-*Enabled by Default Since*
-
-* 4.5.0
-
-*Issue ID*
-
-* MULE-19967
-<.^|`force.runtime.profiling.consumers.enablement`
-|When enabled, profiling consumers implemented by Mule are enabled by default.
-
-*Available Since*
-
-* 4.5.0
-
-* 4.4.0-202202
 
 *Enabled by Default Since*
 
@@ -529,13 +494,12 @@ This feature isn't configurable by system property.
 *Available Since*
 
 * 4.5.0
+
 * 4.4.0-202210
 
 *Enabled by Default Since*
 
-* 4.5.0
-* 4.4.0-202210
-* 4.3.0-202210
+* 4.5.0, 4.4.0-202210, 4.3.0-202210
 
 *Issue ID*
 
@@ -577,22 +541,11 @@ This feature isn't configurable by system property.
 
 *Enabled by Default Since*
 
-* 4.0.0
-
-* 4.1.0
-
-* 4.2.0
-
-* 4.3.0
-
-* 4.4.0
-
-* 4.5.0
+* 4.0.0, 4.1.0, 4.2.0, 4.3.0, 4.4.0, 4.5.0
 
 *Issue ID*
 
 * W-12128703
-
 <.^|`mule.enable.policy.context.parallel.scopes`
 |When enabled, a new (Source) Policy Context is created for the execution of parallel scopes: ParallelForeach, ScatterGather, and Async.
 
@@ -629,7 +582,9 @@ This feature isn't configurable by system property.
 *Available Since*
 
 * 4.6.0
+
 * 4.5.1
+
 * 4.4.0-20231026
 
 *Enabled by Default Since*
@@ -639,18 +594,18 @@ This feature isn't configurable by system property.
 *Issue ID*
 
 * W-13881167
-
 <.^|`mule.forkJoin.completeChildContextsOnTimeout`
 |When enabled, the processors that perform fork and join work (currently, Scatter-Gather and Parallel For Each routers) complete the child event contexts when a timeout occurs.
 
 *Available Since*
 
 * 4.6.14
+
 * 4.4.0-20250217
 
 *Enabled by Default Since*
 
-* Not enabled by default in any Mule version
+* 4.10.0
 
 *Issue ID*
 
@@ -661,8 +616,11 @@ This feature isn't configurable by system property.
 *Available Since*
 
 * 4.11.0
+
 * 4.10.1
+
 * 4.9.11
+
 * 4.6.24
 
 *Enabled by Default Since*
@@ -678,33 +636,228 @@ This feature isn't configurable by system property.
 *Available Since*
 
 * 4.11.2
+
 * 4.9.15
+
 * 4.6.28
 
 *Enabled by Default Since*
 
-* Not enabled by default in any Mule version
+* 4.12.0
 
 *Issue ID*
 
-* W-21215761
+* W-19607093
 <.^|`mule.enable.inline.tls.context.initialization`
 |When set to true, inline TLS contexts invoke their lifecycle initialization method, ensuring inline TLS contexts are fully initialized before use.
 
 *Available Since*
 
 * 4.11.3
+
 * 4.9.16
+
 * 4.6.29
 
 *Enabled by Default Since*
 
-* Not enabled by default in any Mule version
+* 4.12.0
 
 *Issue ID*
 
 * W-20038933
+<.^|`mule.put.trace.id.and.span.id.in.mdc`
+|When enabled, the trace id and span id will be added to the MDC when available.
 
+*Available Since*
+
+* 4.5.0
+
+*Enabled by Default Since*
+
+* 4.5.0
+
+*Issue ID*
+
+* W-12979787
+<.^|`mule.enable.mule.specific.tracing.information`
+|When enabled the ancestor-mule-span-id value will be added in the trace state when a span is propagated.
+
+*Available Since*
+
+* 4.5.0
+
+*Enabled by Default Since*
+
+*Issue ID*
+
+* W-13215870
+<.^|`mule.tx.error.when.timeout`
+|When enabled, when a (local or xa) transaction reached timeout, an error will be thrown that can be handled using error handling
+
+*Available Since*
+
+* 4.6.1
+
+*Enabled by Default Since*
+
+* 4.6.1
+
+*Issue ID*
+
+* W-14608096
+<.^|`mule.enable.xml.sdk.mdc.reset`
+|When enabled, the MDC context will reset after XML SDK Operation has been executed.
+
+*Available Since*
+
+* 4.8.0
+
+* 4.7.1
+
+* 4.6.4
+
+* 4.4.0-202406
+
+*Enabled by Default Since*
+
+* 4.8.0
+
+*Issue ID*
+
+* W-15206528
+<.^|`mule.honour.persisted.flow.state`
+|When enabled, flows will honour the state configured in flows.deployment.properties when restarting the app, regardless of the initial state.
+
+*Available Since*
+
+* 4.8
+
+*Enabled by Default Since*
+
+* 4.8.0
+
+*Issue ID*
+
+* W-15750334
+<.^|`mule.disable.optimised.notification.handler.dynamic.resolution.update.based.on.delegate`
+|When disabled, dynamic resolution of notification handling will not happen after the mule artifact is initialized. This can result in race conditions that can affect monitoring metrics.
+
+*Available Since*
+
+* 4.8
+
+*Enabled by Default Since*
+
+*Issue ID*
+
+* W-16828516
+<.^|`mule.ntlm.avoid.send.payload.on.type1`
+|When enabled, body contents will not be sent on NTLM type 1 requests. This saves resources by not sending a payload that will never be consumed (the server will reject it until the dance is completed).
+
+*Available Since*
+
+* 4.8
+
+*Enabled by Default Since*
+
+* 4.9.0
+
+*Issue ID*
+
+* W-17107281
+<.^|`mule.repeatableStreaming.bytes.eagerRead`
+|When enabled, cursors from repeatable streams 'read' methods will return immediately after readily available data has been read. If disabled, 'read' methods will not return until the requested 'len' has been read. Setting this to 'true' is useful, for instance, so that SSE events sent over HTTP can be processed as they arrive instead of being buffered by repeatable streaming.
+
+*Available Since*
+
+* 4.10.0
+
+* 4.9.7
+
+* 4.6.20
+
+* 4.4.1
+
+*Enabled by Default Since*
+
+* 4.10.0
+
+*Issue ID*
+
+* W-18716253
+<.^|`mule.redeliveryPolicy.encode.secureHash`
+|When set to true, the result of the encryption of the payload will be encoded to Hexadecimal. This only affects the case when there is no ExpressionID set by the user.
+
+*Available Since*
+
+* 4.11.0
+
+* 4.10.1
+
+* 4.9.11
+
+*Enabled by Default Since*
+
+* 4.11.0
+
+*Issue ID*
+
+* W-18584560
+<.^|`mule.untilSuccessful.retryOnCriticalError.disallow`
+|When set to true, if a 'MULE:CRITICAL' error is raised within an 'until-successful' the event will NOT be retried.
+
+*Available Since*
+
+* 4.11.0
+
+* 4.10.1
+
+* 4.9.11
+
+* 4.6.24
+
+*Enabled by Default Since*
+
+* 4.11.0
+
+*Issue ID*
+
+* W-19648397
+<.^|`mule.flowStop.parallel.enable`
+|When set to true, when a mule application is stopped all of its flows will be stopped at the same time in parallel rather than sequentially.
+
+*Available Since*
+
+* 4.12.0
+
+* 4.11.1
+
+* 4.9.14
+
+* 4.6.27
+
+*Enabled by Default Since*
+
+* 4.12.0
+
+*Issue ID*
+
+* W-21228085
+<.^|`mule.enable.cluster.in.memory.object.store`
+|When enabled, non-persistent object store partitions use the cluster's in-memory store (e.g. Hazelcast). This ensures transient object store entries are consistent across cluster nodes when OSv2 and Hazelcast clustering are both active.
+
+*Available Since*
+
+* 4.13.0
+
+*Enabled by Default Since*
+
+* 4.13.0
+
+*Issue ID*
+
+* W-17714668
 |===
 
 == See Also


### PR DESCRIPTION
Regenerates `modules/ROOT/pages/feature-flagging.adoc` from `MuleRuntimeFeature.java` for runtime version(s) 4.6.32-rc1 (mule-api `1.6.32-rc1`).

Tracked under [W-23162902](https://gus.my.salesforce.com/lightning/r/ADM_Work__c/W-23162902).

Generated by `utils/scripts/update-feature-flags-docs/update_feature_flags_docs.py`.
