### PR TITLE
W-23425450: Fix incorrect anchor ID on CH2 deployment strategy section

### DIFF
--- a/modules/ROOT/pages/_partials/mmp-deploy-to-cloudhub-2.adoc
+++ b/modules/ROOT/pages/_partials/mmp-deploy-to-cloudhub-2.adoc
@@ -41,7 +41,7 @@ See https://anypoint.mulesoft.com/exchange/portals/anypoint-platform/f1e97bc6-31
 // end::prerequisites[]
 
 // tag::DeploymentConfig[]
-[[deploying-to-rtf]]
+[[configure-ch2-deployment-strategy]]
 == Configure the CloudHub 2.0 Deployment Strategy
 
 Inside the `plugin` element, add a configuration for your CloudHub 2.0 deployment, replacing the following placeholder values with your CloudHub 2.0 information:


### PR DESCRIPTION
## Summary

- The anchor `[[deploying-to-rtf]]` was incorrectly applied to the CloudHub 2.0 deployment partial, causing the public URL `ch2-deploy-maven#deploying-to-rtf` to point to the "Configure the CloudHub 2.0 Deployment Strategy" section, which has nothing to do with RTF
- Renamed the anchor to `[[configure-ch2-deployment-strategy]]` to accurately reflect the section content
- The `[[deploying-to-rtf]]` anchor remains intact in `mmp-deploy-to-rtf.adoc` where it legitimately belongs

## Test plan

- [ ] Verify `https://docs.mulesoft.com/cloudhub-2/ch2-deploy-maven#configure-ch2-deployment-strategy` resolves to the correct section after publish
- [ ] Verify no other pages reference the old `#deploying-to-rtf` anchor on this page