### PR TITLE
W-23071797: Remove persistentObjectStore from CH2 deployment settings (v4.9)

### DIFF
--- a/modules/ROOT/pages/_partials/mmp-deploy-to-cloudhub-2.adoc
+++ b/modules/ROOT/pages/_partials/mmp-deploy-to-cloudhub-2.adoc
@@ -356,8 +356,6 @@ Configuration example:
 </deploymentSettings>
 ----
 
-| `persistentObjectStore` | Configures the Mule application to use a persistent object store. By default, it's set to `false`.
-
 | `instanceType` | Specifies the capacity of the replica for application deployment. This flag is available only for organizations using a usage-based pricing (UBP) package. Non-UBP organizations use the `vCores` parameter instead. See xref:general::pricing.adoc[]. | No
 
 |===


### PR DESCRIPTION
## Summary
- Removes the `persistentObjectStore` property from the CloudHub 2.0 deployment settings reference table.
- This property is only applicable to RTF applications. Enabling it on CloudHub 2.0 causes `java.net.UnknownHostException: auth.rtf.svc.cluster.local` errors.

## GUS
W-23071797