### PR TITLE
W-23162902: Regenerate feature-flagging.adoc for 4.9.19-rc1

### DIFF
--- a/modules/ROOT/pages/feature-flagging.adoc
+++ b/modules/ROOT/pages/feature-flagging.adoc
@@ -93,10 +93,6 @@ The following table shows the available feature flags, a description of their fu
 
 * 4.5.0
 
-* 4.4.1
-
-* 4.3.1
-
 *Issue ID*
 
 * MULE-19919
@@ -141,8 +137,6 @@ The following table shows the available feature flags, a description of their fu
 
 *Enabled by Default Since*
 
-* Not enabled by default in any Mule version.
-
 *Issue ID*
 
 * MULE-19588
@@ -171,8 +165,6 @@ The following table shows the available feature flags, a description of their fu
 
 *Enabled by Default Since*
 
-* Not enabled by default in any Mule version
-
 *Issue ID*
 
 * MULE-19967
@@ -200,8 +192,6 @@ The following table shows the available feature flags, a description of their fu
 * 4.3.0-20220221
 
 *Enabled by Default Since*
-
-* 4.4.0
 
 * 4.3.0
 
@@ -322,26 +312,11 @@ Suppressed errors are treated as underlying causes that can also be matched by O
 
 *Enabled by Default Since*
 
-* 4.4.0-20220922
-
-
-*Issue ID*
-
-* W-11778765
-<.^|`mule.errorTypes.lax`
-|When enabled, error types validations are enforced even for error handlers/components that aren't referenced.
-
-*Available Since*
-
-* 4.4.0-20211227
-
-*Enabled by Default Since*
-
-* Not enabled by default in any Mule version.
+* Enabled by default in every Mule version
 
 *Issue ID*
 
-* MULE-19879
+* W-11308645
 <.^|`mule.support.native.library.dependencies`
 |When enabled, if an application accesses a native library, the rest of its declared native libraries are also loaded. This prevents errors like `UnsatisfiedLinkError` when the accessed native library depends on another native library. Libraries must be declared at the `sharedLibraries` configuration following the dependency order, meaning that if library A depends on library B, then A must be declared first. Declaring the native libraries at a domain is also supported.
 
@@ -400,8 +375,8 @@ This feature isn't configurable by system property.
 
 *Issue ID*
 
-* W-10619787
-<.^|`disable.attribute.parameter.whitespace.trimming`
+* MULE-19879
+<.^|`mule.disable.attribute.parameter.whitespace.trimming`
 |When enabled, Mule trims whitespaces from parameter values defined at the attribute level in the DSL.
 
 *Available Since*
@@ -415,7 +390,7 @@ This feature isn't configurable by system property.
 *Issue ID*
 
 * MULE-19803
-<.^|`disable.pojo.text.parameter.whitespace.trimming`
+<.^|`mule.disable.pojo.text.parameter.whitespace.trimming`
 |When enabled, Mule trims whitespaces from CDATA text parameter of pojos in the DSL.
 
 *Available Since*
@@ -429,7 +404,7 @@ This feature isn't configurable by system property.
 *Issue ID*
 
 * MULE-20048
-<.^|`enforce.expression.validation`
+<.^|`mule.enforce.expression.validation`
 |When enabled, expression validations are enforced for `targetValue`, not allowing a literal value.
 
 *Available Since*
@@ -443,28 +418,12 @@ This feature isn't configurable by system property.
 *Issue ID*
 
 * MULE-19987
-<.^|`enforce.dw.expression.validation`
+<.^|`mule.enforce.dw.expression.validation`
 |When enabled, expression validations are enforced for all DataWeave expressions.
 
 *Available Since*
 
 * 4.5.0
-
-*Enabled by Default Since*
-
-* 4.5.0
-
-*Issue ID*
-
-* MULE-19967
-<.^|`force.runtime.profiling.consumers.enablement`
-|When enabled, profiling consumers implemented by Mule are enabled by default.
-
-*Available Since*
-
-* 4.5.0
-
-* 4.4.0-202202
 
 *Enabled by Default Since*
 
@@ -486,7 +445,7 @@ This feature isn't configurable by system property.
 
 *Deprecated Since*
 
-* 4.9.0
+* since 4.9.0, `optional` attribute in entries are no longer supported
 
 *Issue ID*
 
@@ -525,13 +484,12 @@ This feature isn't configurable by system property.
 *Available Since*
 
 * 4.5.0
+
 * 4.4.0-202210
 
 *Enabled by Default Since*
 
-* 4.5.0
-* 4.4.0-202210
-* 4.3.0-202210
+* Enabled by default in every Mule version
 
 *Issue ID*
 
@@ -573,22 +531,11 @@ This feature isn't configurable by system property.
 
 *Enabled by Default Since*
 
-* 4.5.0
-
-* 4.4.0
-
-* 4.3.0
-
-* 4.2.0
-
-* 4.1.0
-
-* 4.0.0
+* Enabled by default in every Mule version
 
 *Issue ID*
 
 * W-12128703
-
 <.^|`mule.enable.policy.context.parallel.scopes`
 |When enabled, a new (Source) Policy Context is created for the execution of parallel scopes: ParallelForeach, ScatterGather, and Async.
 
@@ -614,7 +561,7 @@ This feature isn't configurable by system property.
 
 *Enabled by Default Since*
 
-* 4.5.0
+* Not enabled by default in any Mule version
 
 *Issue ID*
 
@@ -757,7 +704,9 @@ This feature isn't configurable by system property.
 *Available Since*
 
 * 4.9.0
+
 * 4.8.4
+
 * 4.6.12
 
 *Enabled by Default Since*
@@ -773,12 +722,14 @@ This feature isn't configurable by system property.
 *Available Since*
 
 * 4.9.2
+
 * 4.6.14
+
 * 4.4.0-20250217
 
 *Enabled by Default Since*
 
-* Not enabled by default in any Mule version
+* 4.10.0
 
 *Issue ID*
 
@@ -789,8 +740,11 @@ This feature isn't configurable by system property.
 *Available Since*
 
 * 4.11.0
+
 * 4.10.1
+
 * 4.9.11
+
 * 4.6.24
 
 *Enabled by Default Since*
@@ -806,24 +760,62 @@ This feature isn't configurable by system property.
 *Available Since*
 
 * 4.11.2
+
 * 4.9.15
+
 * 4.6.28
 
 *Enabled by Default Since*
 
-* Not enabled by default in any Mule version
+* 4.12.0
 
 *Issue ID*
 
-* W-21215761
+* W-19607093
 <.^|`mule.enable.inline.tls.context.initialization`
 |When set to true, inline TLS contexts invoke their lifecycle initialization method, ensuring inline TLS contexts are fully initialized before use.
 
 *Available Since*
 
 * 4.11.3
+
 * 4.9.16
+
 * 4.6.29
+
+*Enabled by Default Since*
+
+* 4.12.0
+
+*Issue ID*
+
+* W-20038933
+<.^|`mule.enable.byteBuddy.objectCreation`
+|When enabled, the Objects factories will be created with Byte Buddy instead of CGLIB.
+
+*Available Since*
+
+* 4.4.0-202203
+
+* 4.3.0-202203
+
+*Enabled by Default Since*
+
+* 4.4.0
+
+*Deprecated Since*
+
+* since 4.5.0, ByteBuddy is always used
+
+*Issue ID*
+
+* W-10672687
+<.^|`mule.disable.optimised.notification.handler.dynamic.resolution.update.based.on.delegate`
+|When disabled, dynamic resolution of notification handling will not happen after the mule artifact is initialized. This can result in race conditions that can affect monitoring metrics.
+
+*Available Since*
+
+* 4.8
 
 *Enabled by Default Since*
 
@@ -831,8 +823,99 @@ This feature isn't configurable by system property.
 
 *Issue ID*
 
-* W-20038933
+* W-16828516
+<.^|`mule.repeatableStreaming.bytes.eagerRead`
+|When enabled, cursors from repeatable streams 'read' methods will return immediately after readily available data has been read. If disabled, 'read' methods will not return until the requested 'len' has been read. Setting this to 'true' is useful, for instance, so that SSE events sent over HTTP can be processed as they arrive instead of being buffered by repeatable streaming.
 
+*Available Since*
+
+* 4.10.0
+
+* 4.9.7
+
+* 4.6.20
+
+* 4.4.1
+
+*Enabled by Default Since*
+
+* Not enabled by default in any Mule version
+
+*Issue ID*
+
+* W-18716253
+<.^|`mule.redeliveryPolicy.encode.secureHash`
+|When set to true, the result of the encryption of the payload will be encoded to Hexadecimal. This only affects the case when there is no ExpressionID set by the user.
+
+*Available Since*
+
+* 4.11.0
+
+* 4.10.1
+
+* 4.9.11
+
+*Enabled by Default Since*
+
+* 4.11.0
+
+*Issue ID*
+
+* W-18584560
+<.^|`mule.untilSuccessful.retryOnCriticalError.disallow`
+|When set to true, if a 'MULE:CRITICAL' error is raised within an 'until-successful' the event will NOT be retried.
+
+*Available Since*
+
+* 4.11.0
+
+* 4.10.1
+
+* 4.9.11
+
+* 4.6.24
+
+*Enabled by Default Since*
+
+* 4.11.0
+
+*Issue ID*
+
+* W-19648397
+<.^|`mule.flowStop.parallel.enable`
+|When set to true, when a mule application is stopped all of its flows will be stopped at the same time in parallel rather than sequentially.
+
+*Available Since*
+
+* 4.12.0
+
+* 4.11.1
+
+* 4.9.14
+
+* 4.6.27
+
+*Enabled by Default Since*
+
+* 4.12.0
+
+*Issue ID*
+
+* W-21228085
+<.^|`mule.enable.cluster.in.memory.object.store`
+|When enabled, non-persistent object store partitions use the cluster's in-memory store (e.g. Hazelcast). This ensures transient object store entries are consistent across cluster nodes when OSv2 and Hazelcast clustering are both active.
+
+*Available Since*
+
+* 4.13.0
+
+*Enabled by Default Since*
+
+* 4.13.0
+
+*Issue ID*
+
+* W-17714668
 |===
 
 == See Also


### PR DESCRIPTION
Regenerates `modules/ROOT/pages/feature-flagging.adoc` from `MuleRuntimeFeature.java` for runtime version(s) 4.9.19-rc1 (mule-api `1.9.19-rc1`).

Tracked under [W-23162902](https://gus.my.salesforce.com/lightning/r/ADM_Work__c/W-23162902).

Generated by `utils/scripts/update-feature-flags-docs/update_feature_flags_docs.py`.
