### PR TITLE
W-23457896: Regenerate feature-flagging.adoc for 4.12.2

### DIFF
--- a/modules/ROOT/pages/feature-flagging.adoc
+++ b/modules/ROOT/pages/feature-flagging.adoc
@@ -137,8 +137,6 @@ The following table shows the available feature flags, a description of their fu
 
 *Enabled by Default Since*
 
-* Not enabled by default in any Mule version
-
 *Issue ID*
 
 * MULE-19588
@@ -166,8 +164,6 @@ The following table shows the available feature flags, a description of their fu
 * 4.4.0-20220221
 
 *Enabled by Default Since*
-
-* Not enabled by default in any Mule version
 
 *Issue ID*
 
@@ -449,7 +445,7 @@ This feature isn't configurable by system property.
 
 *Deprecated Since*
 
-* 4.9.0, the `optional` attribute in entries is no longer supported
+* since 4.9.0, `optional` attribute in entries are no longer supported
 
 *Issue ID*
 
@@ -757,7 +753,7 @@ This feature isn't configurable by system property.
 
 *Deprecated Since*
 
-* 4.12.0, this is configurable on streaming configuration. Use the `bytes.eagerRead` property instead.
+* since 4.12, this is configurable on streaming configuration. Use the
 
 *Issue ID*
 
@@ -901,7 +897,7 @@ This feature isn't configurable by system property.
 
 *Enabled by Default Since*
 
-* Not enabled by default in any Mule version
+* 4.13.0
 
 *Issue ID*
 
@@ -956,7 +952,7 @@ After this feature flag is enabled, it can't be disabled because the format of p
 
 *Deprecated Since*
 
-* 4.5.0, ByteBuddy is mandatory
+* since 4.5.0, ByteBuddy is always used
 
 *Issue ID*
 
@@ -989,7 +985,20 @@ After this feature flag is enabled, it can't be disabled because the format of p
 *Issue ID*
 
 * W-21549351
+<.^|`mule.enable.cluster.in.memory.object.store`
+|When enabled, non-persistent object store partitions use the cluster's in-memory store (e.g. Hazelcast). This ensures transient object store entries are consistent across cluster nodes when OSv2 and Hazelcast clustering are both active.
 
+*Available Since*
+
+* 4.13.0
+
+*Enabled by Default Since*
+
+* 4.13.0
+
+*Issue ID*
+
+* W-17714668
 |===
 
 == See Also


### PR DESCRIPTION
Regenerates `modules/ROOT/pages/feature-flagging.adoc` from `MuleRuntimeFeature.java` for runtime version(s) 4.12.2 (mule-api `1.12.2`).

Tracked under [W-23457896](https://gus.my.salesforce.com/lightning/r/ADM_Work__c/W-23457896).

Generated by `utils/scripts/update-feature-flags-docs/update_feature_flags_docs.py`.
