### PR TITLE
W-23071797: Remove persistentObjectStore property from CloudHub 2.0 d…

### DIFF
--- a/modules/ROOT/pages/_partials/mmp-deploy-to-cloudhub-2.adoc
+++ b/modules/ROOT/pages/_partials/mmp-deploy-to-cloudhub-2.adoc
@@ -359,8 +359,6 @@ Configuration example:
 </deploymentSettings>
 ----
 
-| `persistentObjectStore` | Configures the Mule application to use a persistent object store. By default, it's set to `false`.
-
 | `instanceType` | Specifies the capacity of the replica for application deployment. This flag is available only for organizations using a usage-based pricing (UBP) package. Non-UBP organizations use the `vCores` parameter instead. See xref:general::pricing.adoc[]. | No
 
 |===


### PR DESCRIPTION
…eployment settings

This property is only applicable to RTF applications and should not be used with CloudHub 2.0. Enabling it on CH2 causes java.net.UnknownHostException errors for auth.rtf.svc.cluster.local.

# Writer's Quality Checklist

Before merging your PR, did you:

- [ ] Run spell checker
- [ ] Run link checker to check for broken xrefs
- [ ] Check for orphan files
- [ ] Perform a local build and do a final visual check of your content, including checking for:
  - Broken images
  - Dead links
  - Correct rendering of partials if they are used in your content
  - Formatting issues, such as:
    - Misnumbered ordered lists (steps) or incorrectly nested unordered lists
    - Messed up tables
    - Proper indentation
    - Correct header levels
- [ ] Receive final review and signoff from:
  - Technical SME
  - Product Manager
  - Editor or peer reviewer
  - Reporter, if this content is in response to a reported issue (internal or external feedback)
- [ ] If applicable, verify that the software actually got released