### PR TITLE
@W-23162902 docs(feature-flagging): use "the runtime" wording and fix punctuation

### DIFF
--- a/modules/ROOT/pages/feature-flagging.adoc
+++ b/modules/ROOT/pages/feature-flagging.adoc
@@ -381,7 +381,7 @@ This feature isn't configurable by system property.
 
 * MULE-19879
 <.^|`mule.disable.attribute.parameter.whitespace.trimming`
-|When enabled, Mule trims whitespaces from parameter values defined at the attribute level in the DSL.
+|When enabled, the runtime trims whitespaces from parameter values defined at the attribute level in the DSL.
 
 *Available Since*
 
@@ -395,7 +395,7 @@ This feature isn't configurable by system property.
 
 * MULE-19803
 <.^|`mule.disable.pojo.text.parameter.whitespace.trimming`
-|When enabled, Mule trims whitespaces from CDATA text parameter of pojos in the DSL.
+|When enabled, the runtime trims whitespaces from CDATA text parameter of pojos in the DSL.
 
 *Available Since*
 
@@ -927,7 +927,7 @@ This feature isn't configurable by system property.
 
 * W-21228085
 <.^|`mule.serialize.message.in.cache`
-|When enabled, `ee:cache` persists only the Message instead of the full Event. Java customizations for `ee:cache` aren't supported, including custom implementations of `cachingStrategy-ref`, `keyGenerator`, `responseGenerator`, and `eventCopyStrategy`
+|When enabled, `ee:cache` persists only the Message instead of the full Event. Java customizations for `ee:cache` aren't supported, including custom implementations of `cachingStrategy-ref`, `keyGenerator`, `responseGenerator`, and `eventCopyStrategy`.
 After this feature flag is enabled, it can't be disabled because the format of persisted data is updated.
 
 *Available Since*


### PR DESCRIPTION
## Summary

Wording fixes in the Feature Flags Reference table of `feature-flagging.adoc`:

- Replace "Mule" with "the runtime" in the descriptions of `mule.disable.attribute.parameter.whitespace.trimming` and `mule.disable.pojo.text.parameter.whitespace.trimming`.
- Add a missing period to the `mule.serialize.message.in.cache` flag description.

Docs-only change (single `.adoc` file). No code, tests, or build config touched.

## Test Plan

- [x] AsciiDoc edits render unchanged in table structure (only prose wording).