### PR TITLE
@W-21964600: Document Upgrade Tool path prerequisites

### DIFF
--- a/modules/ROOT/pages/_partials/upgrade-tool.adoc
+++ b/modules/ROOT/pages/_partials/upgrade-tool.adoc
@@ -17,6 +17,7 @@ The Mule upgrade tool requires the full distribution of the Mule runtime. Ensure
 Download the Mule upgrade tool from the https://help.salesforce.com/s/[Salesforce Help Center]. For more information, see https://help.salesforce.com/s/articleView?id=005167229&type=1[How to access MuleSoft Downloads].
 * At least 2 GB of available disk space on the file system and access privileges to install the new Mule distribution.
 * (For Windows environments) The execution policy for Powershell scripts set to *Unrestricted*.
+* Mule distribution paths (`$MULE_HOME` and the new distribution path) that do not contain blank spaces. The upgrade tool does not support paths that contain blank spaces and exits with an error if it detects one.
 * If Anypoint Monitoring agent is installed, uninstall it prior to the upgrade.
 * Rename the `$MULE_HOME` directory before running the upgrade tool to use a generic name or one that matches the target version. For example, `mule-enterprise-4.9.8`.
 +
@@ -26,18 +27,20 @@ Renaming the directory after running the upgrade tool causes Anypoint Monitoring
 // Upgrade Or Update Mule
 // tag::UpgradeOrUpdateMule[]
 [IMPORTANT]
-The parameter `<newMuleDistributionAbsolutePath>` refers to the temporary location where the new Mule runtime distribution is unpacked for the upgrade process. After the upgrade is successfully completed, this location is no longer required by the Upgrade Tool and can be safely deleted.
+The parameter `<newMuleDistributionPath>` refers to the temporary location where the new Mule runtime distribution is unpacked for the upgrade process. After the upgrade is successfully completed, this location is no longer required by the Upgrade Tool and can be safely deleted.
 
 To upgrade or update your clustered Mule instances to the latest version:
 
 . Navigate to the `$MULE_HOME/tools` directory, where you downloaded the Mule upgrade tool.
-. Run the `upgrade -n` subcommand, specifying as an argument the absolute path of the directory where the latest Mule runtime distribution is downloaded and unpacked, for example:
+. Run the `upgrade -n` subcommand, specifying as an argument the path of the directory where the latest Mule runtime distribution is downloaded and unpacked, for example:
 +
 
 [source,bash,linenums]
 ----
-$MULE_HOME/tools/upgrade-tool upgrade -n <newMuleDistributionAbsolutePath>
+$MULE_HOME/tools/upgrade-tool upgrade -n <newMuleDistributionPath>
 ----
++
+You can provide `<newMuleDistributionPath>` (and the `-o` option) as either an absolute or a relative path. Relative paths are resolved against the directory from which you run the tool.
 +
 The script outputs the following:
 +
@@ -68,7 +71,7 @@ Verifying Mule Agent
 INFO: Mule Agent not installed, skipping setup
 ----
 
-Now that your existing Mule instance is upgraded, you can delete the recently downloaded version (referenced in the example as `<newMuleDistributionAbsolutePath>`) as the upgrade tool does not need it anymore.
+Now that your existing Mule instance is upgraded, you can delete the recently downloaded version (referenced in the example as `<newMuleDistributionPath>`) as the upgrade tool does not need it anymore.
 // end::UpgradeOrUpdateMule[]
 
 // Roll Back Upgrade Or Update


### PR DESCRIPTION
## Summary

Documents the Upgrade Tool path prerequisites changed under [W-21964600](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002XnGbDYAV/view). Companion to the code PR in `mulesoft-emu/mule-runtime-upgrade-tool` (#643).

## Changes

Updates the shared `_partials/upgrade-tool.adoc`:

- Adds a prerequisite noting that Mule distribution paths must **not** contain blank spaces; the tool exits with an error if it detects one.
- Clarifies that the new distribution path and the `-o` option accept **both absolute and relative paths** (relative paths resolve against the directory the tool runs from).
- Renames the example placeholder `<newMuleDistributionAbsolutePath>` → `<newMuleDistributionPath>` to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)