### PR TITLE
W-23162902: Fix feature-flag description wording (grammar + backtick balance)

### DIFF
--- a/modules/ROOT/pages/feature-flagging.adoc
+++ b/modules/ROOT/pages/feature-flagging.adoc
@@ -585,7 +585,7 @@ This feature isn't configurable by system property.
 
 * W-13215870
 <.^|`mule.disableJmx.for.commons.pool2`
-|When enabled, MBeans isn't registered for `commons-pool2`.
+|When enabled, MBeans aren't registered for `commons-pool2`.
 
 *Available Since*
 
@@ -661,7 +661,7 @@ This feature isn't configurable by system property.
 
 * W-15206528
 <.^|`mule.unsupportedExtensionsClientRunAsync`
-|When enabled, `org.mule.runtime.extension.api.client.ExtensionsClient` deprecated methods `(executeAsync(String, String, OperationParameters)` and `execute(String, String, OperationParameters))` throw an `UnsupportedOperationException`.
+|When enabled, `org.mule.runtime.extension.api.client.ExtensionsClient` deprecated methods (`executeAsync(String, String, OperationParameters)` and `execute(String, String, OperationParameters)`) throw an `UnsupportedOperationException`.
 
 *Available Since*
 
@@ -675,7 +675,7 @@ This feature isn't configurable by system property.
 
 * W-15399821
 <.^|`ENFORCE_IMPORT_TARGET_SAME_TYPE`
-|When enabled, the root element of `import` targets is validated to be the same as the importing configuration.
+|When enabled, the root element of `import` targets are validated to be the same as the importing configuration.
 
 *Available Since*
 


### PR DESCRIPTION
Fixes three editorial issues in three feature-flag description rows on the v4.12 feature-flagging page:

- `mule.disableJmx.for.commons.pool2`: "MBeans isn't registered" → "MBeans aren't registered" (subject-verb agreement).
- `mule.unsupportedExtensionsClientRunAsync`: moved the parentheses outside the backtick spans so the two method names are code-highlighted and the parentheses read as balanced prose — `(``executeAsync(...)`` and ``execute(...)``)` instead of the parens being captured inside the code spans.
- `ENFORCE_IMPORT_TARGET_SAME_TYPE`: "targets is validated" → "targets are validated" (subject-verb agreement).

These mirror the same wording fixes applied to `MuleRuntimeFeature.java` in mulesoft-emu/mule-api#1891 (commit 3be576a), keeping the docs page and the runtime enum descriptions in sync.

Tracked under [W-23162902](https://gus.my.salesforce.com/lightning/r/ADM_Work__c/W-23162902).