### PR TITLE
W-23162902: Fix feature-flag description wording (grammar + backtick balance)

### DIFF
--- a/modules/ROOT/pages/feature-flagging.adoc
+++ b/modules/ROOT/pages/feature-flagging.adoc
@@ -563,7 +563,7 @@ This feature isn't configurable by system property.
 
 * W-13509911
 <.^|`mule.disableJmx.for.commons.pool2`
-|When enabled, MBeans isn't registered for `commons-pool2`.
+|When enabled, MBeans aren't registered for `commons-pool2`.
 
 *Available Since*
 


### PR DESCRIPTION
Fixes one editorial issue on the v4.6 feature-flagging page:

- `mule.disableJmx.for.commons.pool2`: "MBeans isn't registered" → "MBeans aren't registered" (subject-verb agreement).

(The `executeAsync`/`import`-target flags fixed on newer branches don't exist on v4.6.)

Mirrors the same wording fix applied to `MuleRuntimeFeature.java` in mulesoft-emu/mule-api (W-23162902). Companion to docs PR #3425 (v4.12).

Tracked under [W-23162902](https://gus.my.salesforce.com/lightning/r/ADM_Work__c/W-23162902).