### PR TITLE
@W-23162902 docs(feature-flagging): use "the runtime" wording

### DIFF
--- a/modules/ROOT/pages/feature-flagging.adoc
+++ b/modules/ROOT/pages/feature-flagging.adoc
@@ -391,7 +391,7 @@ This feature isn't configurable by system property.
 
 * MULE-19879
 <.^|`mule.disable.attribute.parameter.whitespace.trimming`
-|When enabled, Mule trims whitespaces from parameter values defined at the attribute level in the DSL.
+|When enabled, the runtime trims whitespaces from parameter values defined at the attribute level in the DSL.
 
 *Available Since*
 
@@ -405,7 +405,7 @@ This feature isn't configurable by system property.
 
 * MULE-19803
 <.^|`mule.disable.pojo.text.parameter.whitespace.trimming`
-|When enabled, Mule trims whitespaces from CDATA text parameter of pojos in the DSL.
+|When enabled, the runtime trims whitespaces from CDATA text parameter of pojos in the DSL.
 
 *Available Since*
 


### PR DESCRIPTION
## Summary

Wording fix in the Feature Flags Reference table of `feature-flagging.adoc`:

- Replace "Mule" with "the runtime" in the descriptions of `mule.disable.attribute.parameter.whitespace.trimming` and `mule.disable.pojo.text.parameter.whitespace.trimming`.

Backport of the wording change from the v4.12 PR (#3420). The `mule.serialize.message.in.cache` punctuation fix from that PR does not apply here — that flag section does not exist on this branch.

Docs-only change (single `.adoc` file).

## Test Plan

- [x] AsciiDoc edits render unchanged in table structure (only prose wording).