### PR TITLE
W-23457896: Regenerate feature-flagging.adoc for 4.9.20

### DIFF
--- a/modules/ROOT/pages/feature-flagging.adoc
+++ b/modules/ROOT/pages/feature-flagging.adoc
@@ -137,8 +137,6 @@ The following table shows the available feature flags, a description of their fu
 
 *Enabled by Default Since*
 
-* Not enabled by default in any Mule version
-
 *Issue ID*
 
 * MULE-19588
@@ -166,8 +164,6 @@ The following table shows the available feature flags, a description of their fu
 * 4.4.0-20220221
 
 *Enabled by Default Since*
-
-* Not enabled by default in any Mule version
 
 *Issue ID*
 
@@ -449,7 +445,7 @@ This feature isn't configurable by system property.
 
 *Deprecated Since*
 
-* 4.9.0, the `optional` attribute in entries is no longer supported
+* since 4.9.0, `optional` attribute in entries are no longer supported
 
 *Issue ID*
 
@@ -809,7 +805,7 @@ This feature isn't configurable by system property.
 
 *Deprecated Since*
 
-* 4.5.0, ByteBuddy is mandatory
+* since 4.5.0, ByteBuddy is always used
 
 *Issue ID*
 
@@ -904,7 +900,20 @@ This feature isn't configurable by system property.
 *Issue ID*
 
 * W-21228085
+<.^|`mule.enable.cluster.in.memory.object.store`
+|When enabled, non-persistent object store partitions use the cluster's in-memory store (e.g. Hazelcast). This ensures transient object store entries are consistent across cluster nodes when OSv2 and Hazelcast clustering are both active.
 
+*Available Since*
+
+* 4.13.0
+
+*Enabled by Default Since*
+
+* 4.13.0
+
+*Issue ID*
+
+* W-17714668
 |===
 
 == See Also


### PR DESCRIPTION
Regenerates `modules/ROOT/pages/feature-flagging.adoc` from `MuleRuntimeFeature.java` for runtime version(s) 4.9.20 (mule-api `1.9.20`).

Tracked under [W-23457896](https://gus.my.salesforce.com/lightning/r/ADM_Work__c/W-23457896).

Generated by `utils/scripts/update-feature-flags-docs/update_feature_flags_docs.py`.
